### PR TITLE
fix(scanners): use service instance for 4k availability detection

### DIFF
--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -131,11 +131,11 @@ class JellyfinScanner
         : undefined;
 
       if (this.enable4kMovie) {
-        const instanceAvailibility =
+        const instanceAvailability =
           await serviceAvailabilityChecker.checkMovieAvailability(tmdbId);
 
-        if (instanceAvailibility.hasStandard || instanceAvailibility.has4k) {
-          if (instanceAvailibility.hasStandard) {
+        if (instanceAvailability.hasStandard || instanceAvailability.has4k) {
+          if (instanceAvailability.hasStandard) {
             await this.processMovie(tmdbId, {
               is4k: false,
               mediaAddedAt,
@@ -145,7 +145,7 @@ class JellyfinScanner
             });
           }
 
-          if (instanceAvailibility.has4k) {
+          if (instanceAvailability.has4k) {
             await this.processMovie(tmdbId, {
               is4k: true,
               mediaAddedAt,
@@ -160,8 +160,8 @@ class JellyfinScanner
             'debug',
             {
               tmdbId,
-              hasStandard: instanceAvailibility.hasStandard,
-              has4k: instanceAvailibility.has4k,
+              hasStandard: instanceAvailability.hasStandard,
+              has4k: instanceAvailability.has4k,
             }
           );
 
@@ -333,19 +333,19 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
-        let instanceAvailibility: Awaited<
+        let instanceAvailability: Awaited<
           ReturnType<typeof serviceAvailabilityChecker.checkShowAvailability>
         > | null = null;
         let useServiceBasedDetection = false;
 
         if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {
-          instanceAvailibility =
+          instanceAvailability =
             await serviceAvailabilityChecker.checkShowAvailability(
               tvShow.external_ids.tvdb_id
             );
 
           useServiceBasedDetection =
-            instanceAvailibility.hasStandard || instanceAvailibility.has4k;
+            instanceAvailability.hasStandard || instanceAvailability.has4k;
 
           if (useServiceBasedDetection) {
             this.log(
@@ -353,9 +353,9 @@ class JellyfinScanner
               'debug',
               {
                 tvdbId: tvShow.external_ids.tvdb_id,
-                hasStandard: instanceAvailibility.hasStandard,
-                has4k: instanceAvailibility.has4k,
-                seasons: instanceAvailibility.seasons.length,
+                hasStandard: instanceAvailability.hasStandard,
+                has4k: instanceAvailability.has4k,
+                seasons: instanceAvailability.seasons.length,
               }
             );
           }
@@ -382,8 +382,8 @@ class JellyfinScanner
             let totalStandard = 0;
             let total4k = 0;
 
-            if (useServiceBasedDetection && instanceAvailibility) {
-              const serviceSeason = instanceAvailibility.seasons.find(
+            if (useServiceBasedDetection && instanceAvailability) {
+              const serviceSeason = instanceAvailability.seasons.find(
                 (s) => s.seasonNumber === season.season_number
               );
 

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -20,6 +20,7 @@ import type {
   StatusBase,
 } from '@server/lib/scanners/baseScanner';
 import BaseScanner from '@server/lib/scanners/baseScanner';
+import serviceAvailabilityChecker from '@server/lib/scanners/serviceAvailabilityChecker';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { getHostname } from '@server/utils/getHostname';
@@ -125,6 +126,57 @@ class JellyfinScanner
 
       const { tmdbId, imdbId, metadata } = extracted;
 
+      const mediaAddedAt = metadata.DateCreated
+        ? new Date(metadata.DateCreated)
+        : undefined;
+
+      if (this.enable4kMovie) {
+        const instanceAvailibility =
+          await serviceAvailabilityChecker.checkMovieAvailability(tmdbId);
+
+        if (instanceAvailibility.hasStandard || instanceAvailibility.has4k) {
+          if (instanceAvailibility.hasStandard) {
+            await this.processMovie(tmdbId, {
+              is4k: false,
+              mediaAddedAt,
+              jellyfinMediaId: metadata.Id,
+              imdbId,
+              title: metadata.Name,
+            });
+          }
+
+          if (instanceAvailibility.has4k) {
+            await this.processMovie(tmdbId, {
+              is4k: true,
+              mediaAddedAt,
+              jellyfinMediaId: metadata.Id,
+              imdbId,
+              title: metadata.Name,
+            });
+          }
+
+          this.log(
+            `Processed movie with service availability check: ${metadata.Name}`,
+            'debug',
+            {
+              tmdbId,
+              hasStandard: instanceAvailibility.hasStandard,
+              has4k: instanceAvailibility.has4k,
+            }
+          );
+
+          return;
+        }
+
+        this.log(
+          `Movie not found in any Radarr instance, using resolution-based detection: ${metadata.Name}`,
+          'debug',
+          {
+            tmdbId,
+          }
+        );
+      }
+
       const has4k = metadata.MediaSources?.some((MediaSource) => {
         return MediaSource.MediaStreams.filter(
           (MediaStream) => MediaStream.Type === 'Video'
@@ -140,10 +192,6 @@ class JellyfinScanner
           return (MediaStream.Width ?? 0) <= 2000;
         });
       });
-
-      const mediaAddedAt = metadata.DateCreated
-        ? new Date(metadata.DateCreated)
-        : undefined;
 
       if (hasOtherResolution || (!this.enable4kMovie && has4k)) {
         await this.processMovie(tmdbId, {
@@ -285,6 +333,34 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
+        let instanceAvailibility: Awaited<
+          ReturnType<typeof serviceAvailabilityChecker.checkShowAvailability>
+        > | null = null;
+        let useServiceBasedDetection = false;
+
+        if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {
+          instanceAvailibility =
+            await serviceAvailabilityChecker.checkShowAvailability(
+              tvShow.external_ids.tvdb_id
+            );
+
+          useServiceBasedDetection =
+            instanceAvailibility.hasStandard || instanceAvailibility.has4k;
+
+          if (useServiceBasedDetection) {
+            this.log(
+              `Using service availability check for show: ${tvShow.name}`,
+              'debug',
+              {
+                tvdbId: tvShow.external_ids.tvdb_id,
+                hasStandard: instanceAvailibility.hasStandard,
+                has4k: instanceAvailibility.has4k,
+                seasons: instanceAvailibility.seasons.length,
+              }
+            );
+          }
+        }
+
         for (const season of filteredSeasons) {
           const matchedJellyfinSeason = jellyfinSeasons.find((md) => {
             if (tvdbSeasonFromAnidb) {
@@ -306,7 +382,16 @@ class JellyfinScanner
             let totalStandard = 0;
             let total4k = 0;
 
-            if (!this.enable4kShow) {
+            if (useServiceBasedDetection && instanceAvailibility) {
+              const serviceSeason = instanceAvailibility.seasons.find(
+                (s) => s.seasonNumber === season.season_number
+              );
+
+              if (serviceSeason) {
+                totalStandard = serviceSeason.episodesStandard;
+                total4k = serviceSeason.episodes4k;
+              }
+            } else if (!this.enable4kShow) {
               const episodes = await this.jfClient.getEpisodes(
                 Id,
                 matchedJellyfinSeason.Id
@@ -362,14 +447,6 @@ class JellyfinScanner
                   )
                 );
 
-                // Count in both if episode has both versions
-                // TODO: Make this more robust in the future
-                // Currently, this detection is based solely on file resolution, not which
-                // Radarr/Sonarr instance the file came from. If a 4K request results in
-                // 1080p files (no 4K release available yet), those files will be counted
-                // as "standard" even though they're in the 4K library. This can cause
-                // non-4K users to see content as "available" when they can't access it.
-                // See issue https://github.com/seerr-team/seerr/issues/1744 for details.
                 if (hasStandard) totalStandard += episodeCount;
                 if (has4k) total4k += episodeCount;
               }
@@ -451,6 +528,8 @@ class JellyfinScanner
     }
 
     const sessionId = this.startRun();
+
+    serviceAvailabilityChecker.clearCache();
 
     try {
       const userRepository = getRepository(User);

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -20,6 +20,7 @@ import type {
   StatusBase,
 } from '@server/lib/scanners/baseScanner';
 import BaseScanner from '@server/lib/scanners/baseScanner';
+import serviceAvailabilityChecker from '@server/lib/scanners/serviceAvailabilityChecker';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { getHostname } from '@server/utils/getHostname';
@@ -127,6 +128,57 @@ class JellyfinScanner
 
       const { tmdbId, imdbId, metadata } = extracted;
 
+      const mediaAddedAt = metadata.DateCreated
+        ? new Date(metadata.DateCreated)
+        : undefined;
+
+      if (this.enable4kMovie) {
+        const instanceAvailibility =
+          await serviceAvailabilityChecker.checkMovieAvailability(tmdbId);
+
+        if (instanceAvailibility.hasStandard || instanceAvailibility.has4k) {
+          if (instanceAvailibility.hasStandard) {
+            await this.processMovie(tmdbId, {
+              is4k: false,
+              mediaAddedAt,
+              jellyfinMediaId: metadata.Id,
+              imdbId,
+              title: metadata.Name,
+            });
+          }
+
+          if (instanceAvailibility.has4k) {
+            await this.processMovie(tmdbId, {
+              is4k: true,
+              mediaAddedAt,
+              jellyfinMediaId: metadata.Id,
+              imdbId,
+              title: metadata.Name,
+            });
+          }
+
+          this.log(
+            `Processed movie with service availability check: ${metadata.Name}`,
+            'debug',
+            {
+              tmdbId,
+              hasStandard: instanceAvailibility.hasStandard,
+              has4k: instanceAvailibility.has4k,
+            }
+          );
+
+          return;
+        }
+
+        this.log(
+          `Movie not found in any Radarr instance, using resolution-based detection: ${metadata.Name}`,
+          'debug',
+          {
+            tmdbId,
+          }
+        );
+      }
+
       const has4k = metadata.MediaSources?.some((MediaSource) => {
         return MediaSource.MediaStreams.filter(
           (MediaStream) => MediaStream.Type === 'Video'
@@ -142,10 +194,6 @@ class JellyfinScanner
           return (MediaStream.Width ?? 0) <= 2000;
         });
       });
-
-      const mediaAddedAt = metadata.DateCreated
-        ? new Date(metadata.DateCreated)
-        : undefined;
 
       if (hasOtherResolution || (!this.enable4kMovie && has4k)) {
         await this.processMovie(tmdbId, {
@@ -289,6 +337,34 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
+        let instanceAvailibility: Awaited<
+          ReturnType<typeof serviceAvailabilityChecker.checkShowAvailability>
+        > | null = null;
+        let useServiceBasedDetection = false;
+
+        if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {
+          instanceAvailibility =
+            await serviceAvailabilityChecker.checkShowAvailability(
+              tvShow.external_ids.tvdb_id
+            );
+
+          useServiceBasedDetection =
+            instanceAvailibility.hasStandard || instanceAvailibility.has4k;
+
+          if (useServiceBasedDetection) {
+            this.log(
+              `Using service availability check for show: ${tvShow.name}`,
+              'debug',
+              {
+                tvdbId: tvShow.external_ids.tvdb_id,
+                hasStandard: instanceAvailibility.hasStandard,
+                has4k: instanceAvailibility.has4k,
+                seasons: instanceAvailibility.seasons.length,
+              }
+            );
+          }
+        }
+
         for (const season of filteredSeasons) {
           const matchedJellyfinSeason = jellyfinSeasons.find((md) => {
             if (tvdbSeasonFromAnidb) {
@@ -310,7 +386,16 @@ class JellyfinScanner
             let totalStandard = 0;
             let total4k = 0;
 
-            if (!this.enable4kShow) {
+            if (useServiceBasedDetection && instanceAvailibility) {
+              const serviceSeason = instanceAvailibility.seasons.find(
+                (s) => s.seasonNumber === season.season_number
+              );
+
+              if (serviceSeason) {
+                totalStandard = serviceSeason.episodesStandard;
+                total4k = serviceSeason.episodes4k;
+              }
+            } else if (!this.enable4kShow) {
               const episodes = await this.jfClient.getEpisodes(
                 Id,
                 matchedJellyfinSeason.Id
@@ -366,14 +451,6 @@ class JellyfinScanner
                   )
                 );
 
-                // Count in both if episode has both versions
-                // TODO: Make this more robust in the future
-                // Currently, this detection is based solely on file resolution, not which
-                // Radarr/Sonarr instance the file came from. If a 4K request results in
-                // 1080p files (no 4K release available yet), those files will be counted
-                // as "standard" even though they're in the 4K library. This can cause
-                // non-4K users to see content as "available" when they can't access it.
-                // See issue https://github.com/seerr-team/seerr/issues/1744 for details.
                 if (hasStandard) totalStandard += episodeCount;
                 if (has4k) total4k += episodeCount;
               }
@@ -462,6 +539,8 @@ class JellyfinScanner
     }
 
     const sessionId = this.startRun();
+
+    serviceAvailabilityChecker.clearCache();
 
     try {
       const userRepository = getRepository(User);

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -20,6 +20,7 @@ import type {
   StatusBase,
 } from '@server/lib/scanners/baseScanner';
 import BaseScanner from '@server/lib/scanners/baseScanner';
+import type { ShowInstanceAvailability } from '@server/lib/scanners/serviceAvailabilityChecker';
 import serviceAvailabilityChecker from '@server/lib/scanners/serviceAvailabilityChecker';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
@@ -337,9 +338,7 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
-        let instanceAvailability: Awaited<
-          ReturnType<typeof serviceAvailabilityChecker.checkShowAvailability>
-        > | null = null;
+        let instanceAvailability: ShowInstanceAvailability | null = null;
         let useServiceBasedDetection = false;
 
         if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -133,11 +133,11 @@ class JellyfinScanner
         : undefined;
 
       if (this.enable4kMovie) {
-        const instanceAvailibility =
+        const instanceAvailability =
           await serviceAvailabilityChecker.checkMovieAvailability(tmdbId);
 
-        if (instanceAvailibility.hasStandard || instanceAvailibility.has4k) {
-          if (instanceAvailibility.hasStandard) {
+        if (instanceAvailability.hasStandard || instanceAvailability.has4k) {
+          if (instanceAvailability.hasStandard) {
             await this.processMovie(tmdbId, {
               is4k: false,
               mediaAddedAt,
@@ -147,7 +147,7 @@ class JellyfinScanner
             });
           }
 
-          if (instanceAvailibility.has4k) {
+          if (instanceAvailability.has4k) {
             await this.processMovie(tmdbId, {
               is4k: true,
               mediaAddedAt,
@@ -162,8 +162,8 @@ class JellyfinScanner
             'debug',
             {
               tmdbId,
-              hasStandard: instanceAvailibility.hasStandard,
-              has4k: instanceAvailibility.has4k,
+              hasStandard: instanceAvailability.hasStandard,
+              has4k: instanceAvailability.has4k,
             }
           );
 
@@ -337,19 +337,19 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
-        let instanceAvailibility: Awaited<
+        let instanceAvailability: Awaited<
           ReturnType<typeof serviceAvailabilityChecker.checkShowAvailability>
         > | null = null;
         let useServiceBasedDetection = false;
 
         if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {
-          instanceAvailibility =
+          instanceAvailability =
             await serviceAvailabilityChecker.checkShowAvailability(
               tvShow.external_ids.tvdb_id
             );
 
           useServiceBasedDetection =
-            instanceAvailibility.hasStandard || instanceAvailibility.has4k;
+            instanceAvailability.hasStandard || instanceAvailability.has4k;
 
           if (useServiceBasedDetection) {
             this.log(
@@ -357,9 +357,9 @@ class JellyfinScanner
               'debug',
               {
                 tvdbId: tvShow.external_ids.tvdb_id,
-                hasStandard: instanceAvailibility.hasStandard,
-                has4k: instanceAvailibility.has4k,
-                seasons: instanceAvailibility.seasons.length,
+                hasStandard: instanceAvailability.hasStandard,
+                has4k: instanceAvailability.has4k,
+                seasons: instanceAvailability.seasons.length,
               }
             );
           }
@@ -386,8 +386,8 @@ class JellyfinScanner
             let totalStandard = 0;
             let total4k = 0;
 
-            if (useServiceBasedDetection && instanceAvailibility) {
-              const serviceSeason = instanceAvailibility.seasons.find(
+            if (useServiceBasedDetection && instanceAvailability) {
+              const serviceSeason = instanceAvailability.seasons.find(
                 (s) => s.seasonNumber === season.season_number
               );
 

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -338,14 +338,17 @@ class JellyfinScanner
           ? seasons
           : seasons.filter((sn) => sn.season_number !== 0);
 
+        const tvdbId =
+          (metadata.ProviderIds.Tvdb
+            ? Number(metadata.ProviderIds.Tvdb)
+            : undefined) ?? tvShow.external_ids?.tvdb_id;
+
         let instanceAvailability: ShowInstanceAvailability | null = null;
         let useServiceBasedDetection = false;
 
-        if (this.enable4kShow && tvShow.external_ids?.tvdb_id) {
+        if (this.enable4kShow && tvdbId) {
           instanceAvailability =
-            await serviceAvailabilityChecker.checkShowAvailability(
-              tvShow.external_ids.tvdb_id
-            );
+            await serviceAvailabilityChecker.checkShowAvailability(tvdbId);
 
           useServiceBasedDetection =
             instanceAvailability.hasStandard || instanceAvailability.has4k;
@@ -355,7 +358,7 @@ class JellyfinScanner
               `Using service availability check for show: ${tvShow.name}`,
               'debug',
               {
-                tvdbId: tvShow.external_ids.tvdb_id,
+                tvdbId,
                 hasStandard: instanceAvailability.hasStandard,
                 has4k: instanceAvailability.has4k,
                 seasons: instanceAvailability.seasons.length,
@@ -487,18 +490,13 @@ class JellyfinScanner
           }
         }
 
-        await this.processShow(
-          tvShow.id,
-          tvShow.external_ids?.tvdb_id,
-          processableSeasons,
-          {
-            mediaAddedAt: metadata.DateCreated
-              ? new Date(metadata.DateCreated)
-              : undefined,
-            jellyfinMediaId: Id,
-            title: tvShow.name,
-          }
-        );
+        await this.processShow(tvShow.id, tvdbId, processableSeasons, {
+          mediaAddedAt: metadata.DateCreated
+            ? new Date(metadata.DateCreated)
+            : undefined,
+          jellyfinMediaId: Id,
+          title: tvShow.name,
+        });
       } else {
         this.log(
           `No information found for the show: ${metadata.Name}`,

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -201,7 +201,8 @@ function fakeJellyfinSeriesItem(id: string): JellyfinLibraryItem {
 
 function fakeJellyfinShowMetadata(
   id: string,
-  tmdbId: string
+  tmdbId: string,
+  tvdbId?: string
 ): JellyfinLibraryItemExtended {
   return {
     Name: 'Test Show',
@@ -210,7 +211,7 @@ function fakeJellyfinShowMetadata(
     HasSubtitles: false,
     LocationType: 'FileSystem',
     MediaType: 'Video',
-    ProviderIds: { Tmdb: tmdbId },
+    ProviderIds: { Tmdb: tmdbId, ...(tvdbId ? { Tvdb: tvdbId } : {}) },
   };
 }
 
@@ -838,6 +839,47 @@ describe('Jellyfin Scanner', () => {
         0,
         'Episode counts should come from Sonarr; getEpisodes must not be called'
       );
+    });
+
+    it('uses the Jellyfin Tvdb provider id when TMDB has no tvdb id', async () => {
+      configureJellyfinWithLibrary();
+      configureSonarr([{ is4k: false }, { is4k: true }]);
+
+      let lookedUpTvdbId: number | undefined;
+      let callCount = 0;
+      getSeriesByTvdbIdImpl = async (id) => {
+        callCount++;
+        if (callCount === 1) {
+          lookedUpTvdbId = id;
+          return fakeSonarrSeries({ tvdbId: 54321 });
+        }
+        throw new Error('Series not found');
+      };
+
+      // TMDB returns no tvdb_id; only Jellyfin's ProviderIds.Tvdb has it
+      getTvShowImpl = async () => fakeTmdbShow(6300);
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinSeriesItem('jf-show-6300')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-show-6300'
+          ? fakeJellyfinShowMetadata('jf-show-6300', '6300', '54321')
+          : undefined;
+      getSeasonsImpl = async (seriesID: string) =>
+        seriesID === 'jf-show-6300'
+          ? [fakeJellyfinSeason(1, 'jf-show-6300-s1')]
+          : [];
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6300 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(lookedUpTvdbId, 54321);
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
     });
 
     it('falls back to Jellyfin episode counting when a show is not in any Sonarr instance', async () => {

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -2,8 +2,13 @@ import animeList from '@server/api/animelist';
 import type {
   JellyfinLibraryItem,
   JellyfinLibraryItemExtended,
+  JellyfinMediaStream,
 } from '@server/api/jellyfin';
 import JellyfinAPI from '@server/api/jellyfin';
+import type { RadarrMovie } from '@server/api/servarr/radarr';
+import RadarrAPI from '@server/api/servarr/radarr';
+import type { SonarrSeries } from '@server/api/servarr/sonarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
 import TheMovieDb from '@server/api/themoviedb';
 import type {
   TmdbTvDetails,
@@ -15,7 +20,11 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
-import type { Library } from '@server/lib/settings';
+import type {
+  Library,
+  RadarrSettings,
+  SonarrSettings,
+} from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
 import assert from 'node:assert/strict';
@@ -42,6 +51,7 @@ let getEpisodesImpl: (
   seriesID: string,
   seasonID: string
 ) => Promise<JellyfinLibraryItem[]> = async () => [];
+let getEpisodesCallCount = 0;
 
 Object.defineProperty(JellyfinAPI.prototype, 'getLibraryContents', {
   get() {
@@ -69,8 +79,10 @@ Object.defineProperty(JellyfinAPI.prototype, 'getSeasons', {
 
 Object.defineProperty(JellyfinAPI.prototype, 'getEpisodes', {
   get() {
-    return async (seriesID: string, seasonID: string) =>
-      getEpisodesImpl(seriesID, seasonID);
+    return async (seriesID: string, seasonID: string) => {
+      getEpisodesCallCount++;
+      return getEpisodesImpl(seriesID, seasonID);
+    };
   },
   set() {},
   configurable: true,
@@ -94,6 +106,28 @@ Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
   get() {
     return async (args: { tvId: number; language?: string }) =>
       getTvShowImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+let getMovieByTmdbIdImpl: (id: number) => Promise<RadarrMovie> = async () => {
+  throw new Error('Movie not found');
+};
+Object.defineProperty(RadarrAPI.prototype, 'getMovieByTmdbId', {
+  get() {
+    return async (id: number) => getMovieByTmdbIdImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+let getSeriesByTvdbIdImpl: (id: number) => Promise<SonarrSeries> = async () => {
+  throw new Error('Series not found');
+};
+Object.defineProperty(SonarrAPI.prototype, 'getSeriesByTvdbId', {
+  get() {
+    return async (id: number) => getSeriesByTvdbIdImpl(id);
   },
   set() {},
   configurable: true,
@@ -221,13 +255,178 @@ function configureJellyfinWithLibrary(
   };
 }
 
+function fakeVideoStream(width: number): JellyfinMediaStream {
+  return {
+    Codec: 'h264',
+    Type: 'Video',
+    Width: width,
+    DisplayTitle: `${width}px`,
+  };
+}
+
+function fakeJellyfinMovieItem(id: string): JellyfinLibraryItem {
+  return {
+    Name: 'Test Movie',
+    Id: id,
+    Type: 'Movie',
+    HasSubtitles: false,
+    LocationType: 'FileSystem',
+    MediaType: 'Video',
+  };
+}
+
+function fakeJellyfinMovieMetadata(
+  id: string,
+  tmdbId: string,
+  width: number
+): JellyfinLibraryItemExtended {
+  return {
+    Name: 'Test Movie',
+    Id: id,
+    Type: 'Movie',
+    HasSubtitles: false,
+    LocationType: 'FileSystem',
+    MediaType: 'Video',
+    ProviderIds: { Tmdb: tmdbId },
+    MediaSources: [
+      {
+        Protocol: 'File',
+        Id: `${id}-source`,
+        Path: '/movies/test.mkv',
+        Type: 'Default',
+        VideoType: 'VideoFile',
+        MediaStreams: [fakeVideoStream(width)],
+      },
+    ],
+  };
+}
+
+function fakeJellyfinEpisodesWithResolution(
+  count: number,
+  width: number
+): JellyfinLibraryItem[] {
+  return Array.from({ length: count }, (_, i) => {
+    const episode: JellyfinLibraryItemExtended = {
+      Name: `Episode ${i + 1}`,
+      Id: `ep-${i}`,
+      IndexNumber: i + 1,
+      Type: 'Episode',
+      HasSubtitles: false,
+      LocationType: 'FileSystem',
+      MediaType: 'Video',
+      ProviderIds: {},
+      MediaSources: [
+        {
+          Protocol: 'File',
+          Id: `ep-${i}-source`,
+          Path: '/tv/test.mkv',
+          Type: 'Default',
+          VideoType: 'VideoFile',
+          MediaStreams: [fakeVideoStream(width)],
+        },
+      ],
+    };
+    return episode;
+  });
+}
+
+function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
+  return {
+    id: 1,
+    tmdbId: 700,
+    hasFile: true,
+    ...overrides,
+  } as RadarrMovie;
+}
+
+function fakeSonarrSeries(overrides: Partial<SonarrSeries> = {}): SonarrSeries {
+  return {
+    id: 1,
+    tvdbId: 12345,
+    title: 'Test Show',
+    statistics: { episodeFileCount: 10 },
+    seasons: [
+      {
+        seasonNumber: 1,
+        monitored: true,
+        statistics: {
+          episodeFileCount: 10,
+          totalEpisodeCount: 10,
+          episodeCount: 10,
+          percentOfEpisodes: 100,
+          sizeOnDisk: 0,
+        },
+      },
+    ],
+    ...overrides,
+  } as SonarrSeries;
+}
+
+function configureRadarr(overrides: Partial<RadarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.radarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Radarr ${i}`,
+    hostname: 'localhost',
+    port: 7878,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/movies',
+    is4k: false,
+    minimumAvailability: 'released',
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as RadarrSettings[];
+}
+
+function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.sonarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Sonarr ${i}`,
+    hostname: 'localhost',
+    port: 8989,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/tv',
+    activeLanguageProfileId: 1,
+    is4k: false,
+    enableSeasonFolders: true,
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as SonarrSettings[];
+}
+
 describe('Jellyfin Scanner', () => {
   beforeEach(async () => {
     getLibraryContentsImpl = async () => [];
     getItemDataImpl = async () => undefined;
     getSeasonsImpl = async () => [];
     getEpisodesImpl = async () => [];
+    getEpisodesCallCount = 0;
     getTvShowImpl = async () => fakeTmdbShow(1);
+    getMovieByTmdbIdImpl = async () => {
+      throw new Error('Movie not found');
+    };
+    getSeriesByTvdbIdImpl = async () => {
+      throw new Error('Series not found');
+    };
+
+    const settings = getSettings();
+    settings.radarr = [];
+    settings.sonarr = [];
 
     const userRepository = getRepository(User);
     const existingAdmin = await userRepository.findOne({ where: { id: 1 } });
@@ -500,6 +699,244 @@ describe('Jellyfin Scanner', () => {
         MediaStatus.PARTIALLY_AVAILABLE,
         'Show should stay PARTIALLY_AVAILABLE when a DELETED season is missing from the metadata provider'
       );
+    });
+  });
+
+  describe('service availability integration', () => {
+    it('uses service-based detection for a movie found in Radarr and skips resolution fallback', async () => {
+      configureJellyfinWithLibrary([
+        { id: 'test-library-id', name: 'Movies', enabled: true, type: 'movie' },
+      ]);
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+
+      let callCount = 0;
+      getMovieByTmdbIdImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return fakeRadarrMovie({ tmdbId: 6000, hasFile: true });
+        }
+        throw new Error('Movie not found');
+      };
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinMovieItem('jf-movie-6000')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-movie-6000'
+          ? fakeJellyfinMovieMetadata('jf-movie-6000', '6000', 3840)
+          : undefined;
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6000 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(
+        updated.status4k,
+        MediaStatus.UNKNOWN,
+        'Service detection found only a standard file, so the 4K resolution fallback must not run'
+      );
+    });
+
+    it('falls back to resolution-based detection when a movie is not in any Radarr instance', async () => {
+      configureJellyfinWithLibrary([
+        { id: 'test-library-id', name: 'Movies', enabled: true, type: 'movie' },
+      ]);
+      // No Radarr match: getMovieByTmdbIdImpl keeps its throwing default.
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinMovieItem('jf-movie-6001')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-movie-6001'
+          ? fakeJellyfinMovieMetadata('jf-movie-6001', '6001', 1920)
+          : undefined;
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6001 },
+      });
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Resolution fallback should mark the standard-resolution file available'
+      );
+      assert.strictEqual(updated.status4k, MediaStatus.UNKNOWN);
+    });
+
+    it('processes both standard and 4K when a movie is found in both Radarr instances', async () => {
+      configureJellyfinWithLibrary([
+        { id: 'test-library-id', name: 'Movies', enabled: true, type: 'movie' },
+      ]);
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+      getMovieByTmdbIdImpl = async () =>
+        fakeRadarrMovie({ tmdbId: 6002, hasFile: true });
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinMovieItem('jf-movie-6002')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-movie-6002'
+          ? fakeJellyfinMovieMetadata('jf-movie-6002', '6002', 1920)
+          : undefined;
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6002 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(updated.status4k, MediaStatus.AVAILABLE);
+    });
+
+    it('uses Sonarr season counts for a show found in Sonarr without querying episodes', async () => {
+      configureJellyfinWithLibrary();
+      configureSonarr([{ is4k: false }, { is4k: true }]);
+
+      let callCount = 0;
+      getSeriesByTvdbIdImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return fakeSonarrSeries({ tvdbId: 12345 });
+        }
+        throw new Error('Series not found');
+      };
+
+      getTvShowImpl = async () => ({
+        ...fakeTmdbShow(6100),
+        external_ids: { tvdb_id: 12345 },
+      });
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinSeriesItem('jf-show-6100')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-show-6100'
+          ? fakeJellyfinShowMetadata('jf-show-6100', '6100')
+          : undefined;
+      getSeasonsImpl = async (seriesID: string) =>
+        seriesID === 'jf-show-6100'
+          ? [fakeJellyfinSeason(1, 'jf-show-6100-s1')]
+          : [];
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6100 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(
+        getEpisodesCallCount,
+        0,
+        'Episode counts should come from Sonarr; getEpisodes must not be called'
+      );
+    });
+
+    it('falls back to Jellyfin episode counting when a show is not in any Sonarr instance', async () => {
+      configureJellyfinWithLibrary();
+      // No Sonarr match: getSeriesByTvdbIdImpl keeps its throwing default.
+      configureSonarr([{ is4k: true }]);
+
+      getTvShowImpl = async () => ({
+        ...fakeTmdbShow(6101),
+        external_ids: { tvdb_id: 23456 },
+      });
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinSeriesItem('jf-show-6101')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-show-6101'
+          ? fakeJellyfinShowMetadata('jf-show-6101', '6101')
+          : undefined;
+      getSeasonsImpl = async (seriesID: string) =>
+        seriesID === 'jf-show-6101'
+          ? [fakeJellyfinSeason(1, 'jf-show-6101-s1')]
+          : [];
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) =>
+        seasonID === 'jf-show-6101-s1'
+          ? fakeJellyfinEpisodesWithResolution(10, 1920)
+          : [];
+
+      await jellyfinFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 6101 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.ok(
+        getEpisodesCallCount > 0,
+        'A Sonarr miss should fall back to counting Jellyfin episodes'
+      );
+    });
+
+    it('does not mark a show available when a season is missing from the library', async () => {
+      configureJellyfinWithLibrary();
+
+      const mediaRepository = getRepository(Media);
+      const media = new Media();
+      media.tmdbId = 6102;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.jellyfinMediaId = 'jf-show-6102';
+      media.seasons = [];
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () =>
+        fakeTmdbShow(6102, [
+          {
+            id: 1,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 1',
+            overview: '',
+            season_number: 1,
+          },
+          {
+            id: 2,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 2',
+            overview: '',
+            season_number: 2,
+          },
+        ]);
+
+      getLibraryContentsImpl = async (id: string) =>
+        id === 'test-library-id'
+          ? [fakeJellyfinSeriesItem('jf-show-6102')]
+          : [];
+      getItemDataImpl = async (id: string) =>
+        id === 'jf-show-6102'
+          ? fakeJellyfinShowMetadata('jf-show-6102', '6102')
+          : undefined;
+      getSeasonsImpl = async (seriesID: string) =>
+        seriesID === 'jf-show-6102'
+          ? [fakeJellyfinSeason(1, 'jf-show-6102-s1')]
+          : [];
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) =>
+        seasonID === 'jf-show-6102-s1' ? fakeJellyfinEpisodes(10) : [];
+
+      await jellyfinFullScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 6102 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.PARTIALLY_AVAILABLE);
+      const s2 = updated.seasons.find((s) => s.seasonNumber === 2);
+      assert.notStrictEqual(s2, undefined);
+      assert.notStrictEqual(s2?.status, MediaStatus.AVAILABLE);
     });
   });
 });

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -18,6 +18,8 @@ import type {
   StatusBase,
 } from '@server/lib/scanners/baseScanner';
 import BaseScanner from '@server/lib/scanners/baseScanner';
+import type { ShowInstanceAvailability } from '@server/lib/scanners/serviceAvailabilityChecker';
+import serviceAvailabilityChecker from '@server/lib/scanners/serviceAvailabilityChecker';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { uniqWith } from 'lodash';
@@ -65,6 +67,9 @@ class PlexScanner
   public async run(): Promise<void> {
     const settings = getSettings();
     const sessionId = this.startRun();
+
+    serviceAvailabilityChecker.clearCache();
+
     try {
       const userRepository = getRepository(User);
       const admin = await userRepository.findOne({
@@ -224,6 +229,52 @@ class PlexScanner
     }
   }
 
+  private async processMovieWithAvailability(
+    tmdbId: number,
+    has4kResolution: boolean,
+    details: { mediaAddedAt: Date; ratingKey: string; title: string }
+  ) {
+    if (this.enable4kMovie) {
+      const instanceAvailability =
+        await serviceAvailabilityChecker.checkMovieAvailability(tmdbId);
+
+      if (instanceAvailability.hasStandard || instanceAvailability.has4k) {
+        if (instanceAvailability.hasStandard) {
+          await this.processMovie(tmdbId, { is4k: false, ...details });
+        }
+
+        if (instanceAvailability.has4k) {
+          await this.processMovie(tmdbId, { is4k: true, ...details });
+        }
+
+        this.log(
+          `Processed movie with service availability check: ${details.title}`,
+          'debug',
+          {
+            tmdbId,
+            hasStandard: instanceAvailability.hasStandard,
+            has4k: instanceAvailability.has4k,
+          }
+        );
+
+        return;
+      }
+
+      this.log(
+        `Movie not found in any Radarr instance, using resolution-based detection: ${details.title}`,
+        'debug',
+        {
+          tmdbId,
+        }
+      );
+    }
+
+    await this.processMovie(tmdbId, {
+      is4k: has4kResolution && this.enable4kMovie,
+      ...details,
+    });
+  }
+
   private async processPlexMovie(plexitem: PlexLibraryItem) {
     const mediaIds = await this.getMediaIds(plexitem);
 
@@ -231,8 +282,7 @@ class PlexScanner
       (media) => media.videoResolution === '4k'
     );
 
-    await this.processMovie(mediaIds.tmdbId, {
-      is4k: has4k && this.enable4kMovie,
+    await this.processMovieWithAvailability(mediaIds.tmdbId, has4k, {
       mediaAddedAt: new Date(plexitem.addedAt * 1000),
       ratingKey: plexitem.ratingKey,
       title: plexitem.title,
@@ -247,8 +297,7 @@ class PlexScanner
       (media) => media.videoResolution === '4k'
     );
 
-    await this.processMovie(tmdbId, {
-      is4k: has4k && this.enable4kMovie,
+    await this.processMovieWithAvailability(tmdbId, has4k, {
       mediaAddedAt: new Date(plexitem.addedAt * 1000),
       ratingKey: plexitem.ratingKey,
       title: plexitem.title,
@@ -327,44 +376,75 @@ class PlexScanner
       ? seasons
       : seasons.filter((sn) => sn.season_number !== 0);
 
+    const tvdbId = mediaIds.tvdbId ?? tvShow.external_ids?.tvdb_id;
+
+    let instanceAvailability: ShowInstanceAvailability | null = null;
+    let useServiceBasedDetection = false;
+
+    if (this.enable4kShow && tvdbId) {
+      instanceAvailability =
+        await serviceAvailabilityChecker.checkShowAvailability(tvdbId);
+
+      useServiceBasedDetection =
+        instanceAvailability.hasStandard || instanceAvailability.has4k;
+
+      if (useServiceBasedDetection) {
+        this.log(
+          `Using service availability check for show: ${tvShow.name}`,
+          'debug',
+          {
+            tvdbId,
+            hasStandard: instanceAvailability.hasStandard,
+            has4k: instanceAvailability.has4k,
+            seasons: instanceAvailability.seasons.length,
+          }
+        );
+      }
+    }
+
     for (const season of filteredSeasons) {
       const matchedPlexSeason = metadata.Children?.Metadata.find(
         (md) => Number(md.index) === season.season_number
       );
 
-      if (matchedPlexSeason) {
+      let totalStandard = 0;
+      let total4k = 0;
+
+      if (useServiceBasedDetection && instanceAvailability) {
+        const serviceSeason = instanceAvailability.seasons.find(
+          (s) => s.seasonNumber === season.season_number
+        );
+
+        if (serviceSeason) {
+          totalStandard = serviceSeason.episodesStandard;
+          total4k = serviceSeason.episodes4k;
+        }
+      } else if (matchedPlexSeason) {
         // If we have a matched Plex season, get its children metadata so we can check details
         const episodes = await this.plexClient.getChildrenMetadata(
           matchedPlexSeason.ratingKey
         );
         // Total episodes that are in standard definition (not 4k)
-        const totalStandard = episodes.filter((episode) =>
+        totalStandard = episodes.filter((episode) =>
           !this.enable4kShow
             ? true
             : episode.Media.some((media) => media.videoResolution !== '4k')
         ).length;
 
         // Total episodes that are in 4k
-        const total4k = this.enable4kShow
+        total4k = this.enable4kShow
           ? episodes.filter((episode) =>
               episode.Media.some((media) => media.videoResolution === '4k')
             ).length
           : 0;
-
-        processableSeasons.push({
-          seasonNumber: season.season_number,
-          episodes: totalStandard,
-          episodes4k: total4k,
-          totalEpisodes: season.episode_count,
-        });
-      } else {
-        processableSeasons.push({
-          seasonNumber: season.season_number,
-          episodes: 0,
-          episodes4k: 0,
-          totalEpisodes: season.episode_count,
-        });
       }
+
+      processableSeasons.push({
+        seasonNumber: season.season_number,
+        episodes: totalStandard,
+        episodes4k: total4k,
+        totalEpisodes: season.episode_count,
+      });
     }
 
     await this.processShow(

--- a/server/lib/scanners/plex/plex.test.ts
+++ b/server/lib/scanners/plex/plex.test.ts
@@ -461,6 +461,42 @@ describe('Plex Scanner', () => {
       );
     });
 
+    it('uses the Plex Guid tvdb id when TMDB has no tvdb id', async () => {
+      configurePlex('show');
+      configureSonarr([{ is4k: false }, { is4k: true }]);
+
+      let lookedUpTvdbId: number | undefined;
+      let callCount = 0;
+      getSeriesByTvdbIdImpl = async (id) => {
+        callCount++;
+        if (callCount === 1) {
+          lookedUpTvdbId = id;
+          return fakeSonarrSeries({ tvdbId: 55502 });
+        }
+        throw new Error('Series not found');
+      };
+
+      // TMDB returns no tvdb_id; only the Plex Guid has it
+      getTvShowImpl = async () => fakeTmdbShow(7300);
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexShowItem('show-7300')],
+      });
+      getMetadataImpl = async () =>
+        fakePlexShowMetadata('show-7300', 7300, 55502, [
+          fakePlexSeasonMeta(1, 'season-7300-1'),
+        ]);
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7300 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(lookedUpTvdbId, 55502);
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+    });
+
     it('falls back to Plex episode counting when a show is not in any Sonarr instance', async () => {
       configurePlex('show');
       // No Sonarr match: getSeriesByTvdbIdImpl keeps its throwing default.

--- a/server/lib/scanners/plex/plex.test.ts
+++ b/server/lib/scanners/plex/plex.test.ts
@@ -1,0 +1,547 @@
+import animeList from '@server/api/animelist';
+import type {
+  PlexLibrary,
+  PlexLibraryItem,
+  PlexMetadata,
+} from '@server/api/plexapi';
+import PlexAPI from '@server/api/plexapi';
+import type { RadarrMovie } from '@server/api/servarr/radarr';
+import RadarrAPI from '@server/api/servarr/radarr';
+import type { SonarrSeries } from '@server/api/servarr/sonarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbTvDetails,
+  TmdbTvSeasonResult,
+} from '@server/api/themoviedb/interfaces';
+import { MediaStatus, MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+Object.defineProperty(animeList, 'sync', {
+  value: async () => {},
+  configurable: true,
+  writable: true,
+});
+
+let getLibrariesImpl: () => Promise<PlexLibrary[]> = async () => [];
+let getLibraryContentsImpl: () => Promise<{
+  totalSize: number;
+  items: PlexLibraryItem[];
+}> = async () => ({ totalSize: 0, items: [] });
+let getMetadataImpl: (key: string) => Promise<PlexMetadata> = async () => {
+  throw new Error('No metadata');
+};
+let getChildrenMetadataImpl: (
+  key: string
+) => Promise<PlexMetadata[]> = async () => [];
+let getChildrenCallCount = 0;
+
+Object.defineProperty(PlexAPI.prototype, 'getLibraries', {
+  get() {
+    return async () => getLibrariesImpl();
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(PlexAPI.prototype, 'getLibraryContents', {
+  get() {
+    return async () => getLibraryContentsImpl();
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(PlexAPI.prototype, 'getMetadata', {
+  get() {
+    return async (key: string) => getMetadataImpl(key);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(PlexAPI.prototype, 'getChildrenMetadata', {
+  get() {
+    return async (key: string) => {
+      getChildrenCallCount++;
+      return getChildrenMetadataImpl(key);
+    };
+  },
+  set() {},
+  configurable: true,
+});
+
+let getTvShowImpl: (args: {
+  tvId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+
+Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
+  get() {
+    return async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+let getMovieByTmdbIdImpl: (id: number) => Promise<RadarrMovie> = async () => {
+  throw new Error('Movie not found');
+};
+Object.defineProperty(RadarrAPI.prototype, 'getMovieByTmdbId', {
+  get() {
+    return async (id: number) => getMovieByTmdbIdImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+let getSeriesByTvdbIdImpl: (id: number) => Promise<SonarrSeries> = async () => {
+  throw new Error('Series not found');
+};
+Object.defineProperty(SonarrAPI.prototype, 'getSeriesByTvdbId', {
+  get() {
+    return async (id: number) => getSeriesByTvdbIdImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+import { plexFullScanner } from '@server/lib/scanners/plex';
+
+setupTestDb();
+
+function fakeTmdbShow(
+  tmdbId: number,
+  seasons: TmdbTvSeasonResult[] = [
+    {
+      id: 1,
+      air_date: '2024-01-01',
+      episode_count: 10,
+      name: 'Season 1',
+      overview: '',
+      season_number: 1,
+    },
+  ]
+): TmdbTvDetails {
+  return {
+    id: tmdbId,
+    content_ratings: { results: [] },
+    created_by: [],
+    episode_run_time: [],
+    first_air_date: '2024-01-01',
+    genres: [],
+    homepage: '',
+    in_production: false,
+    languages: ['en'],
+    last_air_date: '2024-01-01',
+    name: 'Test Show',
+    networks: [],
+    number_of_episodes: 10,
+    number_of_seasons: seasons.length,
+    origin_country: ['US'],
+    original_language: 'en',
+    original_name: 'Test Show',
+    overview: '',
+    popularity: 0,
+    production_companies: [],
+    production_countries: [],
+    spoken_languages: [],
+    seasons,
+    status: 'Ended',
+    type: 'Scripted',
+    vote_average: 0,
+    vote_count: 0,
+    aggregate_credits: { cast: [] },
+    credits: { crew: [] },
+    external_ids: {},
+    keywords: { results: [] },
+    videos: { results: [] },
+  };
+}
+
+function fakePlexMedia(
+  videoResolution: string
+): PlexLibraryItem['Media'][number] {
+  return { videoResolution } as PlexLibraryItem['Media'][number];
+}
+
+function fakePlexMovieItem(
+  ratingKey: string,
+  tmdbId: number,
+  videoResolution: string
+): PlexLibraryItem {
+  return {
+    ratingKey,
+    title: 'Test Movie',
+    guid: `tmdb://${tmdbId}`,
+    addedAt: 1700000000,
+    updatedAt: 1700000000,
+    type: 'movie',
+    Media: [fakePlexMedia(videoResolution)],
+  };
+}
+
+function fakePlexShowItem(ratingKey: string): PlexLibraryItem {
+  return {
+    ratingKey,
+    title: 'Test Show',
+    guid: `plex://show/${ratingKey}`,
+    addedAt: 1700000000,
+    updatedAt: 1700000000,
+    type: 'show',
+    Media: [],
+  };
+}
+
+function fakePlexSeasonMeta(index: number, ratingKey: string): PlexMetadata {
+  return {
+    ratingKey,
+    index,
+    title: `Season ${index}`,
+  } as PlexMetadata;
+}
+
+function fakePlexShowMetadata(
+  ratingKey: string,
+  tmdbId: number,
+  tvdbId: number,
+  children: PlexMetadata[]
+): PlexMetadata {
+  return {
+    ratingKey,
+    guid: `plex://show/${ratingKey}`,
+    type: 'show',
+    title: 'Test Show',
+    Guid: [{ id: `tmdb://${tmdbId}` }, { id: `tvdb://${tvdbId}` }],
+    Children: { size: 12, Metadata: children },
+    index: 0,
+    leafCount: 0,
+    viewedLeafCount: 0,
+    addedAt: 1700000000,
+    updatedAt: 1700000000,
+    Media: [],
+  };
+}
+
+function fakePlexEpisodes(
+  count: number,
+  videoResolution: string
+): PlexMetadata[] {
+  return Array.from({ length: count }, (_, i) => ({
+    ratingKey: `ep-${i}`,
+    index: i + 1,
+    Media: [fakePlexMedia(videoResolution)],
+  })) as PlexMetadata[];
+}
+
+function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
+  return {
+    id: 1,
+    tmdbId: 700,
+    hasFile: true,
+    ...overrides,
+  } as RadarrMovie;
+}
+
+function fakeSonarrSeries(overrides: Partial<SonarrSeries> = {}): SonarrSeries {
+  return {
+    id: 1,
+    tvdbId: 12345,
+    title: 'Test Show',
+    statistics: { episodeFileCount: 10 },
+    seasons: [
+      {
+        seasonNumber: 1,
+        monitored: true,
+        statistics: {
+          episodeFileCount: 10,
+          totalEpisodeCount: 10,
+          episodeCount: 10,
+          percentOfEpisodes: 100,
+          sizeOnDisk: 0,
+        },
+      },
+    ],
+    ...overrides,
+  } as SonarrSeries;
+}
+
+function configurePlex(type: 'movie' | 'show' = 'movie'): void {
+  const settings = getSettings();
+  settings.plex.libraries = [
+    { id: 'plex-lib', name: 'Library', enabled: true, type },
+  ];
+}
+
+function configureRadarr(overrides: Partial<RadarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.radarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Radarr ${i}`,
+    hostname: 'localhost',
+    port: 7878,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/movies',
+    is4k: false,
+    minimumAvailability: 'released',
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as RadarrSettings[];
+}
+
+function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.sonarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Sonarr ${i}`,
+    hostname: 'localhost',
+    port: 8989,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/tv',
+    activeLanguageProfileId: 1,
+    is4k: false,
+    enableSeasonFolders: true,
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as SonarrSettings[];
+}
+
+describe('Plex Scanner', () => {
+  beforeEach(() => {
+    getLibrariesImpl = async () => [];
+    getLibraryContentsImpl = async () => ({ totalSize: 0, items: [] });
+    getMetadataImpl = async () => {
+      throw new Error('No metadata');
+    };
+    getChildrenMetadataImpl = async () => [];
+    getChildrenCallCount = 0;
+    getTvShowImpl = async () => fakeTmdbShow(1);
+    getMovieByTmdbIdImpl = async () => {
+      throw new Error('Movie not found');
+    };
+    getSeriesByTvdbIdImpl = async () => {
+      throw new Error('Series not found');
+    };
+
+    const settings = getSettings();
+    settings.radarr = [];
+    settings.sonarr = [];
+  });
+
+  describe('service availability integration', () => {
+    it('uses service-based detection for a movie found in Radarr and skips resolution fallback', async () => {
+      configurePlex('movie');
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+
+      let callCount = 0;
+      getMovieByTmdbIdImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return fakeRadarrMovie({ tmdbId: 7000, hasFile: true });
+        }
+        throw new Error('Movie not found');
+      };
+
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexMovieItem('mv-7000', 7000, '4k')],
+      });
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7000 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(
+        updated.status4k,
+        MediaStatus.UNKNOWN,
+        'Service detection found only a standard file, so the 4K resolution fallback must not run'
+      );
+    });
+
+    it('falls back to resolution-based detection when a movie is not in any Radarr instance', async () => {
+      configurePlex('movie');
+      // No Radarr match: getMovieByTmdbIdImpl keeps its throwing default.
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexMovieItem('mv-7001', 7001, '1080')],
+      });
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7001 },
+      });
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Resolution fallback should mark the standard-resolution file available'
+      );
+      assert.strictEqual(updated.status4k, MediaStatus.UNKNOWN);
+    });
+
+    it('processes both standard and 4K when a movie is found in both Radarr instances', async () => {
+      configurePlex('movie');
+      configureRadarr([{ is4k: false }, { is4k: true }]);
+      getMovieByTmdbIdImpl = async () =>
+        fakeRadarrMovie({ tmdbId: 7002, hasFile: true });
+
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexMovieItem('mv-7002', 7002, '1080')],
+      });
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7002 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(updated.status4k, MediaStatus.AVAILABLE);
+    });
+
+    it('uses Sonarr season counts for a show found in Sonarr without querying children', async () => {
+      configurePlex('show');
+      configureSonarr([{ is4k: false }, { is4k: true }]);
+
+      let callCount = 0;
+      getSeriesByTvdbIdImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return fakeSonarrSeries({ tvdbId: 55501 });
+        }
+        throw new Error('Series not found');
+      };
+
+      getTvShowImpl = async () => fakeTmdbShow(7100);
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexShowItem('show-7100')],
+      });
+      getMetadataImpl = async () =>
+        fakePlexShowMetadata('show-7100', 7100, 55501, [
+          fakePlexSeasonMeta(1, 'season-7100-1'),
+        ]);
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7100 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(
+        getChildrenCallCount,
+        0,
+        'Episode counts should come from Sonarr; getChildrenMetadata must not be called'
+      );
+    });
+
+    it('falls back to Plex episode counting when a show is not in any Sonarr instance', async () => {
+      configurePlex('show');
+      // No Sonarr match: getSeriesByTvdbIdImpl keeps its throwing default.
+      configureSonarr([{ is4k: true }]);
+
+      getTvShowImpl = async () => fakeTmdbShow(7101);
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexShowItem('show-7101')],
+      });
+      getMetadataImpl = async () =>
+        fakePlexShowMetadata('show-7101', 7101, 55601, [
+          fakePlexSeasonMeta(1, 'season-7101-1'),
+        ]);
+      getChildrenMetadataImpl = async (key: string) =>
+        key === 'season-7101-1' ? fakePlexEpisodes(10, '1080') : [];
+
+      await plexFullScanner.run();
+
+      const updated = await getRepository(Media).findOneOrFail({
+        where: { tmdbId: 7101 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+      assert.ok(
+        getChildrenCallCount > 0,
+        'A Sonarr miss should fall back to counting Plex episodes'
+      );
+    });
+
+    it('does not mark a show available when a season is missing from the library', async () => {
+      configurePlex('show');
+
+      const mediaRepository = getRepository(Media);
+      const media = new Media();
+      media.tmdbId = 7102;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [];
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () =>
+        fakeTmdbShow(7102, [
+          {
+            id: 1,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 1',
+            overview: '',
+            season_number: 1,
+          },
+          {
+            id: 2,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 2',
+            overview: '',
+            season_number: 2,
+          },
+        ]);
+      getLibraryContentsImpl = async () => ({
+        totalSize: 1,
+        items: [fakePlexShowItem('show-7102')],
+      });
+      getMetadataImpl = async () =>
+        fakePlexShowMetadata('show-7102', 7102, 55701, [
+          fakePlexSeasonMeta(1, 'season-7102-1'),
+        ]);
+      getChildrenMetadataImpl = async (key: string) =>
+        key === 'season-7102-1' ? fakePlexEpisodes(10, '1080') : [];
+
+      await plexFullScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 7102 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.PARTIALLY_AVAILABLE);
+      const s2 = updated.seasons.find((s) => s.seasonNumber === 2);
+      assert.notStrictEqual(s2, undefined);
+      assert.notStrictEqual(s2?.status, MediaStatus.AVAILABLE);
+    });
+  });
+});

--- a/server/lib/scanners/serviceAvailabilityChecker.ts
+++ b/server/lib/scanners/serviceAvailabilityChecker.ts
@@ -158,10 +158,10 @@ class ServiceAvailabilityChecker {
       }
     }
 
-    const allSeasonNumbers = new Set({
+    const allSeasonNumbers = new Set([
       ...standardSeasons.keys(),
       ...seasons4k.keys(),
-    });
+    ]);
 
     result.seasons = Array.from(allSeasonNumbers).map((seasonNumber) => ({
       seasonNumber,

--- a/server/lib/scanners/serviceAvailabilityChecker.ts
+++ b/server/lib/scanners/serviceAvailabilityChecker.ts
@@ -1,0 +1,193 @@
+import RadarrAPI from '@server/api/servarr/radarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+
+interface InstanceAvailability {
+  hasStandard: boolean;
+  has4k: boolean;
+  serviceStandardId?: number;
+  service4kId?: number;
+  externalStandardId?: number;
+  external4kId?: number;
+}
+
+interface SeasonInstanceAvailability {
+  seasonNumber: number;
+  episodesStandard: number;
+  episodes4k: number;
+}
+
+interface ShowInstanceAvailability extends InstanceAvailability {
+  seasons: SeasonInstanceAvailability[];
+}
+
+class ServiceAvailabilityChecker {
+  private movieCache: Map<number, InstanceAvailability>;
+  private showCache: Map<number, ShowInstanceAvailability>;
+
+  constructor() {
+    this.movieCache = new Map();
+    this.showCache = new Map();
+  }
+
+  public clearCache(): void {
+    this.movieCache.clear();
+    this.showCache.clear();
+  }
+
+  public async checkMovieAvailability(
+    tmdbid: number
+  ): Promise<InstanceAvailability> {
+    const cached = this.movieCache.get(tmdbid);
+    if (cached) {
+      return cached;
+    }
+
+    const settings = getSettings();
+    const result: InstanceAvailability = {
+      hasStandard: false,
+      has4k: false,
+    };
+
+    if (!settings.radarr || settings.radarr.length === 0) {
+      return result;
+    }
+
+    for (const radarrSettings of settings.radarr) {
+      try {
+        const radarr = this.createRadarrClient(radarrSettings);
+        const movie = await radarr.getMovieByTmdbId(tmdbid);
+
+        if (movie?.hasFile) {
+          if (radarrSettings.is4k) {
+            result.has4k = true;
+            result.service4kId = radarrSettings.id;
+            result.external4kId = movie.id;
+          } else {
+            result.hasStandard = true;
+            result.serviceStandardId = radarrSettings.id;
+            result.externalStandardId = movie.id;
+          }
+        }
+
+        logger.debug(
+          `Found movie (TMDB: ${tmdbid}) in ${
+            radarrSettings.is4k ? '4K' : 'Standard'
+          } Radarr instance (name: ${radarrSettings.name})`,
+          {
+            label: 'Service Availability',
+            radarrId: radarrSettings.id,
+            movieId: movie?.id,
+          }
+        );
+      } catch {
+        // movie not found in this instance, continue
+      }
+    }
+
+    this.movieCache.set(tmdbid, result);
+    return result;
+  }
+
+  public async checkShowAvailability(
+    tvdbid: number
+  ): Promise<ShowInstanceAvailability> {
+    const cached = this.showCache.get(tvdbid);
+    if (cached) {
+      return cached;
+    }
+
+    const settings = getSettings();
+    const result: ShowInstanceAvailability = {
+      hasStandard: false,
+      has4k: false,
+      seasons: [],
+    };
+
+    if (!settings.sonarr || settings.sonarr.length === 0) {
+      return result;
+    }
+    const standardSeasons = new Map<number, number>();
+    const seasons4k = new Map<number, number>();
+
+    for (const sonarrSettings of settings.sonarr) {
+      try {
+        const sonarr = this.createSonarrClient(sonarrSettings);
+        const series = await sonarr.getSeriesByTvdbId(tvdbid);
+
+        if (series?.id && series.statistics?.episodeFileCount > 0) {
+          if (sonarrSettings.is4k) {
+            result.has4k = true;
+            result.service4kId = sonarrSettings.id;
+            result.external4kId = series.id;
+          } else {
+            result.hasStandard = true;
+            result.serviceStandardId = sonarrSettings.id;
+            result.externalStandardId = series.id;
+          }
+
+          for (const season of series.seasons) {
+            const episodeCount = season.statistics?.episodeFileCount ?? 0;
+            if (episodeCount > 0) {
+              const targetMap = sonarrSettings.is4k
+                ? seasons4k
+                : standardSeasons;
+              const current = targetMap.get(season.seasonNumber) ?? 0;
+              targetMap.set(
+                season.seasonNumber,
+                Math.max(current, episodeCount)
+              );
+            }
+          }
+
+          logger.debug(
+            `Found series (TVDB: ${tvdbid}) in ${
+              sonarrSettings.is4k ? '4K' : 'Standard'
+            } Sonarr instance (name: ${sonarrSettings.name}`,
+            {
+              label: 'Service Availability',
+              sonarrId: sonarrSettings.id,
+              seriesId: series.id,
+            }
+          );
+        }
+      } catch {
+        // series not found in this instance, continue
+      }
+    }
+
+    const allSeasonNumbers = new Set({
+      ...standardSeasons.keys(),
+      ...seasons4k.keys(),
+    });
+
+    result.seasons = Array.from(allSeasonNumbers).map((seasonNumber) => ({
+      seasonNumber,
+      episodesStandard: standardSeasons.get(seasonNumber) ?? 0,
+      episodes4k: seasons4k.get(seasonNumber) ?? 0,
+    }));
+
+    this.showCache.set(tvdbid, result);
+    return result;
+  }
+
+  private createRadarrClient(settings: RadarrSettings): RadarrAPI {
+    return new RadarrAPI({
+      url: RadarrAPI.buildUrl(settings, '/api/v3'),
+      apiKey: settings.apiKey,
+    });
+  }
+
+  private createSonarrClient(settings: SonarrSettings): SonarrAPI {
+    return new SonarrAPI({
+      url: SonarrAPI.buildUrl(settings, '/api/v3'),
+      apiKey: settings.apiKey,
+    });
+  }
+}
+
+const serviceAvailabilityChecker = new ServiceAvailabilityChecker();
+
+export default serviceAvailabilityChecker;

--- a/server/lib/scanners/serviceAvailabilityChecker.ts
+++ b/server/lib/scanners/serviceAvailabilityChecker.ts
@@ -145,7 +145,7 @@ class ServiceAvailabilityChecker {
           logger.debug(
             `Found series (TVDB: ${tvdbid}) in ${
               sonarrSettings.is4k ? '4K' : 'Standard'
-            } Sonarr instance (name: ${sonarrSettings.name}`,
+            } Sonarr instance (name: ${sonarrSettings.name})`,
             {
               label: 'Service Availability',
               sonarrId: sonarrSettings.id,

--- a/server/lib/scanners/serviceAvailabilityChecker.ts
+++ b/server/lib/scanners/serviceAvailabilityChecker.ts
@@ -19,7 +19,7 @@ interface SeasonInstanceAvailability {
   episodes4k: number;
 }
 
-interface ShowInstanceAvailability extends InstanceAvailability {
+export interface ShowInstanceAvailability extends InstanceAvailability {
   seasons: SeasonInstanceAvailability[];
 }
 

--- a/server/lib/scanners/serviceAvailabilityChecker.ts
+++ b/server/lib/scanners/serviceAvailabilityChecker.ts
@@ -3,6 +3,7 @@ import SonarrAPI from '@server/api/servarr/sonarr';
 import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import axios from 'axios';
 
 interface InstanceAvailability {
   hasStandard: boolean;
@@ -82,7 +83,17 @@ class ServiceAvailabilityChecker {
             movieId: movie?.id,
           }
         );
-      } catch {
+      } catch (error) {
+        if (axios.isAxiosError((error as Error)?.cause)) {
+          logger.warn(
+            'Could not reach Radarr instance during availability check',
+            {
+              label: 'Service Availability',
+              radarrId: radarrSettings.id,
+              errorMessage: ((error as Error).cause as Error).message,
+            }
+          );
+        }
         // movie not found in this instance, continue
       }
     }
@@ -153,7 +164,17 @@ class ServiceAvailabilityChecker {
             }
           );
         }
-      } catch {
+      } catch (error) {
+        if (axios.isAxiosError((error as Error)?.cause)) {
+          logger.warn(
+            'Could not reach Sonarr instance during availability check',
+            {
+              label: 'Service Availability',
+              sonarrId: sonarrSettings.id,
+              errorMessage: ((error as Error).cause as Error).message,
+            }
+          );
+        }
         // series not found in this instance, continue
       }
     }


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

When a 4K request results in a lower resolution file (e.g., 1080p while waiting for a 4K release), the Jellyfin/Plex scanner previously used resolution to determine availability, incorrectly marking these files as `Available`. This caused non-4K users to see phantom availability for content only in the 4K library.

This PR adds `ServiceAvailabilityChecker` that queries Radarr/Sonarr instances to determine which tier has the file based on which instance it came from, not resolution. Falls back to resolution-based detection for manually added media. No impact on users without 4K instances configured.

- Fixes #1744 

## How Has This Been Tested?

This has not been tested by me. But unit tests have been added to test the service availability integration

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Movie and show 4K/standard availability now uses Radarr/Sonarr service availability data when enabled, improving accuracy for “what’s actually available.”
  * If service data is missing, the system automatically falls back to resolution-based detection or library-derived episode counting.
  * Jellyfin and Plex scanners now refresh cached service results at sync start.

* **Tests**
  * Added end-to-end integration coverage for service-based and fallback availability scenarios for movies and shows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->