### PR TITLE
feat: ability to use jellyfin access token for user authentication

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -3981,6 +3981,8 @@ paths:
                   type: string
                 serverType:
                   type: number
+                accessToken:
+                  type: string
               required:
                 - username
                 - password

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,3 +1,4 @@
+import type { JellyfinUserResponse } from '@server/api/jellyfin';
 import JellyfinAPI from '@server/api/jellyfin';
 import PlexTvAPI from '@server/api/plextv';
 import { ApiErrorCode } from '@server/constants/error';
@@ -235,6 +236,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     useSsl?: boolean;
     email?: string;
     serverType?: number;
+    accessToken?: string;
   };
 
   //Make sure jellyfin login is enabled, but only if jellyfin && Emby is not already configured
@@ -288,7 +290,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     }
 
     // First we need to attempt to log the user in to jellyfin
-    const jellyfinserver = new JellyfinAPI(hostname ?? '', undefined, deviceId);
+    const jellyfinserver = new JellyfinAPI(
+      hostname ?? '',
+      body.accessToken,
+      deviceId
+    );
 
     const ip = req.ip;
     let clientIp;
@@ -301,15 +307,30 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       }
     }
 
-    const account = await jellyfinserver.login(
-      body.username,
-      body.password,
-      clientIp
-    );
+    let accessToken = body.accessToken;
+    let accountUser: JellyfinUserResponse | undefined = undefined;
+
+    // Some admins limit the amount of times a user can be logged in at once.
+    // Reuse an existing accessToken to prevent creating an extra user login /
+    // session in jellyfin.
+    if (accessToken) {
+      accountUser = await jellyfinserver.getUser();
+    }
+
+    if (!accountUser) {
+      const res = await jellyfinserver.login(
+        body.username,
+        body.password,
+        clientIp
+      );
+
+      accountUser = res.User;
+      accessToken = res.AccessToken;
+    }
 
     // Next let's see if the user already exists
     user = await userRepository.findOne({
-      where: { jellyfinUserId: account.User.Id },
+      where: { jellyfinUserId: accountUser.Id },
     });
 
     const missingAdminUser = !user && !(await userRepository.count());
@@ -318,7 +339,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       settings.main.mediaServerType === MediaServerType.NOT_CONFIGURED
     ) {
       // Check if user is admin on jellyfin
-      if (account.User.Policy.IsAdministrator === false) {
+      if (accountUser.Policy.IsAdministrator === false) {
         throw new ApiError(403, ApiErrorCode.NotAdmin);
       }
 
@@ -336,7 +357,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           {
             label: 'API',
             ip: req.ip,
-            jellyfinUsername: account.User.Name,
+            jellyfinUsername: accountUser.Name,
           }
         );
 
@@ -345,11 +366,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
 
         user = new User({
           id: 1,
-          email: body.email || account.User.Name,
-          jellyfinUsername: account.User.Name,
-          jellyfinUserId: account.User.Id,
+          email: body.email || accountUser.Name,
+          jellyfinUsername: accountUser.Name,
+          jellyfinUserId: accountUser.Id,
           jellyfinDeviceId: deviceId,
-          jellyfinAuthToken: account.AccessToken,
+          jellyfinAuthToken: accessToken,
           permissions: Permission.ADMIN,
           userType:
             body.serverType === MediaServerType.JELLYFIN
@@ -365,7 +386,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
           {
             label: 'API',
             ip: req.ip,
-            jellyfinUsername: account.User.Name,
+            jellyfinUsername: accountUser.Name,
           }
         );
 
@@ -377,11 +398,11 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         if (!user) {
           throw new Error('Unable to find admin user to edit');
         }
-        user.email = body.email || account.User.Name;
-        user.jellyfinUsername = account.User.Name;
-        user.jellyfinUserId = account.User.Id;
+        user.email = body.email || accountUser.Name;
+        user.jellyfinUsername = accountUser.Name;
+        user.jellyfinUserId = accountUser.Id;
         user.jellyfinDeviceId = deviceId;
-        user.jellyfinAuthToken = account.AccessToken;
+        user.jellyfinAuthToken = accessToken;
         user.permissions = Permission.ADMIN;
         user.avatar = getUserAvatarUrl(user);
         user.userType =
@@ -393,17 +414,13 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       }
 
       // Create an API key on Jellyfin from this admin user
-      const jellyfinClient = new JellyfinAPI(
-        hostname,
-        account.AccessToken,
-        deviceId
-      );
+      const jellyfinClient = new JellyfinAPI(hostname, accessToken, deviceId);
       const apiKey = await jellyfinClient.createApiToken('Seerr');
 
       const serverName = await jellyfinserver.getServerName();
 
       settings.jellyfin.name = serverName;
-      settings.jellyfin.serverId = account.User.ServerId;
+      settings.jellyfin.serverId = accountUser.ServerId;
       settings.jellyfin.ip = body.hostname ?? '';
       settings.jellyfin.port = body.port ?? 8096;
       settings.jellyfin.urlBase = body.urlBase ?? '';
@@ -413,7 +430,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
       startJobs();
     }
     // User already exists, let's update their information
-    else if (account.User.Id === user?.jellyfinUserId) {
+    else if (accountUser.Id === user?.jellyfinUserId) {
       logger.info(
         `Found matching ${
           settings.main.mediaServerType === MediaServerType.JELLYFIN
@@ -427,13 +444,14 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         {
           label: 'API',
           ip: req.ip,
-          jellyfinUsername: account.User.Name,
+          jellyfinUsername: accountUser.Name,
         }
       );
       user.avatar = getUserAvatarUrl(user);
-      user.jellyfinUsername = account.User.Name;
+      user.jellyfinUsername = accountUser.Name;
+      user.jellyfinAuthToken = accessToken;
 
-      if (user.username === account.User.Name) {
+      if (user.username === accountUser.Name) {
         user.username = '';
       }
 
@@ -444,8 +462,8 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         {
           label: 'API',
           ip: req.ip,
-          jellyfinUserId: account.User.Id,
-          jellyfinUsername: account.User.Name,
+          jellyfinUserId: accountUser.Id,
+          jellyfinUsername: accountUser.Name,
         }
       );
       return next({
@@ -458,15 +476,16 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
         {
           label: 'API',
           ip: req.ip,
-          jellyfinUsername: account.User.Name,
+          jellyfinUsername: accountUser.Name,
         }
       );
 
       user = new User({
         email: body.email,
-        jellyfinUsername: account.User.Name,
-        jellyfinUserId: account.User.Id,
+        jellyfinUsername: accountUser.Name,
+        jellyfinUserId: accountUser.Id,
         jellyfinDeviceId: deviceId,
+        jellyfinAuthToken: accessToken,
         permissions: settings.main.defaultPermissions,
         userType:
           settings.main.mediaServerType === MediaServerType.JELLYFIN


### PR DESCRIPTION
## Description

- updates jellyfin auth endpoints to:
    -  persist jellyfin access token along user login
    - optionally allow login with existing jellyifn access token to prevent exceeding any admin defined user session limits
- updates auth middleware to also acccept api keys for jellyfin user auth
- adds #2243

## How Has This Been Tested?

Ran dev locally and tested endpoints using postman. I made sure i can login and use the provided `jellyfinAuthToken` in the login response.

I used this auth token to update my `X-API-Key` header to then access `/api/v1/auth/me` while also ensuring cookies were empty to make sure this authenticated using only the key. It properly authenticated to the right user each time.

## Screenshots / Logs (if applicable)
<img width="450" alt="image" src="https://github.com/user-attachments/assets/5f7ec09a-29e7-4377-8d25-0572849a3eff" />
<img width="450" height="585" alt="image" src="https://github.com/user-attachments/assets/87bb75e6-ac3d-4e6f-849b-07645167ae12" />

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [X] Database migration (if required)
