### PR TITLE
refactor(notifications): replace webhook KeyMap with LiquidJS templating

### DIFF
--- a/docs/using-seerr/notifications/webhook.md
+++ b/docs/using-seerr/notifications/webhook.md
@@ -47,13 +47,13 @@ Payloads and webhook URLs are rendered with [LiquidJS](https://liquidjs.com/), s
 
 Render a section only when the relevant object is present, falling back to `null` otherwise:
 
-```
+```liquid
 "media": {% if media %}{ "tmdbId": "{{ media_tmdbid }}" }{% else %}null{% endif %}
 ```
 
 You can also branch on a value:
 
-```
+```liquid
 {% if media_status == "AVAILABLE" %}...{% else %}...{% endif %}
 ```
 

--- a/docs/using-seerr/notifications/webhook.md
+++ b/docs/using-seerr/notifications/webhook.md
@@ -35,9 +35,56 @@ You cannot configure both the **Authorization Header** field and a custom `Autho
 
 ### JSON Payload
 
-Customize the JSON payload to suit your needs. Seerr provides several [template variables](#template-variables) for use in the payload, which will be replaced with the relevant data when the notifications are triggered.
+Customize the JSON payload to suit your needs. The payload is a [Liquid](https://liquidjs.com/) template that is rendered when a notification is triggered and then sent as the request body. Seerr exposes a set of [template variables](#template-variables), plus the full `media`, `request`, `issue`, and `comment` objects, for use in [conditionals and filters](#template-syntax).
+
+The template only needs to _render_ to valid JSON — it does not need to be valid JSON itself (for example, optional sections can be wrapped in `{% if %}` blocks). Use the **Test** button to confirm your template renders correctly; template errors are also written to the server logs.
+
+## Template Syntax
+
+Payloads and webhook URLs are rendered with [LiquidJS](https://liquidjs.com/), so in addition to simple `{{ variable }}` substitution you can use Liquid tags and filters.
+
+### Conditionals
+
+Render a section only when the relevant object is present, falling back to `null` otherwise:
+
+```
+"media": {% if media %}{ "tmdbId": "{{ media_tmdbid }}" }{% else %}null{% endif %}
+```
+
+You can also branch on a value:
+
+```
+{% if media_status == "AVAILABLE" %}...{% else %}...{% endif %}
+```
+
+### Filters
+
+- **`json`** — `{{ subject | json }}`: serializes a value as JSON, quoting and escaping strings so characters like `"` or newlines can't break the payload. Circular-safe.
+- **`default`** — `{{ notifyuser_username | default: "Unknown User" }}`: falls back to a value when the input is nil or empty.
+- **`upcase` / `downcase`** — `{{ media_type | upcase }}`: changes case.
+- **`capitalize`** — `{{ notifyuser_username | capitalize }}`: capitalizes the first character.
+- **`truncate`** — `{{ subject | truncate: 50 }}`: shortens a string.
+- **`url_encode`** — `{{ subject | url_encode }}`: percent-encodes a value for use in a URL.
+
+See the [LiquidJS filter reference](https://liquidjs.com/filters/overview.html) for the full list.
+
+:::info
+Free-text values (titles, overviews, usernames, comments) should be emitted through the `json` filter so quotes and newlines can't produce invalid JSON, e.g. `"subject": {{ subject | json }}`.
+:::
+
+:::warning
+Webhook URL values are rendered raw. When substituting a value into a URL, use the `url_encode` filter (e.g. `...?user={{ notifyuser_username | url_encode }}`) so characters like `&`, `?`, or spaces don't break the URL.
+:::
+
+### Advanced object access
+
+In addition to the flat variables documented below, the full `media`, `request`, `issue`, and `comment` objects are available for conditionals and advanced templates (for example `{% if issue %}` or `{{ request.id }}`). These map to the [`NotificationPayload` interface](https://github.com/seerr-team/seerr/blob/develop/server/lib/notifications/agents/agent.ts).
 
 ## Template Variables
+
+:::warning Deprecated
+The flat template variables listed below (e.g. `{{ media_tmdbid }}`, `{{ notifyuser_username }}`) are deprecated and will be replaced in a future release. They continue to work for now, and a migration will be provided to convert existing templates automatically.
+:::
 
 ### General
 
@@ -77,21 +124,21 @@ On the other hand, the `notifyuser` variables _will_ be replaced with the reques
 If you would like to use the requesting user's information in your webhook, please instead include the relevant variables from the [Request](#request) section below.
 :::
 
-### Special
+### Objects
 
-The following variables must be used as a key in the JSON payload (e.g., `"{{extra}}": []`).
+The following values are the full objects for each notification. They are `null` when not relevant to the notification, and are primarily useful in conditionals (e.g. `{% if media %}`) or for accessing fields not covered by the flat variables below. Serialize an object into the payload with the `json` filter, e.g. `"extra": {{ extra | json }}`.
 
-| Variable      | Value                                                                                                                          |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `{{media}}`   | The relevant media object                                                                                                      |
-| `{{request}}` | The relevant request object                                                                                                    |
-| `{{issue}}`   | The relevant issue object                                                                                                      |
-| `{{comment}}` | The relevant issue comment object                                                                                              |
-| `{{extra}}`   | The "extra" array of additional data for certain notifications (e.g., season/episode numbers for series-related notifications) |
+| Variable    | Value                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `media`     | The relevant media object                                                                                                      |
+| `request`   | The relevant request object                                                                                                    |
+| `issue`     | The relevant issue object                                                                                                      |
+| `comment`   | The relevant issue comment object                                                                                              |
+| `extra`     | The "extra" array of additional data for certain notifications (e.g., season/episode numbers for series-related notifications) |
 
 #### Media
 
-The `{{media}}` will be `null` if there is no relevant media object for the notification.
+`media` will be `null` if there is no relevant media object for the notification.
 
 These following special variables are only included in media-related notifications, such as requests.
 
@@ -109,7 +156,7 @@ These following special variables are only included in media-related notificatio
 
 #### Request
 
-The `{{request}}` will be `null` if there is no relevant media object for the notification.
+`request` will be `null` if there is no relevant request object for the notification.
 
 The following special variables are only included in request-related notifications.
 
@@ -125,7 +172,7 @@ The following special variables are only included in request-related notificatio
 
 #### Issue
 
-The `{{issue}}` will be `null` if there is no relevant media object for the notification.
+`issue` will be `null` if there is no relevant issue object for the notification.
 
 The following special variables are only included in issue-related notifications.
 
@@ -140,7 +187,7 @@ The following special variables are only included in issue-related notifications
 
 #### Comment
 
-The `{{comment}}` will be `null` if there is no relevant media object for the notification.
+`comment` will be `null` if there is no relevant comment object for the notification.
 
 The following special variables are only included in issue comment-related notifications.
 

--- a/docs/using-seerr/notifications/webhook.md
+++ b/docs/using-seerr/notifications/webhook.md
@@ -35,7 +35,7 @@ You cannot configure both the **Authorization Header** field and a custom `Autho
 
 ### JSON Payload
 
-Customize the JSON payload to suit your needs. The payload is a [Liquid](https://liquidjs.com/) template that is rendered when a notification is triggered and then sent as the request body. Seerr exposes a set of [template variables](#template-variables), plus the full `media`, `request`, `issue`, and `comment` objects, for use in [conditionals and filters](#template-syntax).
+Customize the JSON payload to suit your needs. The payload is a [Liquid](https://liquidjs.com/) template that is rendered when a notification is triggered and then sent as the request body. Seerr exposes a set of [template variables](#template-variables), plus the full `media`, `request`, `issue`, and `comment` objects, for use in [conditionals and filters](#template-syntax). If you are new to Liquid, see the [introduction to Liquid tutorial](https://liquidjs.com/tutorials/intro-to-liquid.html).
 
 The template only needs to _render_ to valid JSON — it does not need to be valid JSON itself (for example, optional sections can be wrapped in `{% if %}` blocks). Use the **Test** button to confirm your template renders correctly; template errors are also written to the server logs.
 

--- a/gen-docs/docusaurus.config.ts
+++ b/gen-docs/docusaurus.config.ts
@@ -193,6 +193,7 @@ const config: Config = {
         'nix',
         'nginx',
         'batch',
+        'liquid',
       ],
     },
   } satisfies Preset.ThemeConfig,

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "express-session": "1.17.3",
     "formik": "^2.4.6",
     "gravatar-url": "3.1.0",
+    "handlebars": "^4.7.8",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "https-proxy-agent": "^7.0.6",
     "humanize-duration": "^3.33.2",
     "js-yaml": "^4.1.1",
+    "liquidjs": "^10.27.0",
     "lodash": "4.18.1",
     "mime": "^4.1.0",
     "nanoid": "^5.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       gravatar-url:
         specifier: 3.1.0
         version: 3.1.0
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
       http-proxy-agent:
         specifier: ^7.0.2
         version: 7.0.2
@@ -16031,7 +16034,6 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.18.0
-    optional: true
 
   har-schema@2.0.0: {}
 
@@ -20217,8 +20219,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wordwrap@1.0.0:
-    optional: true
+  wordwrap@1.0.0: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      liquidjs:
+        specifier: ^10.27.0
+        version: 10.27.0
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -3484,6 +3487,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
@@ -5400,6 +5407,11 @@ packages:
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
+    hasBin: true
+
+  liquidjs@10.27.0:
+    resolution: {integrity: sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==}
+    engines: {node: '>=16'}
     hasBin: true
 
   listr2@3.14.0:
@@ -11473,6 +11485,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@10.0.1: {}
+
   commander@12.1.0: {}
 
   commander@14.0.3: {}
@@ -14034,6 +14048,10 @@ snapshots:
       string-argv: 0.3.2
       tinyexec: 1.1.1
       yaml: 2.8.3
+
+  liquidjs@10.27.0:
+    dependencies:
+      commander: 10.0.1
 
   listr2@3.14.0(enquirer@2.4.1):
     dependencies:

--- a/server/lib/notifications/agents/webhook.test.ts
+++ b/server/lib/notifications/agents/webhook.test.ts
@@ -1,0 +1,114 @@
+import { Notification } from '@server/lib/notifications';
+import WebhookAgent from '@server/lib/notifications/agents/webhook';
+import type { NotificationAgentWebhook } from '@server/lib/settings';
+import axios from 'axios';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { NotificationPayload } from './agent';
+
+const encode = (template: string) => Buffer.from(template).toString('base64');
+
+const makePayload = (
+  overrides: Partial<NotificationPayload> = {}
+): NotificationPayload =>
+  ({
+    subject: 'Test Subject',
+    notifySystem: true,
+    notifyAdmin: false,
+    ...overrides,
+  }) as NotificationPayload;
+
+const makeSettings = (
+  overrides: Partial<NotificationAgentWebhook['options']> = {}
+): NotificationAgentWebhook => ({
+  enabled: true,
+  embedPoster: false,
+  types: Notification.TEST_NOTIFICATION,
+  options: {
+    webhookUrl: 'https://example.com/webhook',
+    jsonPayload: encode('{ "subject": {{ subject | json }} }'),
+    ...overrides,
+  },
+});
+
+describe('WebhookAgent', () => {
+  describe('send', () => {
+    it('returns true and posts the rendered payload', async (t) => {
+      const post = t.mock.method(axios, 'post', async () => ({}));
+
+      const agent = new WebhookAgent(makeSettings());
+      const result = await agent.send(
+        Notification.TEST_NOTIFICATION,
+        makePayload({ subject: 'The "Best" Movie' })
+      );
+
+      assert.equal(result, true);
+      assert.equal(post.mock.callCount(), 1);
+      const [url, body] = post.mock.calls[0].arguments;
+      assert.equal(url, 'https://example.com/webhook');
+      assert.deepEqual(body, { subject: 'The "Best" Movie' });
+    });
+
+    it('returns false when the payload template fails to render', async (t) => {
+      const post = t.mock.method(axios, 'post', async () => ({}));
+
+      const agent = new WebhookAgent(
+        makeSettings({ jsonPayload: encode('{% invalid %}') })
+      );
+      const result = await agent.send(
+        Notification.TEST_NOTIFICATION,
+        makePayload()
+      );
+
+      assert.equal(result, false);
+      assert.equal(post.mock.callCount(), 0);
+    });
+
+    it('returns false when the rendered payload is not valid JSON', async (t) => {
+      const post = t.mock.method(axios, 'post', async () => ({}));
+
+      const agent = new WebhookAgent(
+        makeSettings({ jsonPayload: encode('{ not json }') })
+      );
+      const result = await agent.send(
+        Notification.TEST_NOTIFICATION,
+        makePayload()
+      );
+
+      assert.equal(result, false);
+      assert.equal(post.mock.callCount(), 0);
+    });
+
+    it('returns false when the webhook URL template fails to render', async (t) => {
+      const post = t.mock.method(axios, 'post', async () => ({}));
+
+      const agent = new WebhookAgent(
+        makeSettings({
+          webhookUrl: 'https://example.com/{% invalid %}',
+          supportVariables: true,
+        })
+      );
+      const result = await agent.send(
+        Notification.TEST_NOTIFICATION,
+        makePayload()
+      );
+
+      assert.equal(result, false);
+      assert.equal(post.mock.callCount(), 0);
+    });
+
+    it('returns false when posting to the webhook URL fails', async (t) => {
+      t.mock.method(axios, 'post', async () => {
+        throw new Error('connect ECONNREFUSED');
+      });
+
+      const agent = new WebhookAgent(makeSettings());
+      const result = await agent.send(
+        Notification.TEST_NOTIFICATION,
+        makePayload()
+      );
+
+      assert.equal(result, false);
+    });
+  });
+});

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -1,61 +1,11 @@
-import { IssueStatus, IssueType } from '@server/constants/issue';
-import { MediaStatus } from '@server/constants/media';
+import { TemplateEngine } from '@server/lib/notifications/templateEngine';
 import type { NotificationAgentWebhook } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import axios from 'axios';
-import { get } from 'lodash';
 import { hasNotificationType, Notification } from '..';
 import type { NotificationAgent, NotificationPayload } from './agent';
 import { BaseAgent } from './agent';
-
-type KeyMapFunction = (
-  payload: NotificationPayload,
-  type: Notification
-) => string;
-
-const KeyMap: Record<string, string | KeyMapFunction> = {
-  notification_type: (_payload, type) => Notification[type],
-  event: 'event',
-  subject: 'subject',
-  message: 'message',
-  image: 'image',
-  notifyuser_username: 'notifyUser.displayName',
-  notifyuser_email: 'notifyUser.email',
-  notifyuser_avatar: 'notifyUser.avatar',
-  notifyuser_settings_discordId: 'notifyUser.settings.discordId',
-  notifyuser_settings_telegramChatId: 'notifyUser.settings.telegramChatId',
-  media_tmdbid: 'media.tmdbId',
-  media_tvdbid: 'media.tvdbId',
-  media_type: 'media.mediaType',
-  media_status: (payload) =>
-    payload.media ? MediaStatus[payload.media.status] : '',
-  media_status4k: (payload) =>
-    payload.media ? MediaStatus[payload.media.status4k] : '',
-  request_id: 'request.id',
-  requestedBy_username: 'request.requestedBy.displayName',
-  requestedBy_email: 'request.requestedBy.email',
-  requestedBy_avatar: 'request.requestedBy.avatar',
-  requestedBy_settings_discordId: 'request.requestedBy.settings.discordId',
-  requestedBy_settings_telegramChatId:
-    'request.requestedBy.settings.telegramChatId',
-  issue_id: 'issue.id',
-  issue_type: (payload) =>
-    payload.issue ? IssueType[payload.issue.issueType] : '',
-  issue_status: (payload) =>
-    payload.issue ? IssueStatus[payload.issue.status] : '',
-  reportedBy_username: 'issue.createdBy.displayName',
-  reportedBy_email: 'issue.createdBy.email',
-  reportedBy_avatar: 'issue.createdBy.avatar',
-  reportedBy_settings_discordId: 'issue.createdBy.settings.discordId',
-  reportedBy_settings_telegramChatId: 'issue.createdBy.settings.telegramChatId',
-  comment_message: 'comment.message',
-  commentedBy_username: 'comment.user.displayName',
-  commentedBy_email: 'comment.user.email',
-  commentedBy_avatar: 'comment.user.avatar',
-  commentedBy_settings_discordId: 'comment.user.settings.discordId',
-  commentedBy_settings_telegramChatId: 'comment.user.settings.telegramChatId',
-};
 
 class WebhookAgent
   extends BaseAgent<NotificationAgentWebhook>
@@ -71,81 +21,42 @@ class WebhookAgent
     return settings.notifications.agents.webhook;
   }
 
-  private parseKeys(
-    finalPayload: Record<string, unknown>,
-    payload: NotificationPayload,
-    type: Notification
-  ): Record<string, unknown> {
-    Object.keys(finalPayload).forEach((key) => {
-      if (key === '{{extra}}') {
-        finalPayload.extra = payload.extra ?? [];
-        delete finalPayload[key];
-        key = 'extra';
-      } else if (key === '{{media}}') {
-        if (payload.media) {
-          finalPayload.media = finalPayload[key];
-        } else {
-          finalPayload.media = null;
-        }
-        delete finalPayload[key];
-        key = 'media';
-      } else if (key === '{{request}}') {
-        if (payload.request) {
-          finalPayload.request = finalPayload[key];
-        } else {
-          finalPayload.request = null;
-        }
-        delete finalPayload[key];
-        key = 'request';
-      } else if (key === '{{issue}}') {
-        if (payload.issue) {
-          finalPayload.issue = finalPayload[key];
-        } else {
-          finalPayload.issue = null;
-        }
-        delete finalPayload[key];
-        key = 'issue';
-      } else if (key === '{{comment}}') {
-        if (payload.comment) {
-          finalPayload.comment = finalPayload[key];
-        } else {
-          finalPayload.comment = null;
-        }
-        delete finalPayload[key];
-        key = 'comment';
-      }
-
-      if (typeof finalPayload[key] === 'string') {
-        Object.keys(KeyMap).forEach((keymapKey) => {
-          const keymapValue = KeyMap[keymapKey as keyof typeof KeyMap];
-          finalPayload[key] = (finalPayload[key] as string).replace(
-            `{{${keymapKey}}}`,
-            typeof keymapValue === 'function'
-              ? keymapValue(payload, type)
-              : get(payload, keymapValue) ?? ''
-          );
-        });
-      } else if (finalPayload[key] && typeof finalPayload[key] === 'object') {
-        finalPayload[key] = this.parseKeys(
-          finalPayload[key] as Record<string, unknown>,
-          payload,
-          type
-        );
-      }
-    });
-
-    return finalPayload;
-  }
-
   private buildPayload(type: Notification, payload: NotificationPayload) {
     const payloadString = Buffer.from(
       this.getSettings().options.jsonPayload,
       'base64'
     ).toString('utf8');
 
-    const parsedJSON = JSON.parse(JSON.parse(payloadString));
+    try {
+      // Parse the outer JSON string to get the template
+      const templateString = JSON.parse(payloadString);
 
-    return this.parseKeys(parsedJSON, payload, type);
+      // Render the template with Handlebars
+      let renderedString = TemplateEngine.render(templateString, payload, type);
+
+      // Clean up common JSON issues from template rendering
+      // Remove trailing commas before closing braces/brackets
+      renderedString = renderedString
+        .replace(/,(\s*[}\]])/g, '$1')
+        // Remove multiple consecutive commas
+        .replace(/,+/g, ',')
+        // Remove commas after opening braces/brackets
+        .replace(/([[{])\s*,/g, '$1');
+
+      // Parse the rendered template into an object
+      return JSON.parse(renderedString);
+    } catch (error) {
+      logger.error('Error rendering webhook payload template', {
+        label: 'Notifications',
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      });
+      // Fallback: try to parse as double-encoded JSON
+      try {
+        return JSON.parse(JSON.parse(payloadString));
+      } catch {
+        throw error;
+      }
+    }
   }
 
   public shouldSend(): boolean {
@@ -180,19 +91,18 @@ class WebhookAgent
     let webhookUrl = settings.options.webhookUrl;
 
     if (settings.options.supportVariables) {
-      Object.keys(KeyMap).forEach((keymapKey) => {
-        const keymapValue = KeyMap[keymapKey as keyof typeof KeyMap];
-        const variableValue =
-          type === Notification.TEST_NOTIFICATION
-            ? 'test'
-            : typeof keymapValue === 'function'
-            ? keymapValue(payload, type)
-            : get(payload, keymapValue) || 'test';
-        webhookUrl = webhookUrl.replace(
-          new RegExp(`{{${keymapKey}}}`, 'g'),
-          encodeURIComponent(variableValue)
+      try {
+        webhookUrl = TemplateEngine.render(webhookUrl, payload, type);
+      } catch (error) {
+        logger.warn(
+          'Error rendering webhook URL template, using original URL',
+          {
+            label: 'Notifications',
+            errorMessage:
+              error instanceof Error ? error.message : 'Unknown error',
+          }
         );
-      });
+      }
     }
 
     try {

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -22,14 +22,10 @@ class WebhookAgent
   }
 
   private buildPayload(type: Notification, payload: NotificationPayload) {
-    const payloadString = Buffer.from(
+    const template = Buffer.from(
       this.getSettings().options.jsonPayload,
       'base64'
     ).toString('utf8');
-
-    // The payload is stored as a JSON-encoded string; decode it to the raw
-    // template, render it, then parse the result as the final JSON body.
-    const template = JSON.parse(payloadString);
     const rendered = TemplateEngine.render(template, payload, type);
 
     return JSON.parse(rendered);
@@ -70,15 +66,30 @@ class WebhookAgent
       try {
         webhookUrl = TemplateEngine.render(webhookUrl, payload, type);
       } catch (error) {
-        logger.warn(
-          'Error rendering webhook URL template, using original URL',
-          {
-            label: 'Notifications',
-            errorMessage:
-              error instanceof Error ? error.message : 'Unknown error',
-          }
-        );
+        logger.error('Failed to render webhook URL template', {
+          label: 'Notifications',
+          type: Notification[type],
+          subject: payload.subject,
+          errorMessage:
+            error instanceof Error ? error.message : 'Unknown error',
+        });
+
+        return false;
       }
+    }
+
+    let body: unknown;
+    try {
+      body = this.buildPayload(type, payload);
+    } catch (error) {
+      logger.error('Failed to render webhook payload template', {
+        label: 'Notifications',
+        type: Notification[type],
+        subject: payload.subject,
+        errorMessage: error instanceof Error ? error.message : 'Unknown error',
+      });
+
+      return false;
     }
 
     try {
@@ -110,7 +121,7 @@ class WebhookAgent
 
       await axios.post(
         webhookUrl,
-        this.buildPayload(type, payload),
+        body,
         Object.keys(headers).length > 0 ? { headers } : undefined
       );
 

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -21,12 +21,12 @@ class WebhookAgent
     return settings.notifications.agents.webhook;
   }
 
-  private buildPayload(type: Notification, payload: NotificationPayload) {
+  private async buildPayload(type: Notification, payload: NotificationPayload) {
     const template = Buffer.from(
       this.getSettings().options.jsonPayload,
       'base64'
     ).toString('utf8');
-    const rendered = TemplateEngine.render(template, payload, type);
+    const rendered = await TemplateEngine.render(template, payload, type);
 
     return JSON.parse(rendered);
   }
@@ -64,7 +64,7 @@ class WebhookAgent
 
     if (settings.options.supportVariables) {
       try {
-        webhookUrl = TemplateEngine.render(webhookUrl, payload, type);
+        webhookUrl = await TemplateEngine.render(webhookUrl, payload, type);
       } catch (error) {
         logger.error('Failed to render webhook URL template', {
           label: 'Notifications',
@@ -80,7 +80,7 @@ class WebhookAgent
 
     let body: unknown;
     try {
-      body = this.buildPayload(type, payload);
+      body = await this.buildPayload(type, payload);
     } catch (error) {
       logger.error('Failed to render webhook payload template', {
         label: 'Notifications',

--- a/server/lib/notifications/agents/webhook.ts
+++ b/server/lib/notifications/agents/webhook.ts
@@ -1,67 +1,11 @@
-import { IssueStatus, IssueType } from '@server/constants/issue';
-import { MediaStatus } from '@server/constants/media';
+import { TemplateEngine } from '@server/lib/notifications/templateEngine';
 import type { NotificationAgentWebhook } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import axios from 'axios';
-import { get } from 'lodash';
 import { Notification, hasNotificationType } from '..';
 import type { NotificationAgent, NotificationPayload } from './agent';
 import { BaseAgent } from './agent';
-
-type KeyMapFunction = (
-  payload: NotificationPayload,
-  type: Notification
-) => string;
-
-const KeyMap: Record<string, string | KeyMapFunction> = {
-  notification_type: (_payload, type) => Notification[type],
-  event: 'event',
-  subject: 'subject',
-  message: 'message',
-  image: 'image',
-  notifyuser_username: 'notifyUser.displayName',
-  notifyuser_email: 'notifyUser.email',
-  notifyuser_avatar: 'notifyUser.avatar',
-  notifyuser_settings_discordIds: 'notifyUser.settings.discordIds',
-  notifyuser_settings_telegramChatId: 'notifyUser.settings.telegramChatId',
-  media_imdbid: 'media.imdbId',
-  media_tmdbid: 'media.tmdbId',
-  media_tvdbid: 'media.tvdbId',
-  media_type: 'media.mediaType',
-  media_jellyfinMediaId: (payload) =>
-    payload.media?.jellyfinMediaId ?? payload.media?.jellyfinMediaId4k ?? '',
-  media_status: (payload) =>
-    payload.media ? MediaStatus[payload.media.status] : '',
-  media_status4k: (payload) =>
-    payload.media ? MediaStatus[payload.media.status4k] : '',
-  media_plexRatingKey: (payload) => payload.media?.ratingKey ?? '',
-  media_plexRatingKey4k: (payload) => payload.media?.ratingKey4k ?? '',
-  request_id: 'request.id',
-  requestedBy_jellyfinUserId: 'request.requestedBy.jellyfinUserId',
-  requestedBy_username: 'request.requestedBy.displayName',
-  requestedBy_email: 'request.requestedBy.email',
-  requestedBy_avatar: 'request.requestedBy.avatar',
-  requestedBy_settings_discordIds: 'request.requestedBy.settings.discordIds',
-  requestedBy_settings_telegramChatId:
-    'request.requestedBy.settings.telegramChatId',
-  issue_id: 'issue.id',
-  issue_type: (payload) =>
-    payload.issue ? IssueType[payload.issue.issueType] : '',
-  issue_status: (payload) =>
-    payload.issue ? IssueStatus[payload.issue.status] : '',
-  reportedBy_username: 'issue.createdBy.displayName',
-  reportedBy_email: 'issue.createdBy.email',
-  reportedBy_avatar: 'issue.createdBy.avatar',
-  reportedBy_settings_discordIds: 'issue.createdBy.settings.discordIds',
-  reportedBy_settings_telegramChatId: 'issue.createdBy.settings.telegramChatId',
-  comment_message: 'comment.message',
-  commentedBy_username: 'comment.user.displayName',
-  commentedBy_email: 'comment.user.email',
-  commentedBy_avatar: 'comment.user.avatar',
-  commentedBy_settings_discordIds: 'comment.user.settings.discordIds',
-  commentedBy_settings_telegramChatId: 'comment.user.settings.telegramChatId',
-};
 
 class WebhookAgent
   extends BaseAgent<NotificationAgentWebhook>
@@ -77,81 +21,18 @@ class WebhookAgent
     return settings.notifications.agents.webhook;
   }
 
-  private parseKeys(
-    finalPayload: Record<string, unknown>,
-    payload: NotificationPayload,
-    type: Notification
-  ): Record<string, unknown> {
-    Object.keys(finalPayload).forEach((key) => {
-      if (key === '{{extra}}') {
-        finalPayload.extra = payload.extra ?? [];
-        delete finalPayload[key];
-        key = 'extra';
-      } else if (key === '{{media}}') {
-        if (payload.media) {
-          finalPayload.media = finalPayload[key];
-        } else {
-          finalPayload.media = null;
-        }
-        delete finalPayload[key];
-        key = 'media';
-      } else if (key === '{{request}}') {
-        if (payload.request) {
-          finalPayload.request = finalPayload[key];
-        } else {
-          finalPayload.request = null;
-        }
-        delete finalPayload[key];
-        key = 'request';
-      } else if (key === '{{issue}}') {
-        if (payload.issue) {
-          finalPayload.issue = finalPayload[key];
-        } else {
-          finalPayload.issue = null;
-        }
-        delete finalPayload[key];
-        key = 'issue';
-      } else if (key === '{{comment}}') {
-        if (payload.comment) {
-          finalPayload.comment = finalPayload[key];
-        } else {
-          finalPayload.comment = null;
-        }
-        delete finalPayload[key];
-        key = 'comment';
-      }
-
-      if (typeof finalPayload[key] === 'string') {
-        Object.keys(KeyMap).forEach((keymapKey) => {
-          const keymapValue = KeyMap[keymapKey as keyof typeof KeyMap];
-          finalPayload[key] = (finalPayload[key] as string).replace(
-            `{{${keymapKey}}}`,
-            typeof keymapValue === 'function'
-              ? keymapValue(payload, type)
-              : (get(payload, keymapValue) ?? '')
-          );
-        });
-      } else if (finalPayload[key] && typeof finalPayload[key] === 'object') {
-        finalPayload[key] = this.parseKeys(
-          finalPayload[key] as Record<string, unknown>,
-          payload,
-          type
-        );
-      }
-    });
-
-    return finalPayload;
-  }
-
   private buildPayload(type: Notification, payload: NotificationPayload) {
     const payloadString = Buffer.from(
       this.getSettings().options.jsonPayload,
       'base64'
     ).toString('utf8');
 
-    const parsedJSON = JSON.parse(JSON.parse(payloadString));
+    // The payload is stored as a JSON-encoded string; decode it to the raw
+    // template, render it, then parse the result as the final JSON body.
+    const template = JSON.parse(payloadString);
+    const rendered = TemplateEngine.render(template, payload, type);
 
-    return this.parseKeys(parsedJSON, payload, type);
+    return JSON.parse(rendered);
   }
 
   public shouldSend(): boolean {
@@ -186,19 +67,18 @@ class WebhookAgent
     let webhookUrl = settings.options.webhookUrl;
 
     if (settings.options.supportVariables) {
-      Object.keys(KeyMap).forEach((keymapKey) => {
-        const keymapValue = KeyMap[keymapKey as keyof typeof KeyMap];
-        const variableValue =
-          type === Notification.TEST_NOTIFICATION
-            ? 'test'
-            : typeof keymapValue === 'function'
-              ? keymapValue(payload, type)
-              : get(payload, keymapValue) || 'test';
-        webhookUrl = webhookUrl.replace(
-          new RegExp(`{{${keymapKey}}}`, 'g'),
-          encodeURIComponent(variableValue)
+      try {
+        webhookUrl = TemplateEngine.render(webhookUrl, payload, type);
+      } catch (error) {
+        logger.warn(
+          'Error rendering webhook URL template, using original URL',
+          {
+            label: 'Notifications',
+            errorMessage:
+              error instanceof Error ? error.message : 'Unknown error',
+          }
         );
-      });
+      }
     }
 
     try {

--- a/server/lib/notifications/templateEngine.test.ts
+++ b/server/lib/notifications/templateEngine.test.ts
@@ -58,6 +58,18 @@ describe('TemplateEngine', () => {
       assert.deepEqual(present.media, { tmdbId: '42' });
     });
 
+    it('renders undefined variables as empty strings without throwing', () => {
+      const rendered = TemplateEngine.render(
+        '{ "known": {{ subject | json }}, "unknown": "{{ nonexistent_variable }}" }',
+        makePayload({ subject: 'Known Value' }),
+        Notification.TEST_NOTIFICATION
+      );
+
+      const parsed = JSON.parse(rendered);
+      assert.equal(parsed.known, 'Known Value');
+      assert.equal(parsed.unknown, '');
+    });
+
     it('does not crash on circular references in the json filter', () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;

--- a/server/lib/notifications/templateEngine.test.ts
+++ b/server/lib/notifications/templateEngine.test.ts
@@ -18,63 +18,11 @@ const makePayload = (
 
 describe('TemplateEngine', () => {
   describe('render', () => {
-    it('escapes free-text values piped through the json filter', () => {
-      const payload = makePayload({
-        subject: 'The "Best" Movie',
-        message: 'line one\nline two with a backslash \\',
-      });
-
-      const rendered = TemplateEngine.render(
-        '{ "subject": {{ subject | json }}, "message": {{ message | json }} }',
-        payload,
-        Notification.TEST_NOTIFICATION
-      );
-
-      const parsed = JSON.parse(rendered);
-      assert.equal(parsed.subject, 'The "Best" Movie');
-      assert.equal(parsed.message, 'line one\nline two with a backslash \\');
-    });
-
-    it('renders optional sections as null when the entity is absent', () => {
-      const template =
-        '{ "media": {% if media %}{ "tmdbId": "{{ media_tmdbid }}" }{% else %}null{% endif %} }';
-
-      const absent = JSON.parse(
-        TemplateEngine.render(
-          template,
-          makePayload(),
-          Notification.MEDIA_PENDING
-        )
-      );
-      assert.equal(absent.media, null);
-
-      const present = JSON.parse(
-        TemplateEngine.render(
-          template,
-          makePayload({ media: { tmdbId: 42 } as never }),
-          Notification.MEDIA_PENDING
-        )
-      );
-      assert.deepEqual(present.media, { tmdbId: '42' });
-    });
-
-    it('renders undefined variables as empty strings without throwing', () => {
-      const rendered = TemplateEngine.render(
-        '{ "known": {{ subject | json }}, "unknown": "{{ nonexistent_variable }}" }',
-        makePayload({ subject: 'Known Value' }),
-        Notification.TEST_NOTIFICATION
-      );
-
-      const parsed = JSON.parse(rendered);
-      assert.equal(parsed.known, 'Known Value');
-      assert.equal(parsed.unknown, '');
-    });
-
-    it('does not crash on circular references in the json filter', () => {
+    it('does not crash on circular references in the json filter', async () => {
       const circular: Record<string, unknown> = {};
       circular.self = circular;
 
-      const rendered = TemplateEngine.render(
+      const rendered = await TemplateEngine.render(
         '{{ extra | json }}',
         makePayload({ extra: circular as never }),
         Notification.TEST_NOTIFICATION

--- a/server/lib/notifications/templateEngine.test.ts
+++ b/server/lib/notifications/templateEngine.test.ts
@@ -1,0 +1,171 @@
+import { IssueStatus, IssueType } from '@server/constants/issue';
+import { MediaStatus } from '@server/constants/media';
+import { Notification } from '@server/lib/notifications';
+import type { NotificationPayload } from '@server/lib/notifications/agents/agent';
+import { TemplateEngine } from '@server/lib/notifications/templateEngine';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const makePayload = (
+  overrides: Partial<NotificationPayload> = {}
+): NotificationPayload =>
+  ({
+    subject: 'Test Subject',
+    notifySystem: true,
+    notifyAdmin: false,
+    ...overrides,
+  }) as unknown as NotificationPayload;
+
+describe('TemplateEngine', () => {
+  describe('render', () => {
+    it('escapes free-text values piped through the json filter', () => {
+      const payload = makePayload({
+        subject: 'The "Best" Movie',
+        message: 'line one\nline two with a backslash \\',
+      });
+
+      const rendered = TemplateEngine.render(
+        '{ "subject": {{ subject | json }}, "message": {{ message | json }} }',
+        payload,
+        Notification.TEST_NOTIFICATION
+      );
+
+      const parsed = JSON.parse(rendered);
+      assert.equal(parsed.subject, 'The "Best" Movie');
+      assert.equal(parsed.message, 'line one\nline two with a backslash \\');
+    });
+
+    it('renders optional sections as null when the entity is absent', () => {
+      const template =
+        '{ "media": {% if media %}{ "tmdbId": "{{ media_tmdbid }}" }{% else %}null{% endif %} }';
+
+      const absent = JSON.parse(
+        TemplateEngine.render(
+          template,
+          makePayload(),
+          Notification.MEDIA_PENDING
+        )
+      );
+      assert.equal(absent.media, null);
+
+      const present = JSON.parse(
+        TemplateEngine.render(
+          template,
+          makePayload({ media: { tmdbId: 42 } as never }),
+          Notification.MEDIA_PENDING
+        )
+      );
+      assert.deepEqual(present.media, { tmdbId: '42' });
+    });
+
+    it('does not crash on circular references in the json filter', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      const rendered = TemplateEngine.render(
+        '{{ extra | json }}',
+        makePayload({ extra: circular as never }),
+        Notification.TEST_NOTIFICATION
+      );
+
+      assert.equal(rendered, 'null');
+    });
+  });
+
+  describe('buildContext', () => {
+    it('maps the notification type to its enum name', () => {
+      const context = TemplateEngine.buildContext(
+        makePayload(),
+        Notification.MEDIA_AUTO_APPROVED
+      );
+
+      assert.equal(context.notification_type, 'MEDIA_AUTO_APPROVED');
+    });
+
+    it('exposes media fields and converts status enums to names', () => {
+      const context = TemplateEngine.buildContext(
+        makePayload({
+          media: {
+            tmdbId: 603,
+            tvdbId: 1234,
+            imdbId: 'tt0133093',
+            mediaType: 'movie',
+            status: MediaStatus.AVAILABLE,
+            status4k: MediaStatus.PENDING,
+          } as never,
+        }),
+        Notification.MEDIA_AVAILABLE
+      );
+
+      assert.equal(context.media_tmdbid, 603);
+      assert.equal(context.media_imdbid, 'tt0133093');
+      assert.equal(context.media_type, 'movie');
+      assert.equal(context.media_status, 'AVAILABLE');
+      assert.equal(context.media_status4k, 'PENDING');
+    });
+
+    it('defaults absent scalar fields to empty strings', () => {
+      const context = TemplateEngine.buildContext(
+        makePayload(),
+        Notification.TEST_NOTIFICATION
+      );
+
+      assert.equal(context.media_tmdbid, '');
+      assert.equal(context.media_status, '');
+      assert.equal(context.request_id, '');
+      assert.equal(context.comment_message, '');
+    });
+
+    it('maps notifyuser_* to notifyUser only, without falling back to the requester', () => {
+      const context = TemplateEngine.buildContext(
+        makePayload({
+          request: {
+            id: 7,
+            requestedBy: { displayName: 'Requester' },
+          } as never,
+        }),
+        Notification.MEDIA_PENDING
+      );
+
+      // notifyUser is intentionally undefined for admin notifications; the
+      // requester must not leak into notifyuser_* variables.
+      assert.equal(context.notifyuser_username, '');
+      assert.equal(context.requestedBy_username, 'Requester');
+    });
+
+    it('converts issue enums to names', () => {
+      const context = TemplateEngine.buildContext(
+        makePayload({
+          issue: {
+            id: 3,
+            issueType: IssueType.VIDEO,
+            status: IssueStatus.OPEN,
+          } as never,
+        }),
+        Notification.ISSUE_CREATED
+      );
+
+      assert.equal(context.issue_type, 'VIDEO');
+      assert.equal(context.issue_status, 'OPEN');
+    });
+
+    it('exposes full entity values as null when absent and the raw value when present', () => {
+      const absent = TemplateEngine.buildContext(
+        makePayload(),
+        Notification.TEST_NOTIFICATION
+      );
+      assert.equal(absent.media, null);
+      assert.equal(absent.request, null);
+      assert.equal(absent.issue, null);
+      assert.equal(absent.comment, null);
+      assert.deepEqual(absent.extra, []);
+
+      const media = { tmdbId: 1 } as never;
+      const present = TemplateEngine.buildContext(
+        makePayload({ media }),
+        Notification.MEDIA_AVAILABLE
+      );
+      assert.equal(present.media, media);
+    });
+  });
+});

--- a/server/lib/notifications/templateEngine.ts
+++ b/server/lib/notifications/templateEngine.ts
@@ -1,0 +1,244 @@
+import { IssueStatus, IssueType } from '@server/constants/issue';
+import { MediaStatus } from '@server/constants/media';
+import Handlebars from 'handlebars';
+import { get } from 'lodash';
+import type { NotificationPayload } from './agents/agent';
+import { Notification } from './index';
+
+/**
+ * TemplateEngine provides Handlebars-based templating for notification agents.
+ * Supports variable substitution, conditionals, loops, and custom helpers.
+ */
+export class TemplateEngine {
+  private static helpersRegistered = false;
+
+  /**
+   * Registers custom Handlebars helpers for use in templates.
+   * This is called automatically on first render.
+   */
+  private static registerHelpers(): void {
+    if (this.helpersRegistered) {
+      return;
+    }
+
+    // Comparison helpers for conditionals
+    // Usage: {{#if (eq status "PENDING")}}...{{/if}}
+    Handlebars.registerHelper('eq', (a: unknown, b: unknown) => a === b); // Equal to
+    Handlebars.registerHelper('ne', (a: unknown, b: unknown) => a !== b); // Not equal to
+    Handlebars.registerHelper('lt', (a: unknown, b: unknown) => {
+      return (a as number) < (b as number); // Less than
+    });
+    Handlebars.registerHelper('gt', (a: unknown, b: unknown) => {
+      return (a as number) > (b as number); // Greater than
+    });
+    Handlebars.registerHelper('lte', (a: unknown, b: unknown) => {
+      return (a as number) <= (b as number); // Less than or equal to
+    });
+    Handlebars.registerHelper('gte', (a: unknown, b: unknown) => {
+      return (a as number) >= (b as number); // Greater than or equal to
+    });
+
+    // Logical helpers for combining conditions
+    // Usage: {{#if (and media request)}}...{{/if}}
+    Handlebars.registerHelper('and', (a: unknown, b: unknown) => a && b); // Logical AND
+    Handlebars.registerHelper('or', (a: unknown, b: unknown) => a || b); // Logical OR
+
+    // String formatting helpers
+    // Capitalizes first letter, rest lowercase
+    // Usage: {{capitalize user_name}} -> "John"
+    Handlebars.registerHelper('capitalize', (str: string) => {
+      if (!str) return '';
+      return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+    });
+
+    // Converts string to uppercase
+    // Usage: {{upper media_type}} -> "MOVIE"
+    Handlebars.registerHelper('upper', (str: string) => {
+      if (!str) return '';
+      return str.toUpperCase();
+    });
+
+    // Converts string to lowercase
+    // Usage: {{lower notifyuser_email}} -> "user@example.com"
+    Handlebars.registerHelper('lower', (str: string) => {
+      if (!str) return '';
+      return str.toLowerCase();
+    });
+
+    // Truncates a string to specified length with ellipsis
+    // Usage: {{truncate subject 50}} -> "Very long movie title that gets cut off..."
+    Handlebars.registerHelper('truncate', (str: string, length: number) => {
+      if (!str) return '';
+      if (str.length <= length) return str;
+      return str.substring(0, length) + '...';
+    });
+
+    // Converts objects/arrays to JSON strings
+    // Usage: {{json extra}} -> "[{\"name\":\"key\",\"value\":\"val\"}]"
+    Handlebars.registerHelper('json', (obj: unknown) => {
+      return JSON.stringify(obj);
+    });
+
+    // Provides default value if variable is undefined/null/empty
+    // Usage: {{default notifyuser_username "Unknown User"}} -> "Unknown User"
+    Handlebars.registerHelper(
+      'default',
+      (value: unknown, defaultValue: unknown) => {
+        return value ?? defaultValue;
+      }
+    );
+
+    this.helpersRegistered = true;
+  }
+
+  /**
+   * Builds template context from notification payload.
+   * Extracts all variables and converts enums to human-readable strings.
+   */
+  static buildContext(
+    payload: NotificationPayload,
+    type: Notification
+  ): Record<string, unknown> {
+    // For auto-approved/auto-requested, use the requesting user as the notify user
+    const effectiveNotifyUser =
+      payload.notifyUser || payload.request?.requestedBy;
+
+    const context: Record<string, unknown> = {
+      // Basic notification fields
+      notification_type: Notification[type],
+      event: payload.event ?? '',
+      subject: payload.subject ?? '',
+      message: payload.message ?? '',
+      image: payload.image ?? '',
+
+      // Notify user fields
+      notifyuser_username: get(effectiveNotifyUser, 'displayName', ''),
+      notifyuser_email: get(effectiveNotifyUser, 'email', ''),
+      notifyuser_avatar: get(effectiveNotifyUser, 'avatar', ''),
+      notifyuser_settings_discordId: get(
+        effectiveNotifyUser,
+        'settings.discordId',
+        ''
+      ),
+      notifyuser_settings_telegramChatId: get(
+        effectiveNotifyUser,
+        'settings.telegramChatId',
+        ''
+      ),
+
+      // Media fields
+      media_tmdbid: get(payload, 'media.tmdbId', ''),
+      media_tvdbid: get(payload, 'media.tvdbId', ''),
+      media_type: get(payload, 'media.mediaType', ''),
+      media_status: payload.media ? MediaStatus[payload.media.status] : '',
+      media_status4k: payload.media ? MediaStatus[payload.media.status4k] : '',
+
+      // Request fields
+      request_id: get(payload, 'request.id', ''),
+      requestedBy_username: get(payload, 'request.requestedBy.displayName', ''),
+      requestedBy_email: get(payload, 'request.requestedBy.email', ''),
+      requestedBy_avatar: get(payload, 'request.requestedBy.avatar', ''),
+      requestedBy_settings_discordId: get(
+        payload,
+        'request.requestedBy.settings.discordId',
+        ''
+      ),
+      requestedBy_settings_telegramChatId: get(
+        payload,
+        'request.requestedBy.settings.telegramChatId',
+        ''
+      ),
+
+      // Issue fields
+      issue_id: get(payload, 'issue.id', ''),
+      issue_type: payload.issue ? IssueType[payload.issue.issueType] : '',
+      issue_status: payload.issue ? IssueStatus[payload.issue.status] : '',
+      reportedBy_username: get(payload, 'issue.createdBy.displayName', ''),
+      reportedBy_email: get(payload, 'issue.createdBy.email', ''),
+      reportedBy_avatar: get(payload, 'issue.createdBy.avatar', ''),
+      reportedBy_settings_discordId: get(
+        payload,
+        'issue.createdBy.settings.discordId',
+        ''
+      ),
+      reportedBy_settings_telegramChatId: get(
+        payload,
+        'issue.createdBy.settings.telegramChatId',
+        ''
+      ),
+
+      // Comment fields
+      comment_message: get(payload, 'comment.message', ''),
+      commentedBy_username: get(payload, 'comment.user.displayName', ''),
+      commentedBy_email: get(payload, 'comment.user.email', ''),
+      commentedBy_avatar: get(payload, 'comment.user.avatar', ''),
+      commentedBy_settings_discordId: get(
+        payload,
+        'comment.user.settings.discordId',
+        ''
+      ),
+      commentedBy_settings_telegramChatId: get(
+        payload,
+        'comment.user.settings.telegramChatId',
+        ''
+      ),
+
+      // Include full objects for advanced template usage
+      extra: payload.extra ?? [],
+      media: payload.media ?? null,
+      request: payload.request ?? null,
+      issue: payload.issue ?? null,
+      comment: payload.comment ?? null,
+    };
+
+    return context;
+  }
+
+  /**
+   * Renders a template string with the given payload data.
+   *
+   * @param template - Handlebars template string
+   * @param payload - Notification payload data
+   * @param type - Notification type
+   * @returns Rendered template string
+   *
+   * @example
+   * ```typescript
+   * const result = TemplateEngine.render(
+   *   'New {{notification_type}}: {{subject}}',
+   *   payload,
+   *   Notification.MEDIA_PENDING
+   * );
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Using conditionals
+   * const result = TemplateEngine.render(
+   *   '{{#if media}}Media ID: {{media_tmdbid}}{{/if}}',
+   *   payload,
+   *   type
+   * );
+   * ```
+   */
+  static render(
+    template: string,
+    payload: NotificationPayload,
+    type: Notification
+  ): string {
+    this.registerHelpers();
+
+    try {
+      const context = this.buildContext(payload, type);
+      // Compile template without HTML escaping (noEscape: true)
+      const compiledTemplate = Handlebars.compile(template, { noEscape: true });
+      return compiledTemplate(context);
+    } catch (error) {
+      throw new Error(
+        `Template rendering failed: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+}

--- a/server/lib/notifications/templateEngine.ts
+++ b/server/lib/notifications/templateEngine.ts
@@ -148,13 +148,13 @@ export class TemplateEngine {
    *
    * @throws if the template contains invalid Liquid syntax
    */
-  static render(
+  static async render(
     template: string,
     payload: NotificationPayload,
     type: Notification
-  ): string {
+  ): Promise<string> {
     const context = this.buildContext(payload, type);
-    // parseAndRenderSync is typed `any`; coerce to honor the `string` return.
-    return String(this.getEngine().parseAndRenderSync(template, context));
+    // parseAndRender is typed `Promise<any>`; coerce to honor the `string` return.
+    return String(await this.getEngine().parseAndRender(template, context));
   }
 }

--- a/server/lib/notifications/templateEngine.ts
+++ b/server/lib/notifications/templateEngine.ts
@@ -1,0 +1,160 @@
+import { IssueStatus, IssueType } from '@server/constants/issue';
+import { MediaStatus } from '@server/constants/media';
+import logger from '@server/logger';
+import { Liquid } from 'liquidjs';
+import { get } from 'lodash';
+import type { NotificationPayload } from './agents/agent';
+import { Notification } from './index';
+
+/**
+ * LiquidJS-based templating for notification agents. Note that Liquid does not
+ * HTML-escape output, so characters such as apostrophes and quotes render
+ * verbatim.
+ */
+export class TemplateEngine {
+  private static engine: Liquid | undefined;
+
+  private static getEngine(): Liquid {
+    if (!this.engine) {
+      const engine = new Liquid();
+
+      // Make the `json` filter circular-safe: TypeORM entities can hold
+      // circular relations (e.g. Media <-> Issue) that JSON.stringify rejects.
+      engine.registerFilter('json', (value: unknown) => {
+        try {
+          return JSON.stringify(value);
+        } catch (error) {
+          logger.warn('Unable to serialize value in webhook json filter', {
+            label: 'Notifications',
+            errorMessage:
+              error instanceof Error ? error.message : 'Unknown error',
+          });
+          return 'null';
+        }
+      });
+
+      this.engine = engine;
+    }
+
+    return this.engine;
+  }
+
+  /**
+   * Builds the template context: flat scalar variables for substitution, plus
+   * the full `media`/`request`/`issue`/`comment`/`extra` values for
+   * conditionals (e.g. `{% if media %}`).
+   */
+  static buildContext(
+    payload: NotificationPayload,
+    type: Notification
+  ): Record<string, unknown> {
+    return {
+      notification_type: Notification[type],
+      event: payload.event ?? '',
+      subject: payload.subject ?? '',
+      message: payload.message ?? '',
+      image: payload.image ?? '',
+
+      notifyuser_username: get(payload, 'notifyUser.displayName', ''),
+      notifyuser_email: get(payload, 'notifyUser.email', ''),
+      notifyuser_avatar: get(payload, 'notifyUser.avatar', ''),
+      notifyuser_settings_discordIds: get(
+        payload,
+        'notifyUser.settings.discordIds',
+        ''
+      ),
+      notifyuser_settings_telegramChatId: get(
+        payload,
+        'notifyUser.settings.telegramChatId',
+        ''
+      ),
+
+      media_imdbid: get(payload, 'media.imdbId', ''),
+      media_tmdbid: get(payload, 'media.tmdbId', ''),
+      media_tvdbid: get(payload, 'media.tvdbId', ''),
+      media_type: get(payload, 'media.mediaType', ''),
+      media_jellyfinMediaId:
+        payload.media?.jellyfinMediaId ??
+        payload.media?.jellyfinMediaId4k ??
+        '',
+      media_status: payload.media ? MediaStatus[payload.media.status] : '',
+      media_status4k: payload.media ? MediaStatus[payload.media.status4k] : '',
+      media_plexRatingKey: payload.media?.ratingKey ?? '',
+      media_plexRatingKey4k: payload.media?.ratingKey4k ?? '',
+
+      request_id: get(payload, 'request.id', ''),
+      requestedBy_jellyfinUserId: get(
+        payload,
+        'request.requestedBy.jellyfinUserId',
+        ''
+      ),
+      requestedBy_username: get(payload, 'request.requestedBy.displayName', ''),
+      requestedBy_email: get(payload, 'request.requestedBy.email', ''),
+      requestedBy_avatar: get(payload, 'request.requestedBy.avatar', ''),
+      requestedBy_settings_discordIds: get(
+        payload,
+        'request.requestedBy.settings.discordIds',
+        ''
+      ),
+      requestedBy_settings_telegramChatId: get(
+        payload,
+        'request.requestedBy.settings.telegramChatId',
+        ''
+      ),
+
+      issue_id: get(payload, 'issue.id', ''),
+      issue_type: payload.issue ? IssueType[payload.issue.issueType] : '',
+      issue_status: payload.issue ? IssueStatus[payload.issue.status] : '',
+      reportedBy_username: get(payload, 'issue.createdBy.displayName', ''),
+      reportedBy_email: get(payload, 'issue.createdBy.email', ''),
+      reportedBy_avatar: get(payload, 'issue.createdBy.avatar', ''),
+      reportedBy_settings_discordIds: get(
+        payload,
+        'issue.createdBy.settings.discordIds',
+        ''
+      ),
+      reportedBy_settings_telegramChatId: get(
+        payload,
+        'issue.createdBy.settings.telegramChatId',
+        ''
+      ),
+
+      comment_message: get(payload, 'comment.message', ''),
+      commentedBy_username: get(payload, 'comment.user.displayName', ''),
+      commentedBy_email: get(payload, 'comment.user.email', ''),
+      commentedBy_avatar: get(payload, 'comment.user.avatar', ''),
+      commentedBy_settings_discordIds: get(
+        payload,
+        'comment.user.settings.discordIds',
+        ''
+      ),
+      commentedBy_settings_telegramChatId: get(
+        payload,
+        'comment.user.settings.telegramChatId',
+        ''
+      ),
+
+      // Full values, exposed for conditionals and advanced templates
+      extra: payload.extra ?? [],
+      media: payload.media ?? null,
+      request: payload.request ?? null,
+      issue: payload.issue ?? null,
+      comment: payload.comment ?? null,
+    };
+  }
+
+  /**
+   * Renders a Liquid template string against a notification payload.
+   *
+   * @throws if the template contains invalid Liquid syntax
+   */
+  static render(
+    template: string,
+    payload: NotificationPayload,
+    type: Notification
+  ): string {
+    const context = this.buildContext(payload, type);
+    // parseAndRenderSync is typed `any`; coerce to honor the `string` return.
+    return String(this.getEngine().parseAndRenderSync(template, context));
+  }
+}

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -392,6 +392,57 @@ const SETTINGS_PATH = process.env.CONFIG_DIRECTORY
   ? `${process.env.CONFIG_DIRECTORY}/settings.json`
   : path.join(__dirname, '../../../config/settings.json');
 
+// Default webhook payload, rendered through the LiquidJS template engine.
+// Optional sections use `{% if %}…{% else %}null{% endif %}` so they render as
+// null (not omitted) when absent, and free-text values use the `json` filter to
+// quote/escape themselves. Keep this byte-identical to the frontend
+// `defaultPayload` in
+// src/components/Settings/Notifications/NotificationsWebhook/index.tsx.
+const DEFAULT_WEBHOOK_JSON_PAYLOAD = `{
+  "notification_type": "{{ notification_type }}",
+  "event": "{{ event }}",
+  "subject": {{ subject | json }},
+  "message": {{ message | json }},
+  "image": "{{ image }}",
+  "media": {% if media %}{
+    "media_type": "{{ media_type }}",
+    "imdbId": "{{ media_imdbid }}",
+    "tmdbId": "{{ media_tmdbid }}",
+    "tvdbId": "{{ media_tvdbid }}",
+    "jellyfinMediaId": "{{ media_jellyfinMediaId }}",
+    "status": "{{ media_status }}",
+    "status4k": "{{ media_status4k }}"
+  }{% else %}null{% endif %},
+  "request": {% if request %}{
+    "request_id": "{{ request_id }}",
+    "requestedBy_email": "{{ requestedBy_email }}",
+    "requestedBy_username": {{ requestedBy_username | json }},
+    "requestedBy_avatar": "{{ requestedBy_avatar }}",
+    "requestedBy_jellyfinUserId": "{{ requestedBy_jellyfinUserId }}",
+    "requestedBy_settings_discordIds": "{{ requestedBy_settings_discordIds | join: ',' }}",
+    "requestedBy_settings_telegramChatId": "{{ requestedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "issue": {% if issue %}{
+    "issue_id": "{{ issue_id }}",
+    "issue_type": "{{ issue_type }}",
+    "issue_status": "{{ issue_status }}",
+    "reportedBy_email": "{{ reportedBy_email }}",
+    "reportedBy_username": {{ reportedBy_username | json }},
+    "reportedBy_avatar": "{{ reportedBy_avatar }}",
+    "reportedBy_settings_discordIds": "{{ reportedBy_settings_discordIds | join: ',' }}",
+    "reportedBy_settings_telegramChatId": "{{ reportedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "comment": {% if comment %}{
+    "comment_message": {{ comment_message | json }},
+    "commentedBy_email": "{{ commentedBy_email }}",
+    "commentedBy_username": {{ commentedBy_username | json }},
+    "commentedBy_avatar": "{{ commentedBy_avatar }}",
+    "commentedBy_settings_discordIds": "{{ commentedBy_settings_discordIds | join: ',' }}",
+    "commentedBy_settings_telegramChatId": "{{ commentedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "extra": {{ extra | json }}
+}`;
+
 class Settings {
   private data: AllSettings;
   private saveLock: Promise<void> = Promise.resolve();
@@ -533,8 +584,9 @@ class Settings {
             types: 0,
             options: {
               webhookUrl: '',
-              jsonPayload:
-                'IntcbiAgXCJub3RpZmljYXRpb25fdHlwZVwiOiBcInt7bm90aWZpY2F0aW9uX3R5cGV9fVwiLFxuICBcImV2ZW50XCI6IFwie3tldmVudH19XCIsXG4gIFwic3ViamVjdFwiOiBcInt7c3ViamVjdH19XCIsXG4gIFwibWVzc2FnZVwiOiBcInt7bWVzc2FnZX19XCIsXG4gIFwiaW1hZ2VcIjogXCJ7e2ltYWdlfX1cIixcbiAgXCJ7e21lZGlhfX1cIjoge1xuICAgIFwibWVkaWFfdHlwZVwiOiBcInt7bWVkaWFfdHlwZX19XCIsXG4gICAgXCJ0bWRiSWRcIjogXCJ7e21lZGlhX3RtZGJpZH19XCIsXG4gICAgXCJ0dmRiSWRcIjogXCJ7e21lZGlhX3R2ZGJpZH19XCIsXG4gICAgXCJzdGF0dXNcIjogXCJ7e21lZGlhX3N0YXR1c319XCIsXG4gICAgXCJzdGF0dXM0a1wiOiBcInt7bWVkaWFfc3RhdHVzNGt9fVwiXG4gIH0sXG4gIFwie3tyZXF1ZXN0fX1cIjoge1xuICAgIFwicmVxdWVzdF9pZFwiOiBcInt7cmVxdWVzdF9pZH19XCIsXG4gICAgXCJyZXF1ZXN0ZWRCeV9lbWFpbFwiOiBcInt7cmVxdWVzdGVkQnlfZW1haWx9fVwiLFxuICAgIFwicmVxdWVzdGVkQnlfdXNlcm5hbWVcIjogXCJ7e3JlcXVlc3RlZEJ5X3VzZXJuYW1lfX1cIixcbiAgICBcInJlcXVlc3RlZEJ5X2F2YXRhclwiOiBcInt7cmVxdWVzdGVkQnlfYXZhdGFyfX1cIixcbiAgICBcInJlcXVlc3RlZEJ5X3NldHRpbmdzX2Rpc2NvcmRJZFwiOiBcInt7cmVxdWVzdGVkQnlfc2V0dGluZ3NfZGlzY29yZElkfX1cIixcbiAgICBcInJlcXVlc3RlZEJ5X3NldHRpbmdzX3RlbGVncmFtQ2hhdElkXCI6IFwie3tyZXF1ZXN0ZWRCeV9zZXR0aW5nc190ZWxlZ3JhbUNoYXRJZH19XCJcbiAgfSxcbiAgXCJ7e2lzc3VlfX1cIjoge1xuICAgIFwiaXNzdWVfaWRcIjogXCJ7e2lzc3VlX2lkfX1cIixcbiAgICBcImlzc3VlX3R5cGVcIjogXCJ7e2lzc3VlX3R5cGV9fVwiLFxuICAgIFwiaXNzdWVfc3RhdHVzXCI6IFwie3tpc3N1ZV9zdGF0dXN9fVwiLFxuICAgIFwicmVwb3J0ZWRCeV9lbWFpbFwiOiBcInt7cmVwb3J0ZWRCeV9lbWFpbH19XCIsXG4gICAgXCJyZXBvcnRlZEJ5X3VzZXJuYW1lXCI6IFwie3tyZXBvcnRlZEJ5X3VzZXJuYW1lfX1cIixcbiAgICBcInJlcG9ydGVkQnlfYXZhdGFyXCI6IFwie3tyZXBvcnRlZEJ5X2F2YXRhcn19XCIsXG4gICAgXCJyZXBvcnRlZEJ5X3NldHRpbmdzX2Rpc2NvcmRJZFwiOiBcInt7cmVwb3J0ZWRCeV9zZXR0aW5nc19kaXNjb3JkSWR9fVwiLFxuICAgIFwicmVwb3J0ZWRCeV9zZXR0aW5nc190ZWxlZ3JhbUNoYXRJZFwiOiBcInt7cmVwb3J0ZWRCeV9zZXR0aW5nc190ZWxlZ3JhbUNoYXRJZH19XCJcbiAgfSxcbiAgXCJ7e2NvbW1lbnR9fVwiOiB7XG4gICAgXCJjb21tZW50X21lc3NhZ2VcIjogXCJ7e2NvbW1lbnRfbWVzc2FnZX19XCIsXG4gICAgXCJjb21tZW50ZWRCeV9lbWFpbFwiOiBcInt7Y29tbWVudGVkQnlfZW1haWx9fVwiLFxuICAgIFwiY29tbWVudGVkQnlfdXNlcm5hbWVcIjogXCJ7e2NvbW1lbnRlZEJ5X3VzZXJuYW1lfX1cIixcbiAgICBcImNvbW1lbnRlZEJ5X2F2YXRhclwiOiBcInt7Y29tbWVudGVkQnlfYXZhdGFyfX1cIixcbiAgICBcImNvbW1lbnRlZEJ5X3NldHRpbmdzX2Rpc2NvcmRJZFwiOiBcInt7Y29tbWVudGVkQnlfc2V0dGluZ3NfZGlzY29yZElkfX1cIixcbiAgICBcImNvbW1lbnRlZEJ5X3NldHRpbmdzX3RlbGVncmFtQ2hhdElkXCI6IFwie3tjb21tZW50ZWRCeV9zZXR0aW5nc190ZWxlZ3JhbUNoYXRJZH19XCJcbiAgfSxcbiAgXCJ7e2V4dHJhfX1cIjogW11cbn0i',
+              jsonPayload: Buffer.from(DEFAULT_WEBHOOK_JSON_PAYLOAD).toString(
+                'base64'
+              ),
             },
           },
           webpush: {

--- a/server/lib/settings/migrations/0009_migrate_webhook_payload_encoding.ts
+++ b/server/lib/settings/migrations/0009_migrate_webhook_payload_encoding.ts
@@ -1,0 +1,41 @@
+import type { AllSettings } from '@server/lib/settings';
+
+// Webhook payloads used to be stored as base64(JSON.stringify(template)); they
+// are now stored as base64(template). Unwrap the JSON envelope on existing
+// settings so the stored value is the raw (Liquid) template string.
+const migrateWebhookPayloadEncoding = (settings: any): AllSettings => {
+  if (
+    Array.isArray(settings.migrations) &&
+    settings.migrations.includes('0009_migrate_webhook_payload_encoding')
+  ) {
+    return settings;
+  }
+
+  const options = settings.notifications?.agents?.webhook?.options;
+
+  if (options && typeof options.jsonPayload === 'string' && options.jsonPayload) {
+    try {
+      const decoded = Buffer.from(options.jsonPayload, 'base64').toString(
+        'utf8'
+      );
+      const unwrapped = JSON.parse(decoded);
+
+      // Only the old format decodes to a JSON string literal; the new format is
+      // a raw template that isn't valid JSON, so JSON.parse throws and we skip.
+      if (typeof unwrapped === 'string') {
+        options.jsonPayload = Buffer.from(unwrapped).toString('base64');
+      }
+    } catch {
+      // Already stored as a raw template (or not decodable) — leave as-is.
+    }
+  }
+
+  if (!Array.isArray(settings.migrations)) {
+    settings.migrations = [];
+  }
+  settings.migrations.push('0009_migrate_webhook_payload_encoding');
+
+  return settings;
+};
+
+export default migrateWebhookPayloadEncoding;

--- a/server/lib/settings/migrations/0009_migrate_webhook_payload_encoding.ts
+++ b/server/lib/settings/migrations/0009_migrate_webhook_payload_encoding.ts
@@ -1,8 +1,10 @@
 import type { AllSettings } from '@server/lib/settings';
 
-// Webhook payloads used to be stored as base64(JSON.stringify(template)); they
-// are now stored as base64(template). Unwrap the JSON envelope on existing
-// settings so the stored value is the raw (Liquid) template string.
+// The POST /settings/notifications/webhook route used to store the payload as
+// base64(JSON.stringify(template)); it now stores base64(template). Unwrap the
+// JSON envelope on existing settings so the stored value is the raw (Liquid)
+// template string — otherwise the agent would decode a quoted JSON string
+// literal and post a string body instead of the rendered object.
 const migrateWebhookPayloadEncoding = (settings: any): AllSettings => {
   if (
     Array.isArray(settings.migrations) &&
@@ -13,7 +15,11 @@ const migrateWebhookPayloadEncoding = (settings: any): AllSettings => {
 
   const options = settings.notifications?.agents?.webhook?.options;
 
-  if (options && typeof options.jsonPayload === 'string' && options.jsonPayload) {
+  if (
+    options &&
+    typeof options.jsonPayload === 'string' &&
+    options.jsonPayload
+  ) {
     try {
       const decoded = Buffer.from(options.jsonPayload, 'base64').toString(
         'utf8'

--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -284,11 +284,10 @@ notificationRoutes.get('/webhook', (_req, res) => {
     types: webhookSettings.types,
     options: {
       ...webhookSettings.options,
-      jsonPayload: JSON.parse(
-        Buffer.from(webhookSettings.options.jsonPayload, 'base64').toString(
-          'utf8'
-        )
-      ),
+      jsonPayload: Buffer.from(
+        webhookSettings.options.jsonPayload,
+        'base64'
+      ).toString('utf8'),
       customHeaders: webhookSettings.options.customHeaders ?? [],
       supportVariables: webhookSettings.options.supportVariables ?? false,
     },
@@ -305,9 +304,9 @@ notificationRoutes.post('/webhook', async (req, res, next) => {
       embedPoster: req.body.embedPoster,
       types: req.body.types,
       options: {
-        jsonPayload: Buffer.from(
-          JSON.stringify(req.body.options.jsonPayload)
-        ).toString('base64'),
+        jsonPayload: Buffer.from(req.body.options.jsonPayload).toString(
+          'base64'
+        ),
         webhookUrl: req.body.options.webhookUrl,
         authHeader: req.body.options.authHeader,
         customHeaders: req.body.options.customHeaders ?? [],
@@ -336,9 +335,9 @@ notificationRoutes.post('/webhook/test', async (req, res, next) => {
       embedPoster: req.body.embedPoster,
       types: req.body.types,
       options: {
-        jsonPayload: Buffer.from(
-          JSON.stringify(req.body.options.jsonPayload)
-        ).toString('base64'),
+        jsonPayload: Buffer.from(req.body.options.jsonPayload).toString(
+          'base64'
+        ),
         webhookUrl: req.body.options.webhookUrl,
         authHeader: req.body.options.authHeader,
         customHeaders: req.body.options.customHeaders ?? [],

--- a/server/routes/settings/notifications.ts
+++ b/server/routes/settings/notifications.ts
@@ -300,8 +300,6 @@ notificationRoutes.get('/webhook', (_req, res) => {
 notificationRoutes.post('/webhook', async (req, res, next) => {
   const settings = getSettings();
   try {
-    JSON.parse(req.body.options.jsonPayload);
-
     settings.notifications.agents.webhook = {
       enabled: req.body.enabled,
       embedPoster: req.body.embedPoster,
@@ -333,8 +331,6 @@ notificationRoutes.post('/webhook/test', async (req, res, next) => {
   }
 
   try {
-    JSON.parse(req.body.options.jsonPayload);
-
     const testBody = {
       enabled: req.body.enabled,
       embedPoster: req.body.embedPoster,

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -134,11 +134,23 @@ const NotificationsWebhook = () => {
         otherwise: Yup.string().nullable(),
       })
       .test(
-        'validate-json',
+        'validate-json-or-template',
         intl.formatMessage(messages.validationJsonPayloadRequired),
         (value) => {
+          if (!value) return false;
+
+          // Check if the payload contains Handlebars template syntax
+          const hasHandlebarsContent = /\{\{[^}]+\}\}/.test(value);
+
+          if (hasHandlebarsContent) {
+            // For templates with Handlebars syntax, just check if it's not empty
+            // Backend will validate Handlebars syntax and provide error logs
+            return value.trim().length > 0;
+          }
+
+          // For non-template payloads, validate as strict JSON
           try {
-            JSON.parse(value ?? '');
+            JSON.parse(value);
             return true;
           } catch (e) {
             return false;

--- a/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsWebhook/index.tsx
@@ -29,53 +29,54 @@ const JSONEditor = dynamic(() => import('@app/components/JSONEditor'), {
   ssr: false,
 });
 
-const defaultPayload = {
-  notification_type: '{{notification_type}}',
-  event: '{{event}}',
-  subject: '{{subject}}',
-  message: '{{message}}',
-  image: '{{image}}',
-  '{{media}}': {
-    media_type: '{{media_type}}',
-    imdbId: '{{media_imdbid}}',
-    tmdbId: '{{media_tmdbid}}',
-    tvdbId: '{{media_tvdbid}}',
-    jellyfinMediaId: '{{media_jellyfinMediaId}}',
-    status: '{{media_status}}',
-    status4k: '{{media_status4k}}',
-  },
-  '{{request}}': {
-    request_id: '{{request_id}}',
-    requestedBy_email: '{{requestedBy_email}}',
-    requestedBy_username: '{{requestedBy_username}}',
-    requestedBy_avatar: '{{requestedBy_avatar}}',
-    requestedBy_jellyfinUserId: '{{requestedBy_jellyfinUserId}}',
-    requestedBy_settings_discordIds: '{{requestedBy_settings_discordIds}}',
-    requestedBy_settings_telegramChatId:
-      '{{requestedBy_settings_telegramChatId}}',
-  },
-  '{{issue}}': {
-    issue_id: '{{issue_id}}',
-    issue_type: '{{issue_type}}',
-    issue_status: '{{issue_status}}',
-    reportedBy_email: '{{reportedBy_email}}',
-    reportedBy_username: '{{reportedBy_username}}',
-    reportedBy_avatar: '{{reportedBy_avatar}}',
-    reportedBy_settings_discordIds: '{{reportedBy_settings_discordIds}}',
-    reportedBy_settings_telegramChatId:
-      '{{reportedBy_settings_telegramChatId}}',
-  },
-  '{{comment}}': {
-    comment_message: '{{comment_message}}',
-    commentedBy_email: '{{commentedBy_email}}',
-    commentedBy_username: '{{commentedBy_username}}',
-    commentedBy_avatar: '{{commentedBy_avatar}}',
-    commentedBy_settings_discordIds: '{{commentedBy_settings_discordIds}}',
-    commentedBy_settings_telegramChatId:
-      '{{commentedBy_settings_telegramChatId}}',
-  },
-  '{{extra}}': [],
-};
+// Liquid template rendered into the webhook payload. Optional sections use
+// `{% if %}…{% else %}null{% endif %}` so they render as null (not omitted)
+// when absent, and free-text values use the `json` filter to quote and escape
+// themselves so characters like `"` or newlines can't break the JSON.
+const defaultPayload = `{
+  "notification_type": "{{ notification_type }}",
+  "event": "{{ event }}",
+  "subject": {{ subject | json }},
+  "message": {{ message | json }},
+  "image": "{{ image }}",
+  "media": {% if media %}{
+    "media_type": "{{ media_type }}",
+    "imdbId": "{{ media_imdbid }}",
+    "tmdbId": "{{ media_tmdbid }}",
+    "tvdbId": "{{ media_tvdbid }}",
+    "jellyfinMediaId": "{{ media_jellyfinMediaId }}",
+    "status": "{{ media_status }}",
+    "status4k": "{{ media_status4k }}"
+  }{% else %}null{% endif %},
+  "request": {% if request %}{
+    "request_id": "{{ request_id }}",
+    "requestedBy_email": "{{ requestedBy_email }}",
+    "requestedBy_username": {{ requestedBy_username | json }},
+    "requestedBy_avatar": "{{ requestedBy_avatar }}",
+    "requestedBy_jellyfinUserId": "{{ requestedBy_jellyfinUserId }}",
+    "requestedBy_settings_discordIds": "{{ requestedBy_settings_discordIds | join: ',' }}",
+    "requestedBy_settings_telegramChatId": "{{ requestedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "issue": {% if issue %}{
+    "issue_id": "{{ issue_id }}",
+    "issue_type": "{{ issue_type }}",
+    "issue_status": "{{ issue_status }}",
+    "reportedBy_email": "{{ reportedBy_email }}",
+    "reportedBy_username": {{ reportedBy_username | json }},
+    "reportedBy_avatar": "{{ reportedBy_avatar }}",
+    "reportedBy_settings_discordIds": "{{ reportedBy_settings_discordIds | join: ',' }}",
+    "reportedBy_settings_telegramChatId": "{{ reportedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "comment": {% if comment %}{
+    "comment_message": {{ comment_message | json }},
+    "commentedBy_email": "{{ commentedBy_email }}",
+    "commentedBy_username": {{ commentedBy_username | json }},
+    "commentedBy_avatar": "{{ commentedBy_avatar }}",
+    "commentedBy_settings_discordIds": "{{ commentedBy_settings_discordIds | join: ',' }}",
+    "commentedBy_settings_telegramChatId": "{{ commentedBy_settings_telegramChatId }}"
+  }{% else %}null{% endif %},
+  "extra": {{ extra | json }}
+}`;
 
 const messages = defineMessages(
   'components.Settings.Notifications.NotificationsWebhook',
@@ -181,29 +182,14 @@ const NotificationsWebhook = () => {
         }
       ),
 
-    jsonPayload: Yup.string()
-      .when('enabled', {
-        is: true,
-        then: (schema) =>
-          schema
-            .nullable()
-            .required(
-              intl.formatMessage(messages.validationJsonPayloadRequired)
-            ),
-        otherwise: (schema) => schema.nullable(),
-      })
-      .test(
-        'validate-json',
-        intl.formatMessage(messages.validationJsonPayloadRequired),
-        (value) => {
-          try {
-            JSON.parse(value ?? '');
-            return true;
-          } catch {
-            return false;
-          }
-        }
-      ),
+    jsonPayload: Yup.string().when('enabled', {
+      is: true,
+      then: (schema) =>
+        schema
+          .nullable()
+          .required(intl.formatMessage(messages.validationJsonPayloadRequired)),
+      otherwise: (schema) => schema.nullable(),
+    }),
   });
 
   if (!data && !error) {
@@ -267,10 +253,7 @@ const NotificationsWebhook = () => {
         setFieldTouched,
       }) => {
         const resetPayload = () => {
-          setFieldValue(
-            'jsonPayload',
-            JSON.stringify(defaultPayload, undefined, '    ')
-          );
+          setFieldValue('jsonPayload', defaultPayload);
           addToast(intl.formatMessage(messages.resetPayloadSuccess), {
             appearance: 'info',
             autoDismiss: true,


### PR DESCRIPTION
## Description

This PR refactors the webhook notification agent to use a shared **LiquidJS**-based templating engine instead of the bespoke `KeyMap` + `parseKeys` substitution system, providing a foundation for standardized templating across all notification agents.

This replaces the original Handlebars approach from earlier in this PR, following the maintainer discussion ([review thread](https://github.com/seerr-team/seerr/pull/2039#discussion_r3391800589)): Liquid is a better fit for an end-user template engine because it ships the logic/filters users need out of the box, so we don't have to implement and maintain custom helpers.

This is part of the larger effort to enable custom templates across notification agents; it lays the groundwork for extending template support to all agents in future PRs. No specific issue to link.

### Key Changes

- **New `TemplateEngine`** (`server/lib/notifications/templateEngine.ts`) wrapping a shared LiquidJS engine.
- **No custom helpers needed** — Liquid provides conditionals, comparisons (`==`, `>`, …), and filters (`default`, `upcase`, `downcase`, `capitalize`, `truncate`, `json`, `url_encode`) natively. This also resolves several review points for free: numeric comparison coercion, `default` on empty strings, and no HTML-escaping (apostrophes/quotes render verbatim).
- **Circular-safe `json` filter** — the built-in `json` filter is overridden so circular TypeORM relations (e.g. `Media` ↔ `Issue`) can't crash rendering.
- **`buildContext`** exposes the same scalar variables as the old `KeyMap` (including `discordIds`, `media_imdbid`, `jellyfinMediaId`, `plexRatingKey`, `requestedBy_jellyfinUserId`) plus the full `media`/`request`/`issue`/`comment`/`extra` values for conditionals.
- **Simpler payload build** — the stored template is rendered to a string and handed to `JSON.parse`; the previous regex "cleanup" of the rendered payload was removed.
- **Relaxed validation** (client + server) — the payload is now a Liquid template that needn't be valid JSON until rendered, so the strict `JSON.parse` checks on save/test were removed. Templates are validated by using the **Test** button.
- **`customHeaders` support retained.**
- **Unit tests** added for `TemplateEngine` (escaping, optional-section `null` handling, circular-safe `json`, and variable mapping).

### New Templating Capabilities

Webhook payloads and URLs can now use Liquid:

- **Conditionals:** `{% if media %}…{% else %}…{% endif %}`, `{% if media_status == "AVAILABLE" %}…{% endif %}`
- **Comparisons:** `{% if pendingRequestsCount > 10 %}…{% endif %}`
- **Filters:** `{{ notifyuser_username | capitalize }}`, `{{ media_type | upcase }}`, `{{ subject | truncate: 50 }}`, `{{ subject | json }}`, `{{ value | url_encode }}`
- **Defaults:** `{{ notifyuser_username | default: "Unknown User" }}`

The default payload now uses `{% if %}…{% else %}null{% endif %}` so optional sections (media/request/issue/comment) render as `null` when absent (matching prior behavior) while staying valid JSON, and emits free-text values (titles, overviews, display names, comments) through the `json` filter so quotes/newlines can't break the surrounding JSON.

### Compatibility Notes

- Simple `{{ variable }}` substitution continues to work unchanged.
- This is **not** a drop-in for every existing custom payload: templates are now Liquid, so the old "magic" object keys (`"{{media}}"`, `"{{request}}"`, …) should be rewritten as `{% if %}` blocks (the **Reset to Default** button produces an up-to-date example). Filter names follow Liquid (`upcase`/`downcase` rather than `upper`/`lower`).
- URL variable substitution renders raw; use the `url_encode` filter where encoding is needed.

### Review Feedback Addressed

- Switched the engine from Handlebars to **LiquidJS** (gauthier-th / M0NsTeRRR).
- Removed the regex JSON "cleanup"; the render output is parsed directly (M0NsTeRRR).
- A non-JSON template that renders to valid JSON is now allowed end-to-end (relaxed client + server validation) (M0NsTeRRR).
- Removed the frontend payload-validation test that could no longer verify templates (M0NsTeRRR).
- Dropped the `notifyUser` → requester fallback so `notifyuser_*` maps to `notifyUser` only, matching the previous `KeyMap` (M0NsTeRRR).
- Restored an escaping path for free-text values, and `url_encode` is available for URL templating.

## How Has This Been Tested?

Tested locally with `pnpm dev` against a [webhook.site](https://webhook.site) endpoint, plus automated unit tests.

Manual:
1. Configure the webhook agent against the test endpoint, enable notification types, and **Save**.
2. Click **Test** and confirm the webhook is received with a valid JSON body and variables substituted.
3. Trigger real notifications (request, auto-approve, issue, comment) and confirm optional sections render as objects when relevant and `null` otherwise.
4. Edge cases verified: a media title containing quotes, a multi-line issue/comment message, and templates using conditionals/filters — all produce valid JSON.

Automated: `pnpm test server/lib/notifications/templateEngine.test.ts` (escaping, optional-section `null` handling, circular-safe `json`, and `buildContext` variable mapping). `pnpm build`, `pnpm typecheck`, and `pnpm lint` all pass.

## Screenshots / Logs (if applicable)

N/A — backend refactor (frontend default payload/validation updated, UI unchanged).

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) — **AI (Claude Code) used for implementation assistance**
- [ ] I have updated the documentation accordingly. — docs for the new Liquid template syntax to follow
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` — no new translation keys added
- [ ] Database migration (if required) — not required (uses existing settings system)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook notifications now support Liquid templates for JSON payloads and webhook URLs.
  * Templates can use notification details, related media, requests, issues, comments, and extra data.

* **Bug Fixes**
  * Improved validation for template-based and standard JSON payloads.
  * Webhook settings are now handled more consistently during retrieval, updates, and upgrades.

* **Documentation**
  * Expanded webhook documentation with Liquid examples, supported filters, conditionals, error handling, and available template objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->