### PR TITLE
feat: use tmdb with anidb on jellyfin

### DIFF
--- a/server/api/animelist.ts
+++ b/server/api/animelist.ts
@@ -48,11 +48,11 @@ interface AnimeList {
 
 export interface AnidbItem {
   tvdbId?: number;
-  tmdbtv?: number;
+  tmdbTv?: number;
   tmdbId?: number;
   imdbId?: string;
   tvdbSeason?: number;
-  tmdbseason?: number;
+  tmdbSeason?: number;
 }
 
 class AnimeListMapping {
@@ -101,11 +101,11 @@ class AnimeListMapping {
         this.mapping[anidbId] = {
           // for season 0 ignore tvdbid, because this must be movie/OVA
           tvdbId: anime.$.defaulttvdbseason === '0' ? undefined : tvdbId,
-          tmdbtv: tmdbtv,
+          tmdbTv: tmdbtv,
           tmdbId: tmdbId,
           imdbId: imdbIds[0], // this is used for one AniDB -> one imdb movie mapping
           tvdbSeason: Number(anime.$.defaulttvdbseason),
-          tmdbseason: Number(anime.$.tmdbseason),
+          tmdbSeason: Number(anime.$.tmdbseason),
         };
 
         if (tvdbId) {

--- a/server/api/animelist.ts
+++ b/server/api/animelist.ts
@@ -30,6 +30,8 @@ interface Anime {
     anidbid: number;
     tvdbid?: string;
     defaulttvdbseason?: string;
+    tmdbtv?: number;
+    tmdbseason?: number;
     tmdbid?: number;
     imdbid?: string;
   };
@@ -46,9 +48,11 @@ interface AnimeList {
 
 export interface AnidbItem {
   tvdbId?: number;
+  tmdbtv?: number;
   tmdbId?: number;
   imdbId?: string;
   tvdbSeason?: number;
+  tmdbseason?: number;
 }
 
 class AnimeListMapping {
@@ -92,13 +96,16 @@ class AnimeListMapping {
         }
 
         const tmdbId = anime.$.tmdbid ? Number(anime.$.tmdbid) : undefined;
+        const tmdbtv = anime.$.tmdbtv ? Number(anime.$.tmdbtv) : undefined;
         const anidbId = Number(anime.$.anidbid);
         this.mapping[anidbId] = {
           // for season 0 ignore tvdbid, because this must be movie/OVA
           tvdbId: anime.$.defaulttvdbseason === '0' ? undefined : tvdbId,
+          tmdbtv: tmdbtv,
           tmdbId: tmdbId,
           imdbId: imdbIds[0], // this is used for one AniDB -> one imdb movie mapping
           tvdbSeason: Number(anime.$.defaulttvdbseason),
+          tmdbseason: Number(anime.$.tmdbseason),
         };
 
         if (tvdbId) {

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -251,15 +251,15 @@ class JellyfinScanner
         }
       }
 
-      let tvdbSeasonFromAnidb: number | undefined;
+      let tmdbSeasonFromAnidb: number | undefined;
       if (!tvShow && metadata.ProviderIds.AniDB) {
         const anidbId = Number(metadata.ProviderIds.AniDB);
         const result = animeList.getFromAnidbId(anidbId);
-        tvdbSeasonFromAnidb = result?.tvdbSeason;
-        if (result?.tvdbId) {
+        tmdbSeasonFromAnidb = result?.tmdbseason;
+        if (result?.tmdbtv) {
           try {
-            tvShow = await this.tmdb.getShowByTvdbId({
-              tvdbId: result.tvdbId,
+            tvShow = await this.tmdb.getTvShow({
+              tvId: result.tmdbtv,
             });
           } catch {
             this.log('Unable to find AniDB ID for this title.', 'debug', {
@@ -268,7 +268,7 @@ class JellyfinScanner
           }
         }
         // With AniDB we can have mixed libraries with movies in a "show" library
-        else if (result?.imdbId || result?.tmdbId) {
+        else if (result?.tmdbId || result?.imdbId) {
           await this.processJellyfinMovie(jellyfinitem);
           return;
         }
@@ -287,13 +287,13 @@ class JellyfinScanner
 
         for (const season of filteredSeasons) {
           const matchedJellyfinSeason = jellyfinSeasons.find((md) => {
-            if (tvdbSeasonFromAnidb) {
+            if (tmdbSeasonFromAnidb) {
               // In AniDB we don't have the concept of seasons,
               // we have multiple shows with only Season 1 (and sometimes a season with index 0 for specials).
               // We use tvdbSeasonFromAnidb to check if we are on the correct TMDB season and
               // md.IndexNumber === 1 to be sure to find the correct season on jellyfin
               return (
-                tvdbSeasonFromAnidb === season.season_number &&
+                tmdbSeasonFromAnidb === season.season_number &&
                 md.IndexNumber === 1
               );
             } else {
@@ -377,7 +377,7 @@ class JellyfinScanner
 
             // With AniDB we can have multiple shows for one season, so we need to save
             // the episode from all the jellyfin entries to get the total
-            if (tvdbSeasonFromAnidb) {
+            if (tmdbSeasonFromAnidb) {
               let show = this.processedAnidbSeason.get(tvShow.id);
 
               if (!show) {

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -255,11 +255,11 @@ class JellyfinScanner
       if (!tvShow && metadata.ProviderIds.AniDB) {
         const anidbId = Number(metadata.ProviderIds.AniDB);
         const result = animeList.getFromAnidbId(anidbId);
-        tmdbSeasonFromAnidb = result?.tmdbseason;
-        if (result?.tmdbtv) {
+        tmdbSeasonFromAnidb = result?.tmdbSeason;
+        if (result?.tmdbTv) {
           try {
             tvShow = await this.tmdb.getTvShow({
-              tvId: result.tmdbtv,
+              tvId: result.tmdbTv,
             });
           } catch {
             this.log('Unable to find AniDB ID for this title.', 'debug', {


### PR DESCRIPTION
#### Description
This PR changes the metadata provider to TMDB when using anidb for better season recognition

#### To-Dos

- [X] Disclosed any use of AI (see our [policy](../CONTRIBUTING.md#ai-assistance-notice))
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
