### PR TITLE
feat: add route to fetch user by jellyfin id

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -4429,6 +4429,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+  /user/jellyfin/{jellyfinUserId}:
+    get:
+      summary: Get user by Jellyfin user ID
+      description: |
+        Retrieves user details by Jellyfin user ID in a JSON object. Returns filtered data based on the caller's permissions.
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: jellyfinUserId
+          required: true
+          schema:
+            type: string
+          description: The Jellyfin user ID (32-character hexadecimal string)
+      responses:
+        '200':
+          description: User details in JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          description: User not found
   /user/{userId}/requests:
     get:
       summary: Get requests for a specific user

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -4449,6 +4449,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
+  /user/jellyfin/{jellyfinUserId}:
+    get:
+      summary: Get user by Jellyfin user ID
+      description: |
+        Retrieves user details by Jellyfin user ID in a JSON object. Returns filtered data based on the caller's permissions.
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: jellyfinUserId
+          required: true
+          schema:
+            type: string
+          description: The Jellyfin user ID (32-character hexadecimal string)
+      responses:
+        '200':
+          description: User details in JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '404':
+          description: User not found
   /user/{userId}/requests:
     get:
       summary: Get requests for a specific user

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -315,6 +315,22 @@ router.get<{ id: string }>('/:id', async (req, res, next) => {
   }
 });
 
+router.get<{ jellyfinUserId: string }>('/jellyfin/:jellyfinUserId', async (req, res, next) => {
+  try {
+    const userRepository = getRepository(User);
+
+    const user = await userRepository.findOneOrFail({
+      where: { jellyfinUserId: req.params.jellyfinUserId },
+    });
+
+    return res
+      .status(200)
+      .json(user.filter(req.user?.hasPermission(Permission.MANAGE_USERS)));
+  } catch (e) {
+    next({ status: 404, message: 'User not found.' });
+  }
+});
+
 router.use('/:id/settings', userSettingsRoutes);
 
 router.get<{ id: string }, UserRequestsResponse>(

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -420,6 +420,22 @@ router.get<{ id: string }>('/:id', async (req, res, next) => {
   }
 });
 
+router.get<{ jellyfinUserId: string }>('/jellyfin/:jellyfinUserId', async (req, res, next) => {
+  try {
+    const userRepository = getRepository(User);
+
+    const user = await userRepository.findOneOrFail({
+      where: { jellyfinUserId: req.params.jellyfinUserId },
+    });
+
+    return res
+      .status(200)
+      .json(user.filter(req.user?.hasPermission(Permission.MANAGE_USERS)));
+  } catch (e) {
+    next({ status: 404, message: 'User not found.' });
+  }
+});
+
 router.use('/:id/settings', userSettingsRoutes);
 
 router.get<{ id: string }, UserRequestsResponse>(

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -420,21 +420,24 @@ router.get<{ id: string }>('/:id', async (req, res, next) => {
   }
 });
 
-router.get<{ jellyfinUserId: string }>('/jellyfin/:jellyfinUserId', async (req, res, next) => {
-  try {
-    const userRepository = getRepository(User);
+router.get<{ jellyfinUserId: string }>(
+  '/jellyfin/:jellyfinUserId',
+  async (req, res, next) => {
+    try {
+      const userRepository = getRepository(User);
 
-    const user = await userRepository.findOneOrFail({
-      where: { jellyfinUserId: req.params.jellyfinUserId },
-    });
+      const user = await userRepository.findOneOrFail({
+        where: { jellyfinUserId: req.params.jellyfinUserId },
+      });
 
-    return res
-      .status(200)
-      .json(user.filter(req.user?.hasPermission(Permission.MANAGE_USERS)));
-  } catch (e) {
-    next({ status: 404, message: 'User not found.' });
+      return res
+        .status(200)
+        .json(user.filter(req.user?.hasPermission(Permission.MANAGE_USERS)));
+    } catch {
+      next({ status: 404, message: 'User not found.' });
+    }
   }
-});
+);
 
 router.use('/:id/settings', userSettingsRoutes);
 

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -426,8 +426,13 @@ router.get<{ jellyfinUserId: string }>(
     try {
       const userRepository = getRepository(User);
 
+      const jellyfinUserId = normalizeJellyfinGuid(req.params.jellyfinUserId);
+      if (!jellyfinUserId) {
+        return next({ status: 400, message: 'Invalid Jellyfin User ID.' });
+      }
+
       const user = await userRepository.findOneOrFail({
-        where: { jellyfinUserId: req.params.jellyfinUserId },
+        where: { jellyfinUserId },
       });
 
       return res


### PR DESCRIPTION
## Description

Fetch a seerr user by Jellyfin ID. Currently this is not possible and from my understanding makes it difficult for clients to find a user without fetching all users and matching the ID. 

## How Has This Been Tested?

Not tested.

## Screenshots / Logs (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * New endpoint to retrieve user information by Jellyfin ID with permission-based filtering of returned data.
  * Returns 404 when no matching user is found.
  * Returns 400 for invalid Jellyfin ID formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->