### PR TITLE
feat(scanner): add option to exclusively use Radarr/Sonarr for availability

### DIFF
--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -139,28 +139,55 @@ class AvailabilitySync {
 
           // plex
           if (mediaServerType === MediaServerType.PLEX) {
-            const { existsInPlex } = await this.mediaExistsInPlex(media, false);
-            const { existsInPlex: existsInPlex4k } =
-              await this.mediaExistsInPlex(media, true);
+            if (settings.main.prioritizeRadarrSonarr) {
+              // When prioritizing Radarr/Sonarr, use ONLY Radarr availability
+              if (existsInRadarr) {
+                movieExists = true;
+                logger.info(
+                  `The non-4K movie [TMDB ID ${media.tmdbId}] still exists in Radarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
 
-            if (existsInPlex || existsInRadarr) {
-              movieExists = true;
-              logger.info(
-                `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
+              if (existsInRadarr4k) {
+                movieExists4k = true;
+                logger.info(
+                  `The 4K movie [TMDB ID ${media.tmdbId}] still exists in Radarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+            } else {
+              // Original OR logic: check both Plex AND Radarr
+              const { existsInPlex } = await this.mediaExistsInPlex(
+                media,
+                false
               );
-            }
+              const { existsInPlex: existsInPlex4k } =
+                await this.mediaExistsInPlex(media, true);
 
-            if (existsInPlex4k || existsInRadarr4k) {
-              movieExists4k = true;
-              logger.info(
-                `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
+              if (existsInPlex || existsInRadarr) {
+                movieExists = true;
+                logger.info(
+                  `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+
+              if (existsInPlex4k || existsInRadarr4k) {
+                movieExists4k = true;
+                logger.info(
+                  `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
             }
           }
 
@@ -169,31 +196,55 @@ class AvailabilitySync {
             mediaServerType === MediaServerType.JELLYFIN ||
             mediaServerType === MediaServerType.EMBY
           ) {
-            const { existsInJellyfin } = await this.mediaExistsInJellyfin(
-              media,
-              false
-            );
-            const { existsInJellyfin: existsInJellyfin4k } =
-              await this.mediaExistsInJellyfin(media, true);
+            if (settings.main.prioritizeRadarrSonarr) {
+              // When prioritizing Radarr/Sonarr, use ONLY Radarr availability
+              if (existsInRadarr) {
+                movieExists = true;
+                logger.info(
+                  `The non-4K movie [TMDB ID ${media.tmdbId}] still exists in Radarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
 
-            if (existsInJellyfin || existsInRadarr) {
-              movieExists = true;
-              logger.info(
-                `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
+              if (existsInRadarr4k) {
+                movieExists4k = true;
+                logger.info(
+                  `The 4K movie [TMDB ID ${media.tmdbId}] still exists in Radarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+            } else {
+              // Original OR logic: check both Jellyfin AND Radarr
+              const { existsInJellyfin } = await this.mediaExistsInJellyfin(
+                media,
+                false
               );
-            }
+              const { existsInJellyfin: existsInJellyfin4k } =
+                await this.mediaExistsInJellyfin(media, true);
 
-            if (existsInJellyfin4k || existsInRadarr4k) {
-              movieExists4k = true;
-              logger.info(
-                `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
+              if (existsInJellyfin || existsInRadarr) {
+                movieExists = true;
+                logger.info(
+                  `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+
+              if (existsInJellyfin4k || existsInRadarr4k) {
+                movieExists4k = true;
+                logger.info(
+                  `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
             }
           }
 
@@ -212,25 +263,13 @@ class AvailabilitySync {
           let showExists = false;
           let showExists4k = false;
 
-          //plex
+          // Initialize season maps
+          let plexSeasonsMap = new Map<number, boolean>();
+          let plexSeasonsMap4k = new Map<number, boolean>();
+          let jellyfinSeasonsMap = new Map<number, boolean>();
+          let jellyfinSeasonsMap4k = new Map<number, boolean>();
 
-          const { existsInPlex, seasonsMap: plexSeasonsMap = new Map() } =
-            await this.mediaExistsInPlex(media, false);
-          const {
-            existsInPlex: existsInPlex4k,
-            seasonsMap: plexSeasonsMap4k = new Map(),
-          } = await this.mediaExistsInPlex(media, true);
-
-          //jellyfin
-          const {
-            existsInJellyfin,
-            seasonsMap: jellyfinSeasonsMap = new Map(),
-          } = await this.mediaExistsInJellyfin(media, false);
-          const {
-            existsInJellyfin: existsInJellyfin4k,
-            seasonsMap: jellyfinSeasonsMap4k = new Map(),
-          } = await this.mediaExistsInJellyfin(media, true);
-
+          // Always check Sonarr first
           const { existsInSonarr, seasonsMap: sonarrSeasonsMap } =
             await this.mediaExistsInSonarr(media, false);
           const {
@@ -240,26 +279,60 @@ class AvailabilitySync {
 
           //plex
           if (mediaServerType === MediaServerType.PLEX) {
-            if (existsInPlex || existsInSonarr) {
-              showExists = true;
-              logger.info(
-                `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
-            }
-          }
+            if (settings.main.prioritizeRadarrSonarr) {
+              // When prioritizing Radarr/Sonarr, use ONLY Sonarr availability
+              if (existsInSonarr) {
+                showExists = true;
+                logger.info(
+                  `The non-4K show [TMDB ID ${media.tmdbId}] still exists in Sonarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
 
-          if (mediaServerType === MediaServerType.PLEX) {
-            if (existsInPlex4k || existsInSonarr4k) {
-              showExists4k = true;
-              logger.info(
-                `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
+              if (existsInSonarr4k) {
+                showExists4k = true;
+                logger.info(
+                  `The 4K show [TMDB ID ${media.tmdbId}] still exists in Sonarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+            } else {
+              // Original OR logic: check both Plex AND Sonarr
+              const {
+                existsInPlex,
+                seasonsMap: plexSeasonsMapResult = new Map(),
+              } = await this.mediaExistsInPlex(media, false);
+              const {
+                existsInPlex: existsInPlex4k,
+                seasonsMap: plexSeasonsMap4kResult = new Map(),
+              } = await this.mediaExistsInPlex(media, true);
+
+              plexSeasonsMap = plexSeasonsMapResult;
+              plexSeasonsMap4k = plexSeasonsMap4kResult;
+
+              if (existsInPlex || existsInSonarr) {
+                showExists = true;
+                logger.info(
+                  `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+
+              if (existsInPlex4k || existsInSonarr4k) {
+                showExists4k = true;
+                logger.info(
+                  `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
             }
           }
 
@@ -268,29 +341,60 @@ class AvailabilitySync {
             mediaServerType === MediaServerType.JELLYFIN ||
             mediaServerType === MediaServerType.EMBY
           ) {
-            if (existsInJellyfin || existsInSonarr) {
-              showExists = true;
-              logger.info(
-                `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
-            }
-          }
+            if (settings.main.prioritizeRadarrSonarr) {
+              // When prioritizing Radarr/Sonarr, use ONLY Sonarr availability
+              if (existsInSonarr) {
+                showExists = true;
+                logger.info(
+                  `The non-4K show [TMDB ID ${media.tmdbId}] still exists in Sonarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
 
-          if (
-            mediaServerType === MediaServerType.JELLYFIN ||
-            mediaServerType === MediaServerType.EMBY
-          ) {
-            if (existsInJellyfin4k || existsInSonarr4k) {
-              showExists4k = true;
-              logger.info(
-                `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
-                {
-                  label: 'AvailabilitySync',
-                }
-              );
+              if (existsInSonarr4k) {
+                showExists4k = true;
+                logger.info(
+                  `The 4K show [TMDB ID ${media.tmdbId}] still exists in Sonarr. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+            } else {
+              // Original OR logic: check both Jellyfin AND Sonarr
+              const {
+                existsInJellyfin,
+                seasonsMap: jellyfinSeasonsMapResult = new Map(),
+              } = await this.mediaExistsInJellyfin(media, false);
+              const {
+                existsInJellyfin: existsInJellyfin4k,
+                seasonsMap: jellyfinSeasonsMap4kResult = new Map(),
+              } = await this.mediaExistsInJellyfin(media, true);
+
+              jellyfinSeasonsMap = jellyfinSeasonsMapResult;
+              jellyfinSeasonsMap4k = jellyfinSeasonsMap4kResult;
+
+              if (existsInJellyfin || existsInSonarr) {
+                showExists = true;
+                logger.info(
+                  `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
+
+              if (existsInJellyfin4k || existsInSonarr4k) {
+                showExists4k = true;
+                logger.info(
+                  `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
+                  {
+                    label: 'AvailabilitySync',
+                  }
+                );
+              }
             }
           }
 
@@ -310,6 +414,66 @@ class AvailabilitySync {
               filteredSeasonsMap.set(season.seasonNumber, false)
             );
 
+          // non-4k
+          const finalSeasons: Map<number, boolean> = new Map();
+
+          if (mediaServerType === MediaServerType.PLEX) {
+            if (settings.main.prioritizeRadarrSonarr) {
+              filteredSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+
+              sonarrSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+            } else {
+              plexSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+
+              filteredSeasonsMap.forEach((value, key) => {
+                if (!finalSeasons.has(key)) {
+                  finalSeasons.set(key, value);
+                }
+              });
+
+              sonarrSeasonsMap.forEach((value, key) => {
+                if (!finalSeasons.has(key)) {
+                  finalSeasons.set(key, value);
+                }
+              });
+            }
+          } else if (
+            mediaServerType === MediaServerType.JELLYFIN ||
+            mediaServerType === MediaServerType.EMBY
+          ) {
+            if (settings.main.prioritizeRadarrSonarr) {
+              filteredSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+
+              sonarrSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+            } else {
+              jellyfinSeasonsMap.forEach((value, key) => {
+                finalSeasons.set(key, value);
+              });
+
+              filteredSeasonsMap.forEach((value, key) => {
+                if (!finalSeasons.has(key)) {
+                  finalSeasons.set(key, value);
+                }
+              });
+
+              sonarrSeasonsMap.forEach((value, key) => {
+                if (!finalSeasons.has(key)) {
+                  finalSeasons.set(key, value);
+                }
+              });
+            }
+          }
+
           const filteredSeasonsMap4k: Map<number, boolean> = new Map();
           media.seasons
             .filter(
@@ -321,32 +485,63 @@ class AvailabilitySync {
               filteredSeasonsMap4k.set(season.seasonNumber, false)
             );
 
-          let finalSeasons: Map<number, boolean>;
-          let finalSeasons4k: Map<number, boolean>;
+          const finalSeasons4k: Map<number, boolean> = new Map();
 
           if (mediaServerType === MediaServerType.PLEX) {
-            finalSeasons = new Map([
-              ...filteredSeasonsMap,
-              ...plexSeasonsMap,
-              ...sonarrSeasonsMap,
-            ]);
-            finalSeasons4k = new Map([
-              ...filteredSeasonsMap4k,
-              ...plexSeasonsMap4k,
-              ...sonarrSeasonsMap4k,
-            ]);
-          } else {
-            // Jellyfin/Emby
-            finalSeasons = new Map([
-              ...filteredSeasonsMap,
-              ...jellyfinSeasonsMap,
-              ...sonarrSeasonsMap,
-            ]);
-            finalSeasons4k = new Map([
-              ...filteredSeasonsMap4k,
-              ...jellyfinSeasonsMap4k,
-              ...sonarrSeasonsMap4k,
-            ]);
+            if (settings.main.prioritizeRadarrSonarr) {
+              filteredSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+
+              sonarrSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+            } else {
+              plexSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+
+              filteredSeasonsMap4k.forEach((value, key) => {
+                if (!finalSeasons4k.has(key)) {
+                  finalSeasons4k.set(key, value);
+                }
+              });
+
+              sonarrSeasonsMap4k.forEach((value, key) => {
+                if (!finalSeasons4k.has(key)) {
+                  finalSeasons4k.set(key, value);
+                }
+              });
+            }
+          } else if (
+            mediaServerType === MediaServerType.JELLYFIN ||
+            mediaServerType === MediaServerType.EMBY
+          ) {
+            if (settings.main.prioritizeRadarrSonarr) {
+              filteredSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+
+              sonarrSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+            } else {
+              jellyfinSeasonsMap4k.forEach((value, key) => {
+                finalSeasons4k.set(key, value);
+              });
+
+              filteredSeasonsMap4k.forEach((value, key) => {
+                if (!finalSeasons4k.has(key)) {
+                  finalSeasons4k.set(key, value);
+                }
+              });
+
+              sonarrSeasonsMap4k.forEach((value, key) => {
+                if (!finalSeasons4k.has(key)) {
+                  finalSeasons4k.set(key, value);
+                }
+              });
+            }
           }
 
           if (
@@ -447,6 +642,7 @@ class AvailabilitySync {
     mediaServerType: MediaServerType
   ): Promise<void> {
     const mediaRepository = getRepository(Media);
+    const settings = getSettings();
 
     try {
       // If media type is tv, check if a season is processing
@@ -476,10 +672,12 @@ class AvailabilitySync {
         }
       }
 
-      // Set the non-4K or 4K media to deleted
-      // and change related columns to null if media
-      // is not processing
-      media[is4k ? 'status4k' : 'status'] = MediaStatus.DELETED;
+      // When prioritizing Radarr/Sonarr, set status to UNKNOWN instead of DELETED
+      // (placeholder files were never legitimate, so they're not "deleted")
+      // Otherwise use DELETED (natural Seerr flow for removed media)
+      media[is4k ? 'status4k' : 'status'] = settings.main.prioritizeRadarrSonarr
+        ? MediaStatus.UNKNOWN
+        : MediaStatus.DELETED;
       media[is4k ? 'serviceId4k' : 'serviceId'] = isMediaProcessing
         ? media[is4k ? 'serviceId4k' : 'serviceId']
         : null;
@@ -504,18 +702,27 @@ class AvailabilitySync {
             ? media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId']
             : null;
       }
+      const newStatus = settings.main.prioritizeRadarrSonarr
+        ? 'unknown'
+        : 'deleted';
+      const searchLocation = settings.main.prioritizeRadarrSonarr
+        ? media.mediaType === 'movie'
+          ? 'Radarr'
+          : 'Sonarr'
+        : `${media.mediaType === 'movie' ? 'Radarr' : 'Sonarr'} and ${
+            mediaServerType === MediaServerType.PLEX
+              ? 'Plex'
+              : mediaServerType === MediaServerType.JELLYFIN
+              ? 'Jellyfin'
+              : 'Emby'
+          }`;
+
       logger.info(
         `The ${is4k ? '4K' : 'non-4K'} ${
           media.mediaType === 'movie' ? 'movie' : 'show'
-        } [TMDB ID ${media.tmdbId}] was not found in any ${
-          media.mediaType === 'movie' ? 'Radarr' : 'Sonarr'
-        } and ${
-          mediaServerType === MediaServerType.PLEX
-            ? 'plex'
-            : mediaServerType === MediaServerType.JELLYFIN
-              ? 'jellyfin'
-              : 'emby'
-        } instance. Status will be changed to deleted.`,
+        } [TMDB ID ${
+          media.tmdbId
+        }] was not found in ${searchLocation}. Status will be changed to ${newStatus}.`,
         { label: 'AvailabilitySync' }
       );
 
@@ -540,6 +747,7 @@ class AvailabilitySync {
     mediaServerType: MediaServerType
   ): Promise<void> {
     const mediaRepository = getRepository(Media);
+    const settings = getSettings();
 
     // Filter out only the values that are false
     // (media that should be deleted)
@@ -554,9 +762,14 @@ class AvailabilitySync {
     // let isSeasonRemoved = false;
 
     try {
+      // When prioritizing Radarr/Sonarr, set status to UNKNOWN instead of DELETED
+      const removalStatus = settings.main.prioritizeRadarrSonarr
+        ? MediaStatus.UNKNOWN
+        : MediaStatus.DELETED;
+
       for (const mediaSeason of media.seasons) {
         if (seasonsPendingRemoval.has(mediaSeason.seasonNumber)) {
-          mediaSeason[is4k ? 'status4k' : 'status'] = MediaStatus.DELETED;
+          mediaSeason[is4k ? 'status4k' : 'status'] = removalStatus;
         }
       }
 
@@ -579,18 +792,25 @@ class AvailabilitySync {
       media.lastSeasonChange = new Date();
       await mediaRepository.save(media);
 
+      const newStatus = settings.main.prioritizeRadarrSonarr
+        ? 'unknown'
+        : 'deleted';
+      const searchLocation = settings.main.prioritizeRadarrSonarr
+        ? media.mediaType === 'tv'
+          ? 'Sonarr'
+          : 'Radarr'
+        : `${media.mediaType === 'tv' ? 'Sonarr' : 'Radarr'} and ${
+            mediaServerType === MediaServerType.PLEX
+              ? 'Plex'
+              : mediaServerType === MediaServerType.JELLYFIN
+              ? 'Jellyfin'
+              : 'Emby'
+          }`;
+
       logger.info(
         `The ${is4k ? '4K' : 'non-4K'} season(s) [${seasonKeys}] [TMDB ID ${
           media.tmdbId
-        }] was not found in any ${
-          media.mediaType === 'tv' ? 'Sonarr' : 'Radarr'
-        } and ${
-          mediaServerType === MediaServerType.PLEX
-            ? 'plex'
-            : mediaServerType === MediaServerType.JELLYFIN
-              ? 'jellyfin'
-              : 'emby'
-        } instance. Status will be changed to deleted.`,
+        }] was not found in ${searchLocation}. Status will be changed to ${newStatus}.`,
         { label: 'AvailabilitySync' }
       );
     } catch (ex) {

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -678,29 +678,37 @@ class AvailabilitySync {
       media[is4k ? 'status4k' : 'status'] = settings.main.prioritizeRadarrSonarr
         ? MediaStatus.UNKNOWN
         : MediaStatus.DELETED;
-      media[is4k ? 'serviceId4k' : 'serviceId'] = isMediaProcessing
-        ? media[is4k ? 'serviceId4k' : 'serviceId']
-        : null;
+
+      // When prioritizing Radarr/Sonarr, always clear metadata since the item
+      // doesn't exist in Radarr/Sonarr (even if there's a pending request)
+      // Otherwise, only clear if not processing
+      const shouldClearMetadata =
+        settings.main.prioritizeRadarrSonarr || !isMediaProcessing;
+
+      media[is4k ? 'serviceId4k' : 'serviceId'] = shouldClearMetadata
+        ? null
+        : media[is4k ? 'serviceId4k' : 'serviceId'];
       media[is4k ? 'externalServiceId4k' : 'externalServiceId'] =
-        isMediaProcessing
-          ? media[is4k ? 'externalServiceId4k' : 'externalServiceId']
-          : null;
+        shouldClearMetadata
+          ? null
+          : media[is4k ? 'externalServiceId4k' : 'externalServiceId'];
       media[is4k ? 'externalServiceSlug4k' : 'externalServiceSlug'] =
-        isMediaProcessing
-          ? media[is4k ? 'externalServiceSlug4k' : 'externalServiceSlug']
-          : null;
+        shouldClearMetadata
+          ? null
+          : media[is4k ? 'externalServiceSlug4k' : 'externalServiceSlug'];
+
       if (mediaServerType === MediaServerType.PLEX) {
-        media[is4k ? 'ratingKey4k' : 'ratingKey'] = isMediaProcessing
-          ? media[is4k ? 'ratingKey4k' : 'ratingKey']
-          : null;
+        media[is4k ? 'ratingKey4k' : 'ratingKey'] = shouldClearMetadata
+          ? null
+          : media[is4k ? 'ratingKey4k' : 'ratingKey'];
       } else if (
         mediaServerType === MediaServerType.JELLYFIN ||
         mediaServerType === MediaServerType.EMBY
       ) {
         media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId'] =
-          isMediaProcessing
-            ? media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId']
-            : null;
+          shouldClearMetadata
+            ? null
+            : media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId'];
       }
       const newStatus = settings.main.prioritizeRadarrSonarr
         ? 'unknown'

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -109,6 +109,13 @@ class BaseScanner<T> {
     const mediaRepository = getRepository(Media);
     const settings = getSettings();
 
+    // Skip status updates ONLY when prioritizing Radarr/Sonarr AND this is from a media server
+    // (ratingKey/jellyfinMediaId indicates Plex/Jellyfin scanner; Radarr/Sonarr don't provide these)
+    const isFromMediaServer =
+      ratingKey !== undefined || jellyfinMediaId !== undefined;
+    const shouldSkipStatusUpdate =
+      settings.main.prioritizeRadarrSonarr && isFromMediaServer;
+
     await this.asyncLock.dispatch(tmdbId, async () => {
       const existing = await this.getExisting(tmdbId, MediaType.MOVIE);
 
@@ -116,7 +123,7 @@ class BaseScanner<T> {
         let changedExisting = false;
 
         if (
-          !settings.main.prioritizeRadarrSonarr &&
+          !shouldSkipStatusUpdate &&
           existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE
         ) {
           existing[is4k ? 'status4k' : 'status'] = !processing
@@ -130,10 +137,10 @@ class BaseScanner<T> {
           changedExisting = true;
         }
 
-        // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
-        // (otherwise Plex/Jellyfin could set wrong dates)
+        // Only update mediaAddedAt if not from Plex when prioritizing Radarr/Sonarr
+        // (otherwise Plex could set wrong dates)
         if (
-          !settings.main.prioritizeRadarrSonarr &&
+          !shouldSkipStatusUpdate &&
           !changedExisting &&
           !existing.mediaAddedAt &&
           mediaAddedAt
@@ -203,8 +210,8 @@ class BaseScanner<T> {
           this.log(`Title already exists and no changes detected for ${title}`);
         }
       } else {
-        // Skip creating new media when prioritizing Radarr/Sonarr
-        if (settings.main.prioritizeRadarrSonarr) {
+        // Skip creating new media when prioritizing Radarr/Sonarr AND this is from a media server
+        if (shouldSkipStatusUpdate) {
           this.log(
             `Skipping creation of new media for ${title} (Radarr/Sonarr priority mode enabled)`,
             'debug'
@@ -286,6 +293,13 @@ class BaseScanner<T> {
     const mediaRepository = getRepository(Media);
     const settings = getSettings();
 
+    // Skip status updates ONLY when prioritizing Radarr/Sonarr AND this is from a media server
+    // (ratingKey/jellyfinMediaId indicates Plex/Jellyfin scanner; Radarr/Sonarr don't provide these)
+    const isFromMediaServer =
+      ratingKey !== undefined || jellyfinMediaId !== undefined;
+    const shouldSkipStatusUpdate =
+      settings.main.prioritizeRadarrSonarr && isFromMediaServer;
+
     await this.asyncLock.dispatch(tmdbId, async () => {
       const media = await this.getExisting(tmdbId, MediaType.TV);
 
@@ -343,7 +357,8 @@ class BaseScanner<T> {
           // Here we update seasons if they already exist.
           // If the season is already marked as available, we
           // force it to stay available (to avoid competing scanners)
-          if (!settings.main.prioritizeRadarrSonarr) {
+          // Skip status updates when from Plex and prioritizing Radarr/Sonarr
+          if (!shouldSkipStatusUpdate) {
             existingSeason.status =
               (season.totalEpisodes === season.episodes && season.episodes > 0) ||
               existingSeason.status === MediaStatus.AVAILABLE
@@ -381,7 +396,8 @@ class BaseScanner<T> {
                       : existingSeason.status4k;
           }
         } else {
-          if (!settings.main.prioritizeRadarrSonarr) {
+          // Skip creating new seasons when from Plex and prioritizing Radarr/Sonarr
+          if (!shouldSkipStatusUpdate) {
             newSeasons.push(
               new Season({
                 seasonNumber: season.seasonNumber,
@@ -435,8 +451,8 @@ class BaseScanner<T> {
           );
           media.lastSeasonChange = new Date();
 
-          // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
-          if (!settings.main.prioritizeRadarrSonarr && mediaAddedAt) {
+          // Only update mediaAddedAt if not from Plex when prioritizing Radarr/Sonarr
+          if (!shouldSkipStatusUpdate && mediaAddedAt) {
             media.mediaAddedAt = mediaAddedAt;
           }
         }
@@ -451,12 +467,8 @@ class BaseScanner<T> {
           media.lastSeasonChange = new Date();
         }
 
-        // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
-        if (
-          !settings.main.prioritizeRadarrSonarr &&
-          !media.mediaAddedAt &&
-          mediaAddedAt
-        ) {
+        // Only update mediaAddedAt if not from Plex when prioritizing Radarr/Sonarr
+        if (!shouldSkipStatusUpdate && !media.mediaAddedAt && mediaAddedAt) {
           media.mediaAddedAt = mediaAddedAt;
         }
 
@@ -503,7 +515,8 @@ class BaseScanner<T> {
               season.seasonNumber !== 0
           ).length === 0;
 
-        if (!settings.main.prioritizeRadarrSonarr) {
+        // Only update media status if not from Plex when prioritizing Radarr/Sonarr
+        if (!shouldSkipStatusUpdate) {
           media.status =
             isAllStandardSeasonsAvailable || shouldStayAvailable
               ? MediaStatus.AVAILABLE
@@ -544,8 +557,8 @@ class BaseScanner<T> {
         await mediaRepository.save(media);
         this.log(`Updating existing title: ${title}`);
       } else {
-        // Skip creating new media when prioritizing Radarr/Sonarr
-        if (settings.main.prioritizeRadarrSonarr) {
+        // Skip creating new media when prioritizing Radarr/Sonarr AND this is from a media server
+        if (shouldSkipStatusUpdate) {
           this.log(
             `Skipping creation of new show for ${title} (Radarr/Sonarr priority mode enabled)`,
             'debug'

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -107,6 +107,7 @@ class BaseScanner<T> {
     }: ProcessOptions = {}
   ): Promise<void> {
     const mediaRepository = getRepository(Media);
+    const settings = getSettings();
 
     await this.asyncLock.dispatch(tmdbId, async () => {
       const existing = await this.getExisting(tmdbId, MediaType.MOVIE);
@@ -114,7 +115,10 @@ class BaseScanner<T> {
       if (existing) {
         let changedExisting = false;
 
-        if (existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE) {
+        if (
+          !settings.main.prioritizeRadarrSonarr &&
+          existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE
+        ) {
           existing[is4k ? 'status4k' : 'status'] = !processing
             ? MediaStatus.AVAILABLE
             : existing[is4k ? 'status4k' : 'status'] === MediaStatus.DELETED
@@ -126,7 +130,14 @@ class BaseScanner<T> {
           changedExisting = true;
         }
 
-        if (!changedExisting && !existing.mediaAddedAt && mediaAddedAt) {
+        // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
+        // (otherwise Plex/Jellyfin could set wrong dates)
+        if (
+          !settings.main.prioritizeRadarrSonarr &&
+          !changedExisting &&
+          !existing.mediaAddedAt &&
+          mediaAddedAt
+        ) {
           existing.mediaAddedAt = mediaAddedAt;
           changedExisting = true;
         }
@@ -192,6 +203,15 @@ class BaseScanner<T> {
           this.log(`Title already exists and no changes detected for ${title}`);
         }
       } else {
+        // Skip creating new media when prioritizing Radarr/Sonarr
+        if (settings.main.prioritizeRadarrSonarr) {
+          this.log(
+            `Skipping creation of new media for ${title} (Radarr/Sonarr priority mode enabled)`,
+            'debug'
+          );
+          return;
+        }
+
         const newMedia = new Media();
         newMedia.tmdbId = tmdbId;
         newMedia.imdbId = imdbId;
@@ -264,6 +284,7 @@ class BaseScanner<T> {
     }: ProcessOptions = {}
   ): Promise<void> {
     const mediaRepository = getRepository(Media);
+    const settings = getSettings();
 
     await this.asyncLock.dispatch(tmdbId, async () => {
       const media = await this.getExisting(tmdbId, MediaType.TV);
@@ -322,66 +343,69 @@ class BaseScanner<T> {
           // Here we update seasons if they already exist.
           // If the season is already marked as available, we
           // force it to stay available (to avoid competing scanners)
-          existingSeason.status =
-            (season.totalEpisodes === season.episodes && season.episodes > 0) ||
-            existingSeason.status === MediaStatus.AVAILABLE
-              ? MediaStatus.AVAILABLE
-              : season.episodes > 0
-                ? MediaStatus.PARTIALLY_AVAILABLE
-                : !season.is4kOverride &&
-                    season.processing &&
-                    existingSeason.status !== MediaStatus.DELETED
-                  ? MediaStatus.PROCESSING
+          if (!settings.main.prioritizeRadarrSonarr) {
+            existingSeason.status =
+              (season.totalEpisodes === season.episodes && season.episodes > 0) ||
+              existingSeason.status === MediaStatus.AVAILABLE
+                ? MediaStatus.AVAILABLE
+                : season.episodes > 0
+                  ? MediaStatus.PARTIALLY_AVAILABLE
                   : !season.is4kOverride &&
-                      !season.processing &&
-                      season.episodes === 0 &&
-                      existingSeason.status === MediaStatus.PROCESSING
-                    ? MediaStatus.UNKNOWN
-                    : existingSeason.status;
+                      season.processing &&
+                      existingSeason.status !== MediaStatus.DELETED
+                    ? MediaStatus.PROCESSING
+                    : !season.is4kOverride &&
+                        !season.processing &&
+                        season.episodes === 0 &&
+                        existingSeason.status === MediaStatus.PROCESSING
+                      ? MediaStatus.UNKNOWN
+                      : existingSeason.status;
 
-          // Same thing here, except we only do updates if 4k is enabled
-          existingSeason.status4k =
-            (this.enable4kShow &&
-              season.episodes4k === season.totalEpisodes &&
-              season.episodes4k > 0) ||
-            existingSeason.status4k === MediaStatus.AVAILABLE
-              ? MediaStatus.AVAILABLE
-              : this.enable4kShow && season.episodes4k > 0
-                ? MediaStatus.PARTIALLY_AVAILABLE
-                : season.is4kOverride &&
-                    season.processing &&
-                    existingSeason.status4k !== MediaStatus.DELETED
-                  ? MediaStatus.PROCESSING
+            existingSeason.status4k =
+              (this.enable4kShow &&
+                season.episodes4k === season.totalEpisodes &&
+                season.episodes4k > 0) ||
+              existingSeason.status4k === MediaStatus.AVAILABLE
+                ? MediaStatus.AVAILABLE
+                : this.enable4kShow && season.episodes4k > 0
+                  ? MediaStatus.PARTIALLY_AVAILABLE
                   : season.is4kOverride &&
-                      !season.processing &&
-                      season.episodes4k === 0 &&
-                      existingSeason.status4k === MediaStatus.PROCESSING
-                    ? MediaStatus.UNKNOWN
-                    : existingSeason.status4k;
+                      season.processing &&
+                      existingSeason.status4k !== MediaStatus.DELETED
+                    ? MediaStatus.PROCESSING
+                    : season.is4kOverride &&
+                        !season.processing &&
+                        season.episodes4k === 0 &&
+                        existingSeason.status4k === MediaStatus.PROCESSING
+                      ? MediaStatus.UNKNOWN
+                      : existingSeason.status4k;
+          }
         } else {
-          newSeasons.push(
-            new Season({
-              seasonNumber: season.seasonNumber,
-              status:
-                season.totalEpisodes === season.episodes && season.episodes > 0
-                  ? MediaStatus.AVAILABLE
-                  : season.episodes > 0
-                    ? MediaStatus.PARTIALLY_AVAILABLE
-                    : !season.is4kOverride && season.processing
-                      ? MediaStatus.PROCESSING
-                      : MediaStatus.UNKNOWN,
-              status4k:
-                this.enable4kShow &&
-                season.totalEpisodes === season.episodes4k &&
-                season.episodes4k > 0
-                  ? MediaStatus.AVAILABLE
-                  : this.enable4kShow && season.episodes4k > 0
-                    ? MediaStatus.PARTIALLY_AVAILABLE
-                    : season.is4kOverride && season.processing
-                      ? MediaStatus.PROCESSING
-                      : MediaStatus.UNKNOWN,
-            })
-          );
+          if (!settings.main.prioritizeRadarrSonarr) {
+            newSeasons.push(
+              new Season({
+                seasonNumber: season.seasonNumber,
+                status:
+                  season.totalEpisodes === season.episodes && season.episodes > 0
+                    ? MediaStatus.AVAILABLE
+                    : season.episodes > 0
+                      ? MediaStatus.PARTIALLY_AVAILABLE
+                      : !season.is4kOverride && season.processing
+                        ? MediaStatus.PROCESSING
+                        : MediaStatus.UNKNOWN,
+                status4k:
+                  this.enable4kShow &&
+                  season.totalEpisodes === season.episodes4k &&
+                  season.episodes4k > 0
+                    ? MediaStatus.AVAILABLE
+                    : this.enable4kShow && season.episodes4k > 0
+                      ? MediaStatus.PARTIALLY_AVAILABLE
+                      : season.is4kOverride && season.processing
+                        ? MediaStatus.PROCESSING
+                        : MediaStatus.UNKNOWN,
+              })
+            );
+          }
         }
       }
 
@@ -411,7 +435,8 @@ class BaseScanner<T> {
           );
           media.lastSeasonChange = new Date();
 
-          if (mediaAddedAt) {
+          // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
+          if (!settings.main.prioritizeRadarrSonarr && mediaAddedAt) {
             media.mediaAddedAt = mediaAddedAt;
           }
         }
@@ -426,7 +451,12 @@ class BaseScanner<T> {
           media.lastSeasonChange = new Date();
         }
 
-        if (!media.mediaAddedAt && mediaAddedAt) {
+        // Only update mediaAddedAt if not prioritizing Radarr/Sonarr
+        if (
+          !settings.main.prioritizeRadarrSonarr &&
+          !media.mediaAddedAt &&
+          mediaAddedAt
+        ) {
           media.mediaAddedAt = mediaAddedAt;
         }
 
@@ -448,8 +478,6 @@ class BaseScanner<T> {
           (s) => s.seasonNumber !== 0
         );
 
-        // Check the actual season objects instead scanner input
-        // to determine overall availability status
         const isAllStandardSeasonsAvailable =
           nonSpecialSeasons.length > 0 &&
           nonSpecialSeasons.every((s) => s.status === MediaStatus.AVAILABLE);
@@ -458,26 +486,46 @@ class BaseScanner<T> {
           nonSpecialSeasons.length > 0 &&
           nonSpecialSeasons.every((s) => s.status4k === MediaStatus.AVAILABLE);
 
-        media.status = isAllStandardSeasonsAvailable
-          ? MediaStatus.AVAILABLE
-          : media.seasons.some(
-                (season) =>
-                  season.status === MediaStatus.PARTIALLY_AVAILABLE ||
-                  season.status === MediaStatus.AVAILABLE
-              )
-            ? MediaStatus.PARTIALLY_AVAILABLE
-            : (!seasons.length && media.status !== MediaStatus.DELETED) ||
+        const shouldStayAvailable =
+          media.status === MediaStatus.AVAILABLE &&
+          newSeasons.filter(
+            (season) =>
+              season.status !== MediaStatus.UNKNOWN &&
+              season.status !== MediaStatus.DELETED &&
+              season.seasonNumber !== 0
+          ).length === 0;
+        const shouldStayAvailable4k =
+          media.status4k === MediaStatus.AVAILABLE &&
+          newSeasons.filter(
+            (season) =>
+              season.status4k !== MediaStatus.UNKNOWN &&
+              season.status4k !== MediaStatus.DELETED &&
+              season.seasonNumber !== 0
+          ).length === 0;
+
+        if (!settings.main.prioritizeRadarrSonarr) {
+          media.status =
+            isAllStandardSeasonsAvailable || shouldStayAvailable
+              ? MediaStatus.AVAILABLE
+              : media.seasons.some(
+                  (season) =>
+                    season.status === MediaStatus.PARTIALLY_AVAILABLE ||
+                    season.status === MediaStatus.AVAILABLE
+                )
+              ? MediaStatus.PARTIALLY_AVAILABLE
+              : (!seasons.length && media.status !== MediaStatus.DELETED) ||
                 media.seasons.some(
                   (season) => season.status === MediaStatus.PROCESSING
                 )
               ? MediaStatus.PROCESSING
               : media.status === MediaStatus.DELETED
-                ? MediaStatus.DELETED
-                : MediaStatus.UNKNOWN;
-        media.status4k =
-          isAll4kSeasonsAvailable && this.enable4kShow
-            ? MediaStatus.AVAILABLE
-            : this.enable4kShow &&
+              ? MediaStatus.DELETED
+              : MediaStatus.UNKNOWN;
+          media.status4k =
+            (isAll4kSeasonsAvailable || shouldStayAvailable4k) &&
+            this.enable4kShow
+              ? MediaStatus.AVAILABLE
+              : this.enable4kShow &&
                 media.seasons.some(
                   (season) =>
                     season.status4k === MediaStatus.PARTIALLY_AVAILABLE ||
@@ -485,18 +533,26 @@ class BaseScanner<T> {
                 )
               ? MediaStatus.PARTIALLY_AVAILABLE
               : (!seasons.length && media.status4k !== MediaStatus.DELETED) ||
-                  media.seasons.some(
-                    (season) => season.status4k === MediaStatus.PROCESSING
-                  )
-                ? MediaStatus.PROCESSING
-                : media.status4k === MediaStatus.DELETED
-                  ? MediaStatus.DELETED
-                  : MediaStatus.UNKNOWN;
+                media.seasons.some(
+                  (season) => season.status4k === MediaStatus.PROCESSING
+                )
+              ? MediaStatus.PROCESSING
+              : media.status4k === MediaStatus.DELETED
+              ? MediaStatus.DELETED
+              : MediaStatus.UNKNOWN;
+        }
         await mediaRepository.save(media);
         this.log(`Updating existing title: ${title}`);
       } else {
-        // For new media, check actual newSeasons objects instead of scanner
-        // input to determine overall availability status
+        // Skip creating new media when prioritizing Radarr/Sonarr
+        if (settings.main.prioritizeRadarrSonarr) {
+          this.log(
+            `Skipping creation of new show for ${title} (Radarr/Sonarr priority mode enabled)`,
+            'debug'
+          );
+          return;
+        }
+
         const nonSpecialNewSeasons = newSeasons.filter(
           (s) => s.seasonNumber !== 0
         );

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -156,6 +156,7 @@ export interface MainSettings {
   enableSpecialEpisodes: boolean;
   locale: string;
   youtubeUrl: string;
+  prioritizeRadarrSonarr: boolean;
 }
 
 export interface ProxySettings {
@@ -427,6 +428,7 @@ class Settings {
         enableSpecialEpisodes: false,
         locale: 'en',
         youtubeUrl: '',
+        prioritizeRadarrSonarr: false,
       },
       plex: {
         name: '',

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -76,6 +76,9 @@ const messages = defineMessages('components.Settings.SettingsMain', {
     'Base URL for YouTube videos if a self-hosted YouTube instance is used.',
   validationUrl: 'You must provide a valid URL',
   validationUrlTrailingSlash: 'URL must not end in a trailing slash',
+  prioritizeRadarrSonarr: 'Use Radarr/Sonarr for Availability',
+  prioritizeRadarrSonarrTip:
+    'When enabled, media availability will be determined by Radarr/Sonarr, ignoring Plex/Jellyfin/Emby.',
 });
 
 const SettingsMain = () => {
@@ -183,6 +186,7 @@ const SettingsMain = () => {
             enableSpecialEpisodes: data?.enableSpecialEpisodes,
             cacheImages: data?.cacheImages,
             youtubeUrl: data?.youtubeUrl,
+            prioritizeRadarrSonarr: data?.prioritizeRadarrSonarr,
           }}
           enableReinitialize
           validationSchema={MainSettingsSchema}
@@ -205,6 +209,7 @@ const SettingsMain = () => {
                 enableSpecialEpisodes: values.enableSpecialEpisodes,
                 cacheImages: values.cacheImages,
                 youtubeUrl: values.youtubeUrl,
+                prioritizeRadarrSonarr: values.prioritizeRadarrSonarr,
               });
               mutate('/api/v1/settings/public');
               mutate('/api/v1/status');
@@ -533,6 +538,33 @@ const SettingsMain = () => {
                         setFieldValue(
                           'hideBlocklisted',
                           !values.hideBlocklisted
+                        );
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label
+                    htmlFor="prioritizeRadarrSonarr"
+                    className="checkbox-label"
+                  >
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.prioritizeRadarrSonarr)}
+                    </span>
+                    <SettingsBadge badgeType="advanced" />
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.prioritizeRadarrSonarrTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="prioritizeRadarrSonarr"
+                      name="prioritizeRadarrSonarr"
+                      onChange={() => {
+                        setFieldValue(
+                          'prioritizeRadarrSonarr',
+                          !values.prioritizeRadarrSonarr
                         );
                       }}
                     />


### PR DESCRIPTION
## Description

This PR adds a new setting "Use Radarr/Sonarr for Availability" to address an issue when [UMTK](https://github.com/netplexflix/Upcoming-Movies-TV-Shows-for-Kometa) and [Agregarr](https://github.com/agregarr/agregarr) create placeholder trailers in Plex for upcoming or missing items, the item gets matched and marked as available in Seerr, preventing requests for the 'real' item.

Because Seerr's availability logic uses OR logic (exists in Plex OR exists in Radarr/Sonarr), these placeholder files are marked as AVAILABLE even though they don't exist in Radarr/Sonarr. This would usually be the desired behaviour, and the new option is marked as Advanced to reflect that.

When the new setting is enabled:
  - Discovery: Only Radarr/Sonarr can create new media entries in Seerr
  - Availability: Media availability is determined solely by Radarr/Sonarr (Plex/Jellyfin/Emby are ignored)
  - Metadata: Plex/Jellyfin/Emby scanners still run to add metadata (`ratingKey`, `jellyfinMediaId`) to existing entries, to ensure Play on Plex button still appears
  - Cleanup: Availability sync marks placeholder-only media as `UNKNOWN` and clears metadata including `ratingKey`

Fixes #2235 

## How Has This Been Tested?

Built and published docker build, tested by multiple users over multiple weeks.

## Screenshots / Logs (if applicable)

<img width="552" height="118" alt="image" src="https://github.com/user-attachments/assets/0d2d7057-74ed-46d5-856b-20b7cb4a3f7a" />

## Checklist:

- [x] Refactor after PR #2226 is merged
- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
    - AI Assistance: Claude Code was used to implement the bulk of the code changes.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a new configuration option to prioritize Radarr/Sonarr for media availability checks instead of Plex/Jellyfin/Emby, with adjusted handling for removed items and metadata management when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->