### PR TITLE
chore: update renovate bot logic to remove pin from compose files and charts

### DIFF
--- a/.github/renovate/docker.json5
+++ b/.github/renovate/docker.json5
@@ -5,4 +5,11 @@
     'docker:enableMajor',
     'docker:pinDigests'
   ],
+
+  packageRules: [
+    {
+      matchManagers: ['docker-compose'],
+      pinDigests: false,
+    },
+  ],
 }

--- a/.github/renovate/helm.json5
+++ b/.github/renovate/helm.json5
@@ -5,7 +5,8 @@
     {
       matchManagers: ['helm-values'],
       matchFileNames: ['charts/*/values.yaml'],
-      minimumReleaseAge: '0'
+      minimumReleaseAge: '0',
+      pinDigests: false,
     },
   ],
 


### PR DESCRIPTION
chore: update renovate bot logic to remove pin from compose files and charts