### PR TITLE
feat: display user score in discover view and filter it more flexable.

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -1,6 +1,5 @@
 import ExternalAPI from '@server/api/externalapi';
 import cacheManager from '@server/lib/cache';
-import { getSettings } from '@server/lib/settings';
 import { sortBy } from 'lodash';
 import type {
   TmdbCollection,
@@ -99,7 +98,6 @@ interface DiscoverTvOptions {
 }
 
 class TheMovieDb extends ExternalAPI {
-  private locale: string;
   private region?: string;
   private originalLanguage?: string;
   constructor({
@@ -119,7 +117,6 @@ class TheMovieDb extends ExternalAPI {
         },
       }
     );
-    this.locale = getSettings().main?.locale || 'en';
     this.region = region;
     this.originalLanguage = originalLanguage;
   }
@@ -128,7 +125,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = this.locale,
+    language = 'en',
   }: SearchOptions): Promise<TmdbSearchMultiResponse> => {
     try {
       const data = await this.get<TmdbSearchMultiResponse>('/search/multi', {
@@ -150,7 +147,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = this.locale,
+    language = 'en',
     year,
   }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
     try {
@@ -179,7 +176,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = this.locale,
+    language = 'en',
     year,
   }: SingleSearchOptions): Promise<TmdbSearchTvResponse> => {
     try {
@@ -206,7 +203,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPerson = async ({
     personId,
-    language = this.locale,
+    language = 'en',
   }: {
     personId: number;
     language?: string;
@@ -224,7 +221,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPersonCombinedCredits = async ({
     personId,
-    language = this.locale,
+    language = 'en',
   }: {
     personId: number;
     language?: string;
@@ -247,7 +244,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getMovie = async ({
     movieId,
-    language = this.locale,
+    language = 'en',
   }: {
     movieId: number;
     language?: string;
@@ -273,7 +270,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getTvShow = async ({
     tvId,
-    language = this.locale,
+    language = 'en',
   }: {
     tvId: number;
     language?: string;
@@ -326,7 +323,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieRecommendations({
     movieId,
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     movieId: number;
     page?: number;
@@ -352,7 +349,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieSimilar({
     movieId,
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     movieId: number;
     page?: number;
@@ -378,7 +375,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMoviesByKeyword({
     keywordId,
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     keywordId: number;
     page?: number;
@@ -404,7 +401,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvRecommendations({
     tvId,
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     tvId: number;
     page?: number;
@@ -432,7 +429,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvSimilar({
     tvId,
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     tvId: number;
     page?: number;
@@ -456,7 +453,7 @@ class TheMovieDb extends ExternalAPI {
     sortBy = 'popularity.desc',
     page = 1,
     includeAdult = false,
-    language = this.locale,
+    language = 'en',
     primaryReleaseDateGte,
     primaryReleaseDateLte,
     originalLanguage,
@@ -529,7 +526,7 @@ class TheMovieDb extends ExternalAPI {
   public getDiscoverTv = async ({
     sortBy = 'popularity.desc',
     page = 1,
-    language = this.locale,
+    language = 'en',
     firstAirDateGte,
     firstAirDateLte,
     includeEmptyReleaseDate = false,
@@ -602,7 +599,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getUpcomingMovies = async ({
     page = 1,
-    language = this.locale,
+    language = 'en',
   }: {
     page: number;
     language: string;
@@ -629,7 +626,7 @@ class TheMovieDb extends ExternalAPI {
   public getAllTrending = async ({
     page = 1,
     timeWindow = 'day',
-    language = this.locale,
+    language = 'en',
   }: {
     page?: number;
     timeWindow?: 'day' | 'week';
@@ -702,7 +699,7 @@ class TheMovieDb extends ExternalAPI {
   public async getByExternalId({
     externalId,
     type,
-    language = this.locale,
+    language = 'en',
   }:
     | {
         externalId: string;
@@ -733,7 +730,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getMediaByImdbId({
     imdbId,
-    language = this.locale,
+    language = 'en',
   }: {
     imdbId: string;
     language?: string;
@@ -772,7 +769,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getShowByTvdbId({
     tvdbId,
-    language = this.locale,
+    language = 'en',
   }: {
     tvdbId: number;
     language?: string;
@@ -802,7 +799,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getCollection({
     collectionId,
-    language = this.locale,
+    language = 'en',
   }: {
     collectionId: number;
     language?: string;
@@ -878,7 +875,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getMovieGenres({
-    language = this.locale,
+    language = 'en',
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {
@@ -929,7 +926,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getTvGenres({
-    language = this.locale,
+    language = 'en',
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -99,7 +99,7 @@ interface DiscoverTvOptions {
 }
 
 class TheMovieDb extends ExternalAPI {
-  private locale?: string;
+  private locale: string;
   private region?: string;
   private originalLanguage?: string;
   constructor({
@@ -119,7 +119,7 @@ class TheMovieDb extends ExternalAPI {
         },
       }
     );
-    this.locale = getSettings().main.locale;
+    this.locale = getSettings().main?.locale || 'en';
     this.region = region;
     this.originalLanguage = originalLanguage;
   }

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -1,5 +1,6 @@
 import ExternalAPI from '@server/api/externalapi';
 import cacheManager from '@server/lib/cache';
+import { getSettings } from '@server/lib/settings';
 import { sortBy } from 'lodash';
 import type {
   TmdbCollection,
@@ -98,6 +99,7 @@ interface DiscoverTvOptions {
 }
 
 class TheMovieDb extends ExternalAPI {
+  private locale?: string;
   private region?: string;
   private originalLanguage?: string;
   constructor({
@@ -117,6 +119,7 @@ class TheMovieDb extends ExternalAPI {
         },
       }
     );
+    this.locale = getSettings().main.locale;
     this.region = region;
     this.originalLanguage = originalLanguage;
   }
@@ -125,7 +128,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
   }: SearchOptions): Promise<TmdbSearchMultiResponse> => {
     try {
       const data = await this.get<TmdbSearchMultiResponse>('/search/multi', {
@@ -147,7 +150,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     year,
   }: SingleSearchOptions): Promise<TmdbSearchMovieResponse> => {
     try {
@@ -176,7 +179,7 @@ class TheMovieDb extends ExternalAPI {
     query,
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     year,
   }: SingleSearchOptions): Promise<TmdbSearchTvResponse> => {
     try {
@@ -203,7 +206,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPerson = async ({
     personId,
-    language = 'en',
+    language = this.locale,
   }: {
     personId: number;
     language?: string;
@@ -221,7 +224,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getPersonCombinedCredits = async ({
     personId,
-    language = 'en',
+    language = this.locale,
   }: {
     personId: number;
     language?: string;
@@ -244,7 +247,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getMovie = async ({
     movieId,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     language?: string;
@@ -270,7 +273,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getTvShow = async ({
     tvId,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     language?: string;
@@ -323,7 +326,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieRecommendations({
     movieId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     page?: number;
@@ -349,7 +352,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMovieSimilar({
     movieId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     movieId: number;
     page?: number;
@@ -375,7 +378,7 @@ class TheMovieDb extends ExternalAPI {
   public async getMoviesByKeyword({
     keywordId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     keywordId: number;
     page?: number;
@@ -401,7 +404,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvRecommendations({
     tvId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     page?: number;
@@ -429,7 +432,7 @@ class TheMovieDb extends ExternalAPI {
   public async getTvSimilar({
     tvId,
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     tvId: number;
     page?: number;
@@ -453,7 +456,7 @@ class TheMovieDb extends ExternalAPI {
     sortBy = 'popularity.desc',
     page = 1,
     includeAdult = false,
-    language = 'en',
+    language = this.locale,
     primaryReleaseDateGte,
     primaryReleaseDateLte,
     originalLanguage,
@@ -526,7 +529,7 @@ class TheMovieDb extends ExternalAPI {
   public getDiscoverTv = async ({
     sortBy = 'popularity.desc',
     page = 1,
-    language = 'en',
+    language = this.locale,
     firstAirDateGte,
     firstAirDateLte,
     includeEmptyReleaseDate = false,
@@ -599,7 +602,7 @@ class TheMovieDb extends ExternalAPI {
 
   public getUpcomingMovies = async ({
     page = 1,
-    language = 'en',
+    language = this.locale,
   }: {
     page: number;
     language: string;
@@ -626,7 +629,7 @@ class TheMovieDb extends ExternalAPI {
   public getAllTrending = async ({
     page = 1,
     timeWindow = 'day',
-    language = 'en',
+    language = this.locale,
   }: {
     page?: number;
     timeWindow?: 'day' | 'week';
@@ -699,7 +702,7 @@ class TheMovieDb extends ExternalAPI {
   public async getByExternalId({
     externalId,
     type,
-    language = 'en',
+    language = this.locale,
   }:
     | {
         externalId: string;
@@ -730,7 +733,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getMediaByImdbId({
     imdbId,
-    language = 'en',
+    language = this.locale,
   }: {
     imdbId: string;
     language?: string;
@@ -769,7 +772,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getShowByTvdbId({
     tvdbId,
-    language = 'en',
+    language = this.locale,
   }: {
     tvdbId: number;
     language?: string;
@@ -799,7 +802,7 @@ class TheMovieDb extends ExternalAPI {
 
   public async getCollection({
     collectionId,
-    language = 'en',
+    language = this.locale,
   }: {
     collectionId: number;
     language?: string;
@@ -875,7 +878,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getMovieGenres({
-    language = 'en',
+    language = this.locale,
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {
@@ -926,7 +929,7 @@ class TheMovieDb extends ExternalAPI {
   }
 
   public async getTvGenres({
-    language = 'en',
+    language = this.locale,
   }: {
     language?: string;
   } = {}): Promise<TmdbGenre[]> {

--- a/src/components/Common/MultiRangeSlider/index.tsx
+++ b/src/components/Common/MultiRangeSlider/index.tsx
@@ -7,6 +7,7 @@ type MultiRangeSliderProps = {
   max: number;
   defaultMinValue?: number;
   defaultMaxValue?: number;
+  step?: number;
   subText?: string;
   onUpdateMin: (min: number) => void;
   onUpdateMax: (max: number) => void;
@@ -15,6 +16,7 @@ type MultiRangeSliderProps = {
 const MultiRangeSlider = ({
   min,
   max,
+  step = 1,
   defaultMinValue,
   defaultMaxValue,
   subText,
@@ -63,6 +65,7 @@ const MultiRangeSlider = ({
           min={min}
           max={max}
           value={valueMin}
+          step={step}
           className={`pointer-events-none absolute h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-700 ${
             valueMin >= valueMax && valueMin !== min ? 'z-30' : 'z-10'
           }`}
@@ -82,7 +85,7 @@ const MultiRangeSlider = ({
           min={min}
           max={max}
           value={valueMax}
-          step="1"
+          step={step}
           className={`pointer-events-none absolute top-0 left-0 right-0 z-20 h-2 w-full cursor-pointer appearance-none rounded-lg bg-transparent`}
           onChange={(e) => {
             const value = Number(e.target.value);

--- a/src/components/Discover/FilterSlideover/index.tsx
+++ b/src/components/Discover/FilterSlideover/index.tsx
@@ -216,6 +216,7 @@ const FilterSlideover = ({
           <MultiRangeSlider
             min={1}
             max={10}
+            step={0.1}
             defaultMaxValue={
               currentFilters.voteAverageLte
                 ? Number(currentFilters.voteAverageLte)

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -62,6 +62,7 @@ const TitleCard = ({
   isAddedToWatchlist = false,
   inProgress = false,
   canExpand = false,
+  userScore,
   mutateParent,
 }: TitleCardProps) => {
   const isTouch = useIsTouch();
@@ -271,6 +272,15 @@ const TitleCard = ({
                 />
               </div>
             )}
+            <div
+              className={
+                'pointer-events-none z-40 rounded-full border border-blue-500 bg-blue-600 bg-opacity-80 shadow-md'
+              }
+            >
+              <div className="flex h-4 items-center px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white sm:h-5">
+                {userScore?.toFixed(1)}
+              </div>
+            </div>
           </div>
           <Transition
             as={Fragment}


### PR DESCRIPTION
#### Description
The score cannot be seen in discover view, but the api has voteAverage data, just show it on the page. And the filter slide has default step=1, which is not very flexable, for I might be interested in movies that is larger than 7.5, or so. Just make the score filter more flexable by set the step to 0.1.

#### Screenshot (if UI-related)
##### [discover] before:
![image](https://github.com/Fallenbagel/jellyseerr/assets/4396063/a2eae4af-e7bd-4910-aaea-abab8ee2fe6a)

##### [discover] after:
![image](https://github.com/Fallenbagel/jellyseerr/assets/4396063/d7bd1da6-1498-4866-a318-5bdd9b620065)

##### [filter slide] after:
![image](https://github.com/Fallenbagel/jellyseerr/assets/4396063/ba359056-5d87-4e86-91ec-16fe8873fcda)

#### To-Dos

- [x] Successful build `yarn build`
- [x] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
