### PR TITLE
fix(servarr): resolve TVDB ID via Sonarr when TMDB mapping is missing

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -189,6 +189,23 @@ class SonarrAPI extends ServarrBase<{
     }
   }
 
+  public async getSeriesByTmdbId(tmdbId: number): Promise<SonarrSeries | null> {
+    try {
+      const response = await this.axios.get<SonarrSeries[]>('/series/lookup', {
+        params: { term: `tmdb:${tmdbId}` },
+      });
+
+      return response.data[0] ?? null;
+    } catch (e) {
+      logger.debug('Could not find series by TMDB ID in Sonarr', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        tmdbId,
+      });
+      return null;
+    }
+  }
+
   public async addSeries(options: AddSeriesOptions): Promise<SonarrSeries> {
     try {
       const series = await this.getSeriesByTvdbId(options.tvdbid);

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -575,6 +575,9 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
               tmdbId: media.tmdbId,
             }
           );
+          entity.status = MediaRequestStatus.FAILED;
+          const requestRepository = getRepository(MediaRequest);
+          await requestRepository.save(entity);
           return;
         }
 

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -546,13 +546,36 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
         });
         const series = await tmdb.getTvShow({ tvId: media.tmdbId });
-        const tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
+        let tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
 
         if (!tvdbId) {
-          const requestRepository = getRepository(MediaRequest);
-          await mediaRepository.remove(media);
-          await requestRepository.remove(entity);
-          throw new Error('TVDB ID not found');
+          const sonarrSeries = await sonarr.getSeriesByTmdbId(media.tmdbId);
+
+          if (sonarrSeries?.tvdbId) {
+            tvdbId = sonarrSeries.tvdbId;
+            logger.info(
+              `Resolved TVDB ID via Sonarr lookup for TMDB ID ${media.tmdbId}`,
+              {
+                label: 'Media Request',
+                requestId: entity.id,
+                mediaId: entity.media.id,
+                tvdbId,
+              }
+            );
+          }
+        }
+
+        if (!tvdbId) {
+          logger.warn(
+            'No TVDB ID found via TMDB or Sonarr, marking request as FAILED',
+            {
+              label: 'Media Request',
+              requestId: entity.id,
+              mediaId: entity.media.id,
+              tmdbId: media.tmdbId,
+            }
+          );
+          return;
         }
 
         let seriesType: SonarrSeries['seriesType'] = 'standard';


### PR DESCRIPTION
## Description

When a TV show's TMDB entry has no TVDB external ID (common for new or niche
series), `sendToSonarr` deletes both the media and request entities, then
throws. The request deletion triggers `afterRemove` →
`handleRemoveParentUpdate` → `findOneOrFail` on the already-deleted media,
crashing the subscriber. The entire transaction rolls back silently — users
see a success response but no request is persisted.

This PR:

1. Adds a `getSeriesByTmdbId()` method to `SonarrAPI` that queries Sonarr's
   `/series/lookup?term=tmdb:{id}` endpoint as a fallback for TVDB ID
   resolution (Sonarr can often resolve TVDB IDs that TMDB doesn't have)
2. Removes the destructive `remove()` calls that delete media and request
   entities when TVDB ID is missing
3. Returns gracefully instead of throwing, allowing `updateParentStatus` to
   run without crashing

- Fixes the silent request rollback for shows without TMDB→TVDB mappings
- Preserves media and request entities on failure instead of deleting them

### AI Assistance Notice

AI tools were used to help identify the root cause and draft this fix.

## How Has This Been Tested?

Tested on a local Seerr v3.0.1 instance with patched compiled JS:

| Show | TMDB TVDB | Sonarr TVDB | Before | After |
|---|---|---|---|---|
| Heart Code (TMDB 303724) | None | 470287 | Crash + rollback | Sonarr lookup resolves TVDB → sent to Sonarr |
| Truth or Date (TMDB 305000) | None | None | Crash + rollback | Graceful return, no crash |
| Adolescence (TMDB 249042) | 452467 | 452467 | Works | Works (no change) |

## Checklist

- [x] Contribution guidelines followed
- [x] AI assistance disclosed
- [ ] Documentation updated (N/A)
- [ ] All new and existing tests passed (no test suite)
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` (N/A)
- [ ] Database migration (not required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TV series lookup capability using TMDB ID
  * Implemented fallback mechanism to resolve TV series data when primary lookup fails
* **Bug Fixes**
  * Improved error handling for media requests with unresolved data—requests now safely marked as failed with detailed logging instead of destructive removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->