### PR TITLE
fix: queue pageSize to get more than 10 downloading items in Servarr

### DIFF
--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -161,7 +161,7 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
         `/queue`,
         {
           includeEpisode: 'true',
-          pageSize: 1000
+          pageSize: '1000'
         },
         0
       );

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -161,7 +161,7 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
         `/queue`,
         {
           includeEpisode: 'true',
-          pageSize: '1000'
+          pageSize: '1000',
         },
         0
       );

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -161,6 +161,7 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
         `/queue`,
         {
           includeEpisode: 'true',
+          pageSize: 1000
         },
         0
       );


### PR DESCRIPTION
Allows to get all processing Series when entire seasons are downloded on Sonarr

#### Description

When downloading Season packs, Jellyseerr wasn't displaying all the downloading episodes due to Servarr default pageSize set to 10. 1000 should be a safe number to display correctly the processing items while downloading multiple Seasons (or season with >10 episodes) in parallel.

#### Screenshot (if UI-related)

Not UI related

#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [X] Database migration (if required)

#### Issues Fixed or Closed
None