### PR TITLE
feat(settings): hide already requested media

### DIFF
--- a/docs/using-seerr/settings/general.md
+++ b/docs/using-seerr/settings/general.md
@@ -71,6 +71,14 @@ When enabled, media that has been blocklisted will not appear on the "Discover" 
 
 This setting is **disabled** by default.
 
+## Hide Requested Media
+
+When enabled, media that has been requested (but not yet available) will not appear on the "Discover" home page, or in the "Recommended" or "Similar" categories or other links on media detail pages.
+
+Requested media will still appear in search results, however, so it is possible to locate and view hidden items by searching for them by title.
+
+This setting is **disabled** by default.
+
 ## Allow Partial Series Requests
 
 When enabled, users will be able to submit requests for specific seasons of TV series. If disabled, users will only be able to submit requests for all unavailable seasons.

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -232,6 +232,9 @@ components:
         hideAvailable:
           type: boolean
           example: false
+        hideRequested:
+          type: boolean
+          example: false
         partialRequestsEnabled:
           type: boolean
           example: false

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -49,7 +49,8 @@ class Media {
           'watchlist',
           'media.id= watchlist.media and watchlist.requestedBy = :userId',
           { userId: user?.id }
-        ) //,
+        )
+        .leftJoinAndSelect('media.requests', 'requests')
         .where(' media.tmdbId in (:...finalIds)', { finalIds })
         .getMany();
 

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -35,7 +35,8 @@ import Season from './Season';
 class Media {
   public static async getRelatedMedia(
     user: User | undefined,
-    items: { tmdbId: number; mediaType: string }[]
+    items: { tmdbId: number; mediaType: string }[],
+    { includeActiveRequest = false }: { includeActiveRequest?: boolean } = {}
   ): Promise<Media[]> {
     const mediaRepository = getRepository(Media);
 
@@ -61,7 +62,11 @@ class Media {
         items.some((i) => i.tmdbId === m.tmdbId && i.mediaType === m.mediaType)
       );
 
-      if (getSettings().main.hideRequested && relatedMedia.length > 0) {
+      if (
+        includeActiveRequest &&
+        getSettings().main.hideRequested &&
+        relatedMedia.length > 0
+      ) {
         const activeRequestMediaIds = await mediaRepository
           .createQueryBuilder('media')
           .select('media.id', 'id')

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -1,6 +1,10 @@
 import RadarrAPI from '@server/api/servarr/radarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import { getRepository } from '@server/datasource';
 import { Blocklist } from '@server/entity/Blocklist';
@@ -50,13 +54,35 @@ class Media {
           'media.id= watchlist.media and watchlist.requestedBy = :userId',
           { userId: user?.id }
         )
-        .leftJoinAndSelect('media.requests', 'requests')
         .where(' media.tmdbId in (:...finalIds)', { finalIds })
         .getMany();
 
-      return media.filter((m) =>
+      const relatedMedia = media.filter((m) =>
         items.some((i) => i.tmdbId === m.tmdbId && i.mediaType === m.mediaType)
       );
+
+      if (getSettings().main.hideRequested && relatedMedia.length > 0) {
+        const activeRequestMediaIds = await mediaRepository
+          .createQueryBuilder('media')
+          .select('media.id', 'id')
+          .distinct(true)
+          .innerJoin('media.requests', 'request')
+          .where('media.id IN (:...mediaIds)', {
+            mediaIds: relatedMedia.map((m) => m.id),
+          })
+          .andWhere('request.status IN (:...statuses)', {
+            statuses: [MediaRequestStatus.PENDING, MediaRequestStatus.APPROVED],
+          })
+          .getRawMany<{ id: number }>();
+
+        const activeIds = new Set(activeRequestMediaIds.map((row) => row.id));
+
+        relatedMedia.forEach((m) => {
+          m.hasActiveRequest = activeIds.has(m.id);
+        });
+      }
+
+      return relatedMedia;
     } catch (e) {
       logger.error(e.message);
       return [];
@@ -188,6 +214,7 @@ class Media {
 
   public serviceUrl?: string;
   public serviceUrl4k?: string;
+  public hasActiveRequest?: boolean;
   public downloadStatus?: DownloadingItem[] = [];
   public downloadStatus4k?: DownloadingItem[] = [];
 

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -31,6 +31,7 @@ export interface PublicSettingsResponse {
   applicationUrl: string;
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -141,6 +141,7 @@ export interface MainSettings {
   };
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   newPlexLogin: boolean;
@@ -194,6 +195,7 @@ interface FullPublicSettings extends PublicSettings {
   applicationUrl: string;
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;
@@ -416,6 +418,7 @@ class Settings {
         },
         hideAvailable: false,
         hideBlocklisted: false,
+        hideRequested: false,
         localLogin: true,
         mediaServerLogin: true,
         newPlexLogin: true,
@@ -712,6 +715,7 @@ class Settings {
       applicationUrl: this.data.main.applicationUrl,
       hideAvailable: this.data.main.hideAvailable,
       hideBlocklisted: this.data.main.hideBlocklisted,
+      hideRequested: this.data.main.hideRequested,
       localLogin: this.data.main.localLogin,
       mediaServerLogin: this.data.main.mediaServerLogin,
       jellyfinExternalHost: this.data.jellyfin.externalHostname,

--- a/server/routes/collection.ts
+++ b/server/routes/collection.ts
@@ -21,7 +21,8 @@ collectionRoutes.get<{ id: string }>('/:id', async (req, res, next) => {
       collection.parts.map((part) => ({
         tmdbId: part.id,
         mediaType: MediaType.MOVIE,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json(mapCollection(collection, media));

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -136,7 +136,8 @@ discoverRoutes.get('/movies', async (req, res, next) => {
       data.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.MOVIE,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     let keywordData: TmdbKeyword[] = [];
@@ -208,7 +209,8 @@ discoverRoutes.get<{ language: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.MOVIE,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -269,7 +271,8 @@ discoverRoutes.get<{ genreId: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.MOVIE,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -320,7 +323,8 @@ discoverRoutes.get<{ studioId: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.MOVIE,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -373,7 +377,8 @@ discoverRoutes.get('/movies/upcoming', async (req, res, next) => {
       data.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.MOVIE,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({
@@ -444,7 +449,8 @@ discoverRoutes.get('/tv', async (req, res, next) => {
       data.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.TV,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     let keywordData: TmdbKeyword[] = [];
@@ -515,7 +521,8 @@ discoverRoutes.get<{ language: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.TV,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -576,7 +583,8 @@ discoverRoutes.get<{ genreId: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.TV,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -627,7 +635,8 @@ discoverRoutes.get<{ networkId: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.TV,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({
@@ -680,7 +689,8 @@ discoverRoutes.get('/tv/upcoming', async (req, res, next) => {
       data.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.TV,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({
@@ -753,7 +763,8 @@ discoverRoutes.get('/trending', async (req, res, next) => {
       data.results.map((result) => ({
         tmdbId: result.id,
         mediaType: isMovie(result) ? MediaType.MOVIE : MediaType.TV,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({
@@ -800,7 +811,8 @@ discoverRoutes.get<{ keywordId: string }>(
         data.results.map((result) => ({
           tmdbId: result.id,
           mediaType: MediaType.MOVIE,
-        }))
+        })),
+        { includeActiveRequest: true }
       );
 
       return res.status(200).json({

--- a/server/routes/movie.ts
+++ b/server/routes/movie.ts
@@ -71,7 +71,8 @@ movieRoutes.get('/:id/recommendations', async (req, res, next) => {
       results.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.MOVIE,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({
@@ -116,7 +117,8 @@ movieRoutes.get('/:id/similar', async (req, res, next) => {
       results.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.MOVIE,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({

--- a/server/routes/tv.ts
+++ b/server/routes/tv.ts
@@ -114,7 +114,8 @@ tvRoutes.get('/:id/recommendations', async (req, res, next) => {
       results.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.TV,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({
@@ -158,7 +159,8 @@ tvRoutes.get('/:id/similar', async (req, res, next) => {
       results.results.map((result) => ({
         tmdbId: result.id,
         mediaType: MediaType.TV,
-      }))
+      })),
+      { includeActiveRequest: true }
     );
 
     return res.status(200).json({

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -82,6 +82,14 @@ const MediaSlider = ({
     );
   }
 
+  if (settings.currentSettings.hideRequested) {
+    titles = titles.filter(
+      (i) =>
+        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
+        (!i.mediaInfo?.requests || i.mediaInfo.requests.length === 0)
+    );
+  }
+
   useEffect(() => {
     if (
       titles.length < 24 &&

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -86,7 +86,10 @@ const MediaSlider = ({
     titles = titles.filter(
       (i) =>
         (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        (!i.mediaInfo?.requests || i.mediaInfo.requests.length === 0)
+        (i.mediaInfo?.status === MediaStatus.AVAILABLE ||
+          i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
+          !i.mediaInfo?.requests ||
+          i.mediaInfo.requests.length === 0)
     );
   }
 

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -88,12 +88,7 @@ const MediaSlider = ({
         return true;
       }
 
-      return (
-        i.mediaInfo?.status === MediaStatus.AVAILABLE ||
-        i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
-        !i.mediaInfo?.requests ||
-        i.mediaInfo.requests.length === 0
-      );
+      return !i.mediaInfo?.hasActiveRequest;
     });
   }
 

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -83,14 +83,18 @@ const MediaSlider = ({
   }
 
   if (settings.currentSettings.hideRequested) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        (i.mediaInfo?.status === MediaStatus.AVAILABLE ||
-          i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
-          !i.mediaInfo?.requests ||
-          i.mediaInfo.requests.length === 0)
-    );
+    titles = titles.filter((i) => {
+      if (i.mediaType !== 'movie' && i.mediaType !== 'tv') {
+        return true;
+      }
+
+      return (
+        i.mediaInfo?.status === MediaStatus.AVAILABLE ||
+        i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
+        !i.mediaInfo?.requests ||
+        i.mediaInfo.requests.length === 0
+      );
+    });
   }
 
   useEffect(() => {

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -34,7 +34,7 @@ const Search = () => {
     {
       query: router.query.query,
     },
-    { hideAvailable: false, hideBlocklisted: false }
+    { hideAvailable: false, hideBlocklisted: false, hideRequested: false }
   );
 
   if (error) {

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -62,6 +62,9 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   hideAvailable: 'Hide Available Media',
   hideAvailableTip:
     'Hide available media from the discover pages but not search results',
+  hideRequested: 'Hide Requested Media',
+  hideRequestedTip:
+    'Hide media that has been requested from the discover pages but not search results',
   cacheImages: 'Enable Image Caching',
   cacheImagesTip:
     'Cache externally sourced images (requires a significant amount of disk space)',
@@ -173,6 +176,7 @@ const SettingsMain = () => {
             applicationUrl: data?.applicationUrl,
             hideAvailable: data?.hideAvailable,
             hideBlocklisted: data?.hideBlocklisted,
+            hideRequested: data?.hideRequested,
             locale: data?.locale ?? 'en',
             discoverRegion: data?.discoverRegion,
             originalLanguage: data?.originalLanguage,
@@ -196,6 +200,7 @@ const SettingsMain = () => {
                 applicationUrl: values.applicationUrl,
                 hideAvailable: values.hideAvailable,
                 hideBlocklisted: values.hideBlocklisted,
+                hideRequested: values.hideRequested,
                 locale: values.locale,
                 discoverRegion: values.discoverRegion,
                 streamingRegion: values.streamingRegion,
@@ -538,6 +543,26 @@ const SettingsMain = () => {
                           'hideBlocklisted',
                           !values.hideBlocklisted
                         );
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="hideRequested" className="checkbox-label">
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.hideRequested)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.hideRequestedTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="hideRequested"
+                      name="hideRequested"
+                      onChange={() => {
+                        setFieldValue('hideRequested', !values.hideRequested);
                       }}
                     />
                   </div>

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -14,6 +14,7 @@ const defaultSettings = {
   applicationUrl: '',
   hideAvailable: false,
   hideBlocklisted: false,
+  hideRequested: false,
   localLogin: true,
   mediaServerLogin: true,
   movie4kEnabled: false,

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -19,7 +19,7 @@ interface BaseMedia {
   mediaType: string;
   mediaInfo?: {
     status: MediaStatus;
-    requests?: any[];
+    requests?: unknown[];
   };
 }
 

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -19,7 +19,7 @@ interface BaseMedia {
   mediaType: string;
   mediaInfo?: {
     status: MediaStatus;
-    requests?: unknown[];
+    hasActiveRequest?: boolean;
   };
 }
 
@@ -144,14 +144,13 @@ const useDiscover = <
   }
 
   if (settings.currentSettings.hideRequested && hideRequested) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        (i.mediaInfo?.status === MediaStatus.AVAILABLE ||
-          i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
-          !i.mediaInfo?.requests ||
-          i.mediaInfo.requests.length === 0)
-    );
+    titles = titles.filter((i) => {
+      if (i.mediaType !== 'movie' && i.mediaType !== 'tv') {
+        return true;
+      }
+
+      return !i.mediaInfo?.hasActiveRequest;
+    });
   }
 
   const isEmpty = !isLoadingInitialData && titles?.length === 0;

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -19,6 +19,7 @@ interface BaseMedia {
   mediaType: string;
   mediaInfo?: {
     status: MediaStatus;
+    requests?: any[];
   };
 }
 
@@ -58,7 +59,7 @@ const useDiscover = <
 >(
   endpoint: string,
   options?: O,
-  { hideAvailable = true, hideBlocklisted = true } = {}
+  { hideAvailable = true, hideBlocklisted = true, hideRequested = true } = {}
 ): DiscoverResult<T, S> => {
   const settings = useSettings();
   const { hasPermission } = useUser();
@@ -139,6 +140,17 @@ const useDiscover = <
       (i) =>
         (i.mediaType === 'movie' || i.mediaType === 'tv') &&
         i.mediaInfo?.status !== MediaStatus.BLOCKLISTED
+    );
+  }
+
+  if (settings.currentSettings.hideRequested && hideRequested) {
+    titles = titles.filter(
+      (i) =>
+        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
+        (i.mediaInfo?.status === MediaStatus.AVAILABLE ||
+          i.mediaInfo?.status === MediaStatus.PARTIALLY_AVAILABLE ||
+          !i.mediaInfo?.requests ||
+          i.mediaInfo.requests.length === 0)
     );
   }
 

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1035,6 +1035,8 @@
   "components.Settings.SettingsMain.hideAvailableTip": "Hide available media from the discover pages but not search results",
   "components.Settings.SettingsMain.hideBlocklisted": "Hide Blocklisted Items",
   "components.Settings.SettingsMain.hideBlocklistedTip": "Hide blocklisted items from discover pages for all users with the \"Manage Blocklist\" permission",
+  "components.Settings.SettingsMain.hideRequested": "Hide Requested Media",
+  "components.Settings.SettingsMain.hideRequestedTip": "Hide media that has been requested from the discover pages but not search results",
   "components.Settings.SettingsMain.locale": "Display Language",
   "components.Settings.SettingsMain.originallanguage": "Discover Language",
   "components.Settings.SettingsMain.originallanguageTip": "Filter content by original language",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -244,6 +244,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     applicationUrl: '',
     hideAvailable: false,
     hideBlocklisted: false,
+    hideRequested: false,
     movie4kEnabled: false,
     series4kEnabled: false,
     localLogin: true,


### PR DESCRIPTION
## Description

This PR introduces a new setting that allows users to hide media that has been requested but is not yet available from the "Discover" home page and related categories.

## How Has This Been Tested?

## Screenshots / Logs (if applicable)
<img width="465" height="84" alt="image" src="https://github.com/user-attachments/assets/49f7fb30-c6b0-468c-8241-33653b157a29" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1048


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Hide Requested Media”** toggle in Settings to hide requested-but-not-yet-available movie/TV items across Discover, Recommended, Similar, and media detail browsing; it’s **off by default**. Requested items remain **searchable**.
* **Documentation**
  * Added documentation explaining the new **Hide Requested Media** behavior and its coverage.
* **Localization**
  * Added the UI label and tooltip text for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->