### PR TITLE
feat: add plex media ratingKey and ratingKey4k to webhook payload and…

### DIFF
--- a/docs/using-jellyseerr/notifications/webhooks.md
+++ b/docs/using-jellyseerr/notifications/webhooks.md
@@ -1,0 +1,134 @@
+# Webhook
+
+The webhook notification agent enables you to send a custom JSON payload to any endpoint for specific notification events.
+
+## Configuration
+
+### Webhook URL
+
+The URL you would like to post notifications to. Your JSON will be sent as the body of the request.
+
+### Authorization Header (optional)
+
+{% hint style="info" %}
+This is typically not needed. Please refer to your webhook provider's documentation for details.
+{% endhint %}
+
+This value will be sent as an `Authorization` HTTP header.
+
+### JSON Payload
+
+Customize the JSON payload to suit your needs. Jellyseerr provides several [template variables](#template-variables) for use in the payload, which will be replaced with the relevant data when the notifications are triggered.
+
+## Template Variables
+
+### General
+
+| Variable                | Value                                                                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `{{notification_type}}` | The type of notification (e.g. `MEDIA_PENDING` or `ISSUE_COMMENT`)                                                                  |
+| `{{event}}`             | A friendly description of the notification event                                                                                    |
+| `{{subject}}`           | The notification subject (typically the media title)                                                                                |
+| `{{message}}`           | The notification message body (the media overview/synopsis for request notifications; the issue description for issue notificatons) |
+| `{{image}}`             | The notification image (typically the media poster)                                                                                 |
+
+### Notify User
+
+These variables are for the target recipient of the notification.
+
+| Variable                                 | Value                                                         |
+| ---------------------------------------- | ------------------------------------------------------------- |
+| `{{notifyuser_username}}`                | The target notification recipient's username                  |
+| `{{notifyuser_email}}`                   | The target notification recipient's email address             |
+| `{{notifyuser_avatar}}`                  | The target notification recipient's avatar URL                |
+| `{{notifyuser_settings_discordId}}`      | The target notification recipient's Discord ID (if set)       |
+| `{{notifyuser_settings_telegramChatId}}` | The target notification recipient's Telegram Chat ID (if set) |
+
+{% hint style="info" %}
+The `notifyuser` variables are not defined for the following request notification types, as they are intended for application administrators rather than end users:
+
+- Request Pending Approval
+- Request Automatically Approved
+- Request Processing Failed
+
+On the other hand, the `notifyuser` variables _will_ be replaced with the requesting user's information for the below notification types:
+
+- Request Approved
+- Request Declined
+- Request Available
+
+If you would like to use the requesting user's information in your webhook, please instead include the relevant variables from the [Request](#request) section below.
+{% endhint %}
+
+### Special
+
+The following variables must be used as a key in the JSON payload (e.g., `"{{extra}}": []`).
+
+| Variable      | Value                                                                                                                          |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `{{media}}`   | The relevant media object                                                                                                      |
+| `{{request}}` | The relevant request object                                                                                                    |
+| `{{issue}}`   | The relevant issue object                                                                                                      |
+| `{{comment}}` | The relevant issue comment object                                                                                              |
+| `{{extra}}`   | The "extra" array of additional data for certain notifications (e.g., season/episode numbers for series-related notifications) |
+
+#### Media
+
+The `{{media}}` will be `null` if there is no relevant media object for the notification.
+
+These following special variables are only included in media-related notifications, such as requests.
+
+| Variable                | Value                                                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `{{media_type}}`        | The media type (`movie` or `tv`)                                                                               |
+| `{{media_tmdbid}}`      | The media's TMDB ID                                                                                            |
+| `{{media_tvdbid}}`      | The media's TheTVDB ID                                                                                         |
+| `{{media_status}}`      | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
+| `{{media_status4k}}`    | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| `{{media_plexRatingKey}}`   | The media's Plex ratingKey, if available (for standard library match)                                          |
+| `{{media_plexRatingKey4k}}` | The media's Plex ratingKey for 4K match, if available                                                          |
+
+#### Request
+
+The `{{request}}` will be `null` if there is no relevant media object for the notification.
+
+The following special variables are only included in request-related notifications.
+
+| Variable                                  | Value                                           |
+| ----------------------------------------- | ----------------------------------------------- |
+| `{{request_id}}`                          | The request ID                                  |
+| `{{requestedBy_username}}`                | The requesting user's username                  |
+| `{{requestedBy_email}}`                   | The requesting user's email address             |
+| `{{requestedBy_avatar}}`                  | The requesting user's avatar URL                |
+| `{{requestedBy_settings_discordId}}`      | The requesting user's Discord ID (if set)       |
+| `{{requestedBy_settings_telegramChatId}}` | The requesting user's Telegram Chat ID (if set) |
+
+#### Issue
+
+The `{{issue}}` will be `null` if there is no relevant media object for the notification.
+
+The following special variables are only included in issue-related notifications.
+
+| Variable                                 | Value                                           |
+| ---------------------------------------- | ----------------------------------------------- |
+| `{{issue_id}}`                           | The issue ID                                    |
+| `{{reportedBy_username}}`                | The requesting user's username                  |
+| `{{reportedBy_email}}`                   | The requesting user's email address             |
+| `{{reportedBy_avatar}}`                  | The requesting user's avatar URL                |
+| `{{reportedBy_settings_discordId}}`      | The requesting user's Discord ID (if set)       |
+| `{{reportedBy_settings_telegramChatId}}` | The requesting user's Telegram Chat ID (if set) |
+
+#### Comment
+
+The `{{comment}}` will be `null` if there is no relevant media object for the notification.
+
+The following special variables are only included in issue comment-related notifications.
+
+| Variable                                  | Value                                           |
+| ----------------------------------------- | ----------------------------------------------- |
+| `{{comment_message}}`                     | The comment message                             |
+| `{{commentedBy_username}}`                | The commenting user's username                  |
+| `{{commentedBy_email}}`                   | The commenting user's email address             |
+| `{{commentedBy_avatar}}`                  | The commenting user's avatar URL                |
+| `{{commentedBy_settings_discordId}}`      | The commenting user's Discord ID (if set)       |
+| `{{commentedBy_settings_telegramChatId}}` | The commenting user's Telegram Chat ID (if set) |

--- a/docs/using-seerr/notifications/webhook.md
+++ b/docs/using-seerr/notifications/webhook.md
@@ -95,15 +95,17 @@ The `{{media}}` will be `null` if there is no relevant media object for the noti
 
 These following special variables are only included in media-related notifications, such as requests.
 
-| Variable                      | Value                                                                                                          |
-| ------------------------------| -------------------------------------------------------------------------------------------------------------- |
-| `{{media_type}}`              | The media type (`movie` or `tv`)                                                                               |
-| `{{media_imdbid}}`            | The media's IMDb ID                                                                                            |
-| `{{media_tmdbid}}`            | The media's TMDB ID                                                                                            |
-| `{{media_tvdbid}}`            | The media's TheTVDB ID                                                                                         |
-| `{{media_status}}`            | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
-| `{{media_status4k}}`          | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
-| `{{media_jellyfinMediaId}}`   | The media's Jellyfin Media ID                                                                                  |
+| Variable                    | Value                                                                                                          |
+| ----------------------------| -------------------------------------------------------------------------------------------------------------- |
+| `{{media_type}}`            | The media type (`movie` or `tv`)                                                                               |
+| `{{media_imdbid}}`          | The media's IMDb ID                                                                                            |
+| `{{media_tmdbid}}`          | The media's TMDB ID                                                                                            |
+| `{{media_tvdbid}}`          | The media's TheTVDB ID                                                                                         |
+| `{{media_status}}`          | The media's availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`)    |
+| `{{media_status4k}}`        | The media's 4K availability status (`UNKNOWN`, `PENDING`, `PROCESSING`, `PARTIALLY_AVAILABLE`, or `AVAILABLE`) |
+| `{{media_jellyfinMediaId}}` | The media's Jellyfin Media ID                                                                                  |
+| `{{media_plexRatingKey}}`   | The media's Plex ratingKey, if available (for standard library match)                                          |
+| `{{media_plexRatingKey4k}}` | The media's Plex ratingKey for 4K match, if available                                                          |
 
 #### Request
 

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -32,6 +32,8 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
     payload.media ? MediaStatus[payload.media.status] : '',
   media_status4k: (payload) =>
     payload.media ? MediaStatus[payload.media.status4k] : '',
+  media_plexRatingKey: (payload) => payload.media?.ratingKey ?? '',
+  media_plexrRatingKey4k: (payload) => payload.media?.ratingKey4k ?? '',
   request_id: 'request.id',
   requestedBy_username: 'request.requestedBy.displayName',
   requestedBy_email: 'request.requestedBy.email',

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -35,6 +35,8 @@ const KeyMap: Record<string, string | KeyMapFunction> = {
     payload.media ? MediaStatus[payload.media.status] : '',
   media_status4k: (payload) =>
     payload.media ? MediaStatus[payload.media.status4k] : '',
+  media_plexRatingKey: (payload) => payload.media?.ratingKey ?? '',
+  media_plexRatingKey4k: (payload) => payload.media?.ratingKey4k ?? '',
   request_id: 'request.id',
   requestedBy_jellyfinUserId: 'request.requestedBy.jellyfinUserId',
   requestedBy_username: 'request.requestedBy.displayName',


### PR DESCRIPTION
## Description

- Adds the plex ratingKey to the webhook JSON payload.
- Updates docs with new newly added keys.

Allows the user to generate direct links to plex media.

This is a copy of the pull request that I also submitted to Overseerr devs, except this also adds the missing webhooks documentation. 
https://github.com/sct/overseerr/pull/4204

## How Has This Been Tested?

N/A

## Screenshots / Logs (if applicable)

Example: HomeAssistant notification when tapped, opens plex to the media.
<img width="1617" height="197" alt="471286480-9d4a73c7-c20b-4f3d-b2b9-39ecad809d9d" src="https://github.com/user-attachments/assets/2468a6ce-d158-4b61-af27-d5736cfeddf1" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new webhook payload variables to expose Plex media rating keys and corresponding 4K variants for richer templates.

* **Documentation**
  * Expanded webhook documentation with additional Media template variables (including Plex rating key and related media identifiers) to enable more detailed and flexible notification templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->