### PR TITLE
fix(sonarr): search only requested seasons

### DIFF
--- a/.github/renovate/docker.json5
+++ b/.github/renovate/docker.json5
@@ -1,10 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
 
-  extends: [
-    'docker:enableMajor',
-    'docker:pinDigests'
-  ],
+  extends: ['docker:enableMajor', 'docker:pinDigests'],
 
   packageRules: [
     {

--- a/.github/renovate/pnpm.json5
+++ b/.github/renovate/pnpm.json5
@@ -7,5 +7,4 @@
   lockFileMaintenance: {
     enabled: true,
   },
-
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,8 +20,6 @@
   "files.associations": {
     "globals.css": "tailwindcss"
   },
-  "i18n-ally.localesPaths": [
-    "src/i18n/locale"
-  ],
+  "i18n-ally.localesPaths": ["src/i18n/locale"],
   "yaml.format.singleQuote": true
 }

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -210,7 +210,29 @@ class SonarrAPI extends ServarrBase<{
           });
 
           if (options.searchNow) {
-            this.searchSeries(newSeriesResponse.data.id);
+            const seasonsToSearch = this.getSeasonsNeedingSearch(
+              options.seasons,
+              newSeriesResponse.data.seasons
+            );
+
+            if (seasonsToSearch.length > 0) {
+              logger.debug('Searching seasons with missing episodes', {
+                label: 'Sonarr',
+                seriesId: newSeriesResponse.data.id,
+                requestedSeasons: options.seasons,
+                seasonsToSearch,
+              });
+              this.searchSeasons(newSeriesResponse.data.id, seasonsToSearch);
+            } else {
+              logger.debug(
+                'All requested seasons appear fully downloaded, skipping search',
+                {
+                  label: 'Sonarr',
+                  seriesId: newSeriesResponse.data.id,
+                  requestedSeasons: options.seasons,
+                }
+              );
+            }
           }
 
           return newSeriesResponse.data;
@@ -245,7 +267,9 @@ class SonarrAPI extends ServarrBase<{
           seriesType: options.seriesType,
           addOptions: {
             ignoreEpisodesWithFiles: true,
-            searchForMissingEpisodes: options.searchNow,
+            // Prevent Sonarr from triggering a series-wide missing search. We run
+            // explicit per-season searches below when requested.
+            searchForMissingEpisodes: false,
           },
         } as Partial<SonarrSeries>
       );
@@ -256,6 +280,32 @@ class SonarrAPI extends ServarrBase<{
           label: 'Sonarr',
           series: createdSeriesResponse.data,
         });
+
+        if (options.searchNow) {
+          const seasonsToSearch = this.getSeasonsNeedingSearch(
+            options.seasons,
+            createdSeriesResponse.data.seasons
+          );
+
+          if (seasonsToSearch.length > 0) {
+            logger.debug('Searching seasons with missing episodes', {
+              label: 'Sonarr',
+              seriesId: createdSeriesResponse.data.id,
+              requestedSeasons: options.seasons,
+              seasonsToSearch,
+            });
+            this.searchSeasons(createdSeriesResponse.data.id, seasonsToSearch);
+          } else {
+            logger.debug(
+              'All requested seasons appear fully downloaded, skipping search',
+              {
+                label: 'Sonarr',
+                seriesId: createdSeriesResponse.data.id,
+                requestedSeasons: options.seasons,
+              }
+            );
+          }
+        }
       } else {
         logger.error('Failed to add series to Sonarr', {
           label: 'Sonarr',
@@ -316,6 +366,74 @@ class SonarrAPI extends ServarrBase<{
         }
       );
     }
+  }
+
+  public async searchSeasons(
+    seriesId: number,
+    seasonNumbers: number[]
+  ): Promise<void> {
+    const uniqueSeasonNumbers = Array.from(new Set(seasonNumbers)).filter(
+      (sn) => Number.isInteger(sn) && sn >= 0
+    );
+
+    if (uniqueSeasonNumbers.length === 0) {
+      return;
+    }
+
+    logger.info('Executing season search command.', {
+      label: 'Sonarr API',
+      seriesId,
+      seasonNumbers: uniqueSeasonNumbers,
+    });
+
+    try {
+      // Search each season individually
+      for (const seasonNumber of uniqueSeasonNumbers) {
+        await this.runCommand('SeasonSearch', {
+          seriesId,
+          seasonNumber,
+        });
+      }
+    } catch (e) {
+      logger.error(
+        'Something went wrong while executing Sonarr season search.',
+        {
+          label: 'Sonarr API',
+          errorMessage: e.message,
+          seriesId,
+          seasonNumbers: uniqueSeasonNumbers,
+        }
+      );
+    }
+  }
+
+  private getSeasonsNeedingSearch(
+    requestedSeasons: number[],
+    seriesSeasons?: SonarrSeason[] | null
+  ): number[] {
+    if (!Array.isArray(seriesSeasons) || seriesSeasons.length === 0) {
+      return requestedSeasons;
+    }
+
+    return requestedSeasons.filter((seasonNumber) => {
+      const season = seriesSeasons.find((s) => s.seasonNumber === seasonNumber);
+
+      if (!season) {
+        return true;
+      }
+
+      if (!season.statistics) {
+        return true;
+      }
+
+      if (!season.statistics.episodeCount) {
+        return false;
+      }
+
+      return (
+        season.statistics.episodeFileCount < season.statistics.episodeCount
+      );
+    });
   }
 
   private buildSeasonList(


### PR DESCRIPTION
## Description

What it does (summary):
Prevents seer from triggering a series-wide search in Sonarr, when not all seasons are requested.

Runs Sonarr SeasonSearch only for the requested season number.
Skips searching seasons that appear fully downloaded (via season statistics) to avoid wasted searches
Key file: sonarr.ts

AI disclosure: I used AI assistance in writing this patch, both OpenAI Codex (GPT-5.2) and Claude opus 4.5. I tested and reviewed.  manually.


- Fixes 
sonarr.ts

## How Has This Been Tested?

Requested a TV series with only Season 1 selected + search now; verified Sonarr only received SeasonSearch for that season (no full-series search). Did this with both existing series with missing seasons and a new series addition. Then Re-requested a fully-downloaded season; verified search is skipped.

Testing env was docker based setup with sonarr running in same stack.  Change was isolated to sonarr.ts so I don't think it impacts anything outside of this.


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`  #NA? 
- [ ] Database migration (if required) #NA?

apologies if I messed anything up this is my first pr
