### PR TITLE
feat(prefetch): add prefetching functionality for TV shows

### DIFF
--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -2104,7 +2104,6 @@ components:
           nullable: true
       required:
         - certification
-
     CertificationResponse:
       type: object
       properties:
@@ -2123,6 +2122,15 @@ components:
             - certification: 'PG'
               meaning: 'Some material may not be suitable for children under 10.'
               order: 2
+    PrefetchSettings:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+        episodeThreshold:
+          type: number
+          example: 2
+
   securitySchemes:
     cookieAuth:
       type: apiKey
@@ -6877,6 +6885,33 @@ paths:
       responses:
         '204':
           description: Successfully removed media item
+  /media/{mediaId}/prefetch:
+    post:
+      summary: Saves TV Prefetch Settings
+      description: Takes in TV Prefetch Settings in JSON then saves and returns them.
+      tags:
+        - tv
+      parameters:
+        - in: path
+          name: mediaId
+          description: Media ID
+          required: true
+          example: '1'
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrefetchSettings'
+      responses:
+        '200':
+          description: Prefetch Settings returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrefetchSettings'
   /media/{mediaId}/{status}:
     post:
       summary: Update media status

--- a/jellyseerr-api.yml
+++ b/jellyseerr-api.yml
@@ -6907,11 +6907,7 @@ paths:
               $ref: '#/components/schemas/PrefetchSettings'
       responses:
         '200':
-          description: Prefetch Settings returned
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PrefetchSettings'
+          description: Successfully saved Prefetch Settings
   /media/{mediaId}/{status}:
     post:
       summary: Update media status

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -185,6 +185,12 @@ class Media {
   @Column({ nullable: true, type: 'varchar' })
   public jellyfinMediaId4k?: string | null;
 
+  @Column({ nullable: true, type: 'boolean' })
+  prefetchEnabled?: boolean;
+
+  @Column({ nullable: true, type: 'int' })
+  prefetchEpisodeThreshold?: number;
+
   public serviceUrl?: string;
   public serviceUrl4k?: string;
   public downloadStatus?: DownloadingItem[] = [];

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -186,10 +186,10 @@ class Media {
   public jellyfinMediaId4k?: string | null;
 
   @Column({ nullable: true, type: 'boolean' })
-  prefetchEnabled?: boolean;
+  public prefetchEnabled?: boolean;
 
   @Column({ nullable: true, type: 'int' })
-  prefetchEpisodeThreshold?: number;
+  public prefetchEpisodeThreshold?: number;
 
   public serviceUrl?: string;
   public serviceUrl4k?: string;

--- a/server/job/prefetchScanner.ts
+++ b/server/job/prefetchScanner.ts
@@ -1,0 +1,153 @@
+import JellyfinMainAPI from '@server/api/jellyfinMain';
+import JellyfinPlaybackReportingAPI from '@server/api/jellyfinPlaybackReporting';
+import { getMetadataProvider } from '@server/api/metadata';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import type {
+  RunnableScanner,
+  StatusBase,
+} from '@server/lib/scanners/baseScanner';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import type { SeasonWithEpisodes } from '@server/models/Tv';
+import { getHostname } from '@server/utils/getHostname';
+import { getMediaServerAdmin } from '@server/utils/getMediaServerAdmin';
+
+class AbortPrefetchScan extends Error {}
+
+class PrefetchScanner implements RunnableScanner<StatusBase> {
+  private running = false;
+  private progress = 0;
+
+  private jfClient: JellyfinMainAPI;
+  private jfPlaybackReportingClient: JellyfinPlaybackReportingAPI;
+  private fullyPlayedEpisodes: SeasonWithEpisodes[] = [];
+
+  public async run() {
+    this.running = true;
+
+    try {
+      await this.queryPlaybackActivity();
+    } catch (err) {
+      if (err instanceof AbortPrefetchScan) {
+        logger.info('Aborting job: Scan for Episodes to Prefetch', {
+          label: 'Jobs',
+        });
+      } else {
+        throw err;
+      }
+    } finally {
+      this.reset();
+    }
+  }
+
+  public status(): StatusBase {
+    return {
+      running: this.running,
+      progress: this.progress,
+      total: this.fullyPlayedEpisodes.length,
+    };
+  }
+
+  public cancel() {
+    this.running = false;
+    this.progress = 0;
+    this.fullyPlayedEpisodes = [];
+  }
+
+  private reset() {
+    this.cancel();
+  }
+
+  private async queryPlaybackActivity() {
+    const settings = getSettings();
+    const admin = await getMediaServerAdmin();
+
+    if (!admin) {
+      logger.warn('No admin configured. Prefetch scan skipped.');
+      return;
+    }
+
+    this.jfClient = new JellyfinMainAPI(
+      getHostname(),
+      settings.jellyfin.apiKey,
+      admin.jellyfinDeviceId
+    );
+    this.jfPlaybackReportingClient = new JellyfinPlaybackReportingAPI(
+      getHostname(),
+      settings.jellyfin.apiKey,
+      admin.jellyfinDeviceId
+    );
+
+    const playbackActivity =
+      await this.jfPlaybackReportingClient.getPlaybackActivity({
+        itemType: 'Episode',
+      });
+
+    const mediaRepository = getRepository(Media);
+    const metadataProvider = await getMetadataProvider('tv');
+
+    for (let i = 0; i < playbackActivity.length; ++i) {
+      const activity = playbackActivity[i];
+
+      const item = await this.jfClient.getItemData(activity.ItemId);
+      if (
+        !item ||
+        !item.ParentIndexNumber ||
+        !item.IndexNumber ||
+        !item.RunTimeTicks
+      ) {
+        logger.debug(`Jellyfin Item with ID ${activity.ItemId} not found`);
+        continue;
+      }
+
+      const media = await mediaRepository.findOne({
+        where: { jellyfinMediaId: item.SeriesId },
+      });
+      if (!media) {
+        logger.debug(`Media with Jellyfin ID ${item.SeriesId} not found`);
+        continue;
+      }
+
+      const show = await metadataProvider.getTvShow({
+        tvId: media.tmdbId,
+      });
+      const season = await metadataProvider.getTvSeason({
+        tvId: media.tmdbId,
+        seasonNumber: item.ParentIndexNumber,
+      });
+      const episode = season.episodes.find(
+        (episode) => episode.episode_number === item.IndexNumber
+      );
+      if (!episode) {
+        logger.debug(
+          `Episode ${item.IndexNumber} not found at ${season.name} of ${show.name}`
+        );
+        continue;
+      }
+
+      // the runtime is in minutes while the PlayDuration is provided in seconds
+      const activityPlayDurationMinutes = activity.PlayDuration / 60;
+      if (episode.runtime * 0.9 > activityPlayDurationMinutes) {
+        continue;
+      }
+
+      const prefetchEpisodeThreshold = media.prefetchEpisodeThreshold ?? 2;
+      if (
+        season.episodes.length >
+        item.IndexNumber + prefetchEpisodeThreshold
+      ) {
+        continue;
+      }
+
+      console.log(`Threshold exceeded at ${season.name} of ${show.name}`);
+      console.log(
+        `Runtime: ${episode.runtime}, Jellyfin: ${
+          item.RunTimeTicks / 10_000_000 / 60
+        }`
+      );
+    }
+  }
+}
+
+export const prefetchScanner = new PrefetchScanner();

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -61,6 +61,11 @@ interface SpokenLanguage {
   name: string;
 }
 
+interface PrefetchSettings {
+  enabled: boolean;
+  episodeThreshold: number;
+}
+
 export interface TvDetails {
   id: number;
   backdropPath?: string;
@@ -112,6 +117,7 @@ export interface TvDetails {
   mediaInfo?: Media;
   watchProviders?: WatchProviders[];
   onUserWatchlist?: boolean;
+  prefetchSettings?: PrefetchSettings;
 }
 
 const mapEpisodeResult = (episode: TmdbTvEpisodeResult): Episode => ({

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -61,11 +61,6 @@ interface SpokenLanguage {
   name: string;
 }
 
-interface PrefetchSettings {
-  enabled: boolean;
-  episodeThreshold: number;
-}
-
 export interface TvDetails {
   id: number;
   backdropPath?: string;
@@ -117,7 +112,6 @@ export interface TvDetails {
   mediaInfo?: Media;
   watchProviders?: WatchProviders[];
   onUserWatchlist?: boolean;
-  prefetchSettings?: PrefetchSettings;
 }
 
 const mapEpisodeResult = (episode: TmdbTvEpisodeResult): Episode => ({

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -91,38 +91,42 @@ mediaRoutes.get('/', async (req, res, next) => {
   }
 });
 
-mediaRoutes.post<{ id: string }>('/:id/prefetch', async (req, res, next) => {
-  try {
-    const mediaRepository = getRepository(Media);
-    const media = await mediaRepository.findOneOrFail({
-      where: { id: Number(req.params.id) },
-    });
+mediaRoutes.post<{ id: string }>(
+  '/:id/prefetch',
+  isAuthenticated(Permission.MANAGE_REQUESTS),
+  async (req, res, next) => {
+    try {
+      const mediaRepository = getRepository(Media);
+      const media = await mediaRepository.findOneOrFail({
+        where: { id: Number(req.params.id) },
+      });
 
-    if (media.mediaType !== MediaType.TV) {
+      if (media.mediaType !== MediaType.TV) {
+        return next({
+          status: 400,
+          message: 'Prefetching is only available to media with type TV.',
+        });
+      }
+
+      media.prefetchEnabled = req.body.enabled;
+      media.prefetchEpisodeThreshold = req.body.episodeThreshold;
+
+      await mediaRepository.save(media);
+
+      return res.status(200).send();
+    } catch (e) {
+      logger.debug('Something went wrong saving series prefetch settings', {
+        label: 'API',
+        errorMessage: e.message,
+        tvId: req.params.id,
+      });
       return next({
-        status: 400,
-        message: 'Prefetching is only available to media with type TV.',
+        status: 500,
+        message: 'Failed to save series prefetch settings.',
       });
     }
-
-    media.prefetchEnabled = req.body.enabled;
-    media.prefetchEpisodeThreshold = req.body.episodeThreshold;
-
-    await mediaRepository.save(media);
-
-    return res.status(200).json(media);
-  } catch (e) {
-    logger.debug('Something went wrong saving series prefetch settings', {
-      label: 'API',
-      errorMessage: e.message,
-      tvId: req.params.id,
-    });
-    return next({
-      status: 500,
-      message: 'Failed to save series prefetch settings.',
-    });
   }
-});
+);
 
 mediaRoutes.post<
   {

--- a/src/components/Common/ToggleSwitch/index.tsx
+++ b/src/components/Common/ToggleSwitch/index.tsx
@@ -1,0 +1,45 @@
+interface ToggleSwitchProps {
+  isToggled: boolean;
+  onToggle: () => void;
+  disabled?: unknown;
+}
+
+function ToggleSwitch({ isToggled, onToggle, disabled }: ToggleSwitchProps) {
+  const onClick = () => {
+    if (!disabled) {
+      onToggle();
+    }
+  };
+
+  return (
+    <span
+      role="checkbox"
+      tabIndex={0}
+      aria-checked={isToggled}
+      onClick={() => onClick()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === 'Space') {
+          onClick();
+        }
+      }}
+      className={`relative inline-flex h-5 w-10 flex-shrink-0 items-center justify-center pt-2 focus:outline-none ${
+        disabled ? 'cursor-default opacity-50' : 'cursor-pointer'
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className={`${
+          isToggled ? 'bg-indigo-500' : 'bg-gray-700'
+        } absolute mx-auto h-4 w-9 rounded-full transition-colors duration-200 ease-in-out`}
+      ></span>
+      <span
+        aria-hidden="true"
+        className={`${
+          isToggled ? 'translate-x-5' : 'translate-x-0'
+        } absolute left-0 inline-block h-5 w-5 rounded-full border border-gray-200 bg-white shadow transition-transform duration-200 ease-in-out group-focus:border-blue-300 group-focus:ring`}
+      ></span>
+    </span>
+  );
+}
+
+export default ToggleSwitch;

--- a/src/components/ManageSlideOver/PrefetchForm.tsx
+++ b/src/components/ManageSlideOver/PrefetchForm.tsx
@@ -1,0 +1,96 @@
+import Button from '@app/components/Common/Button';
+import defineMessages from '@app/utils/defineMessages';
+import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
+import type { TvDetails } from '@server/models/Tv';
+import axios from 'axios';
+import { Field, Form, Formik } from 'formik';
+import { useIntl } from 'react-intl';
+import { useToasts } from 'react-toast-notifications';
+
+const DEFAULT_EPISODE_THRESHOLD = 2;
+
+const messages = defineMessages('components.ManageSlideOver.PrefetchForm', {
+  prefetchEnable: 'Enable Prefetch',
+  prefetchEnableTip: 'Automatically prefetches next season',
+  prefetchEpisodeThreshold: 'Episode Threshold',
+  prefetchEpisodeThresholdTip:
+    'Prefetches if this count of episodes is left to watch',
+  prefetchSave: 'Save Prefetch Settings',
+  prefetchSettingsSaved: 'Prefetch Settings saved successfully!',
+  prefetchSettingsFailed: 'Prefetch Settings failed to save.',
+});
+
+interface PrefetchFormProps {
+  data: TvDetails;
+}
+
+function PrefetchForm({ data }: PrefetchFormProps) {
+  const intl = useIntl();
+  const { addToast } = useToasts();
+
+  return (
+    <Formik
+      initialValues={{
+        enabled: data.prefetchSettings?.enabled,
+        episodeThreshold:
+          data.prefetchSettings?.episodeThreshold ?? DEFAULT_EPISODE_THRESHOLD,
+      }}
+      onSubmit={async (values) => {
+        try {
+          await axios.post(`/api/v1/tv/${data.id}/prefetch`, {
+            enabled: values.enabled,
+            episodeThreshold: values.episodeThreshold,
+          });
+
+          addToast(intl.formatMessage(messages.prefetchSettingsSaved), {
+            appearance: 'success',
+            autoDismiss: true,
+          });
+        } catch (e) {
+          addToast(intl.formatMessage(messages.prefetchSettingsFailed), {
+            appearance: 'error',
+            autoDismiss: true,
+          });
+        }
+      }}
+    >
+      <Form>
+        <div className="mb-2 overflow-hidden rounded-md border border-gray-700 shadow">
+          <div className="flex min-w-full gap-4 border-b border-gray-700 px-4 py-3">
+            <label htmlFor="enabled" className="grow">
+              <span>{intl.formatMessage(messages.prefetchEnable)}</span>
+              <span className="label-tip">
+                {intl.formatMessage(messages.prefetchEnableTip)}
+              </span>
+            </label>
+            <Field type="checkbox" id="enabled" name="enabled" />
+          </div>
+          <div className="flex min-w-full gap-4 px-4 py-3">
+            <label htmlFor="episodeThreshold" className="grow basis-2/3">
+              <span>
+                {intl.formatMessage(messages.prefetchEpisodeThreshold)}
+              </span>
+              <span className="label-tip">
+                {intl.formatMessage(messages.prefetchEpisodeThresholdTip)}
+              </span>
+            </label>
+            <Field as="select" id="episodeThreshold" name="episodeThreshold">
+              {[...Array(10)].map((_item, i) => (
+                <option value={i + 1} key={`prefetch-threshold-${i + 1}`}>
+                  {i + 1}
+                </option>
+              ))}
+            </Field>
+          </div>
+        </div>
+
+        <Button type="submit" buttonType="primary" className="w-full">
+          <ArrowDownOnSquareIcon />
+          <span>{intl.formatMessage(messages.prefetchSave)}</span>
+        </Button>
+      </Form>
+    </Formik>
+  );
+}
+
+export default PrefetchForm;

--- a/src/components/ManageSlideOver/PrefetchForm.tsx
+++ b/src/components/ManageSlideOver/PrefetchForm.tsx
@@ -22,9 +22,10 @@ const messages = defineMessages('components.ManageSlideOver.PrefetchForm', {
 
 interface PrefetchFormProps {
   data: TvDetails;
+  revalidate: () => void;
 }
 
-function PrefetchForm({ data }: PrefetchFormProps) {
+function PrefetchForm({ data, revalidate }: PrefetchFormProps) {
   const intl = useIntl();
   const { addToast } = useToasts();
 
@@ -51,6 +52,8 @@ function PrefetchForm({ data }: PrefetchFormProps) {
             appearance: 'error',
             autoDismiss: true,
           });
+        } finally {
+          revalidate();
         }
       }}
     >

--- a/src/components/ManageSlideOver/PrefetchForm.tsx
+++ b/src/components/ManageSlideOver/PrefetchForm.tsx
@@ -31,15 +31,15 @@ function PrefetchForm({ data }: PrefetchFormProps) {
   return (
     <Formik
       initialValues={{
-        enabled: data.prefetchSettings?.enabled,
+        enabled: data.mediaInfo?.prefetchEnabled,
         episodeThreshold:
-          data.prefetchSettings?.episodeThreshold ?? DEFAULT_EPISODE_THRESHOLD,
+          data.mediaInfo?.prefetchEpisodeThreshold ?? DEFAULT_EPISODE_THRESHOLD,
       }}
       onSubmit={async (values) => {
         try {
-          await axios.post(`/api/v1/tv/${data.id}/prefetch`, {
+          await axios.post(`/api/v1/media/${data.mediaInfo?.id}/prefetch`, {
             enabled: values.enabled,
-            episodeThreshold: values.episodeThreshold,
+            episodeThreshold: Number(values.episodeThreshold),
           });
 
           addToast(intl.formatMessage(messages.prefetchSettingsSaved), {

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -6,6 +6,7 @@ import SlideOver from '@app/components/Common/SlideOver';
 import Tooltip from '@app/components/Common/Tooltip';
 import DownloadBlock from '@app/components/DownloadBlock';
 import IssueBlock from '@app/components/IssueBlock';
+import PrefetchForm from '@app/components/ManageSlideOver/PrefetchForm';
 import RequestBlock from '@app/components/RequestBlock';
 import useSettings from '@app/hooks/useSettings';
 import { Permission, useUser } from '@app/hooks/useUser';
@@ -35,6 +36,7 @@ import useSWR from 'swr';
 
 const messages = defineMessages('components.ManageSlideOver', {
   manageModalTitle: 'Manage {mediaType}',
+  manageModalPrefetch: 'Prefetch',
   manageModalIssues: 'Open Issues',
   manageModalRequests: 'Requests',
   manageModalMedia: 'Media',
@@ -227,6 +229,14 @@ const ManageSlideOver = ({
                 ))}
               </ul>
             </div>
+          </div>
+        )}
+        {mediaType === 'tv' && hasPermission(Permission.MANAGE_REQUESTS) && (
+          <div>
+            <h3 className="mb-2 text-xl font-bold">
+              {intl.formatMessage(messages.manageModalPrefetch)}
+            </h3>
+            <PrefetchForm data={data} />
           </div>
         )}
         {hasPermission([Permission.MANAGE_ISSUES, Permission.VIEW_ISSUES], {

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -236,7 +236,7 @@ const ManageSlideOver = ({
             <h3 className="mb-2 text-xl font-bold">
               {intl.formatMessage(messages.manageModalPrefetch)}
             </h3>
-            <PrefetchForm data={data} />
+            <PrefetchForm data={data} revalidate={revalidate} />
           </div>
         )}
         {hasPermission([Permission.MANAGE_ISSUES, Permission.VIEW_ISSUES], {


### PR DESCRIPTION
#### Description
This PR adds prefetching functionality like [Prefetcharr](https://github.com/p-hueber/prefetcharr/) to Jellyseerr only for Jellyfin/Ebny media servers. The prefetching will be configurable via the TV show management Sideover.

To retrieve playback information this PR uses the Jellyfin Playback Reporting plugin API. Therefore it is dependent on #1941.

Additionally some rights will be added to only allow requesting first seasons and letting everything else prefetch if a user gets within the specified threshold.

This is WIP!

#### Screenshot (if UI-related)
<img width="1467" height="339" alt="2025-09-03_00-12" src="https://github.com/user-attachments/assets/52e9d286-0115-44f4-bd89-91a08d708810" />


#### To-Dos

- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #1385
- Fixes #1939
