### PR TITLE
fix: support for IPv6 address literals in HOST env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mime": "^4.1.0",
     "nanoid": "^5.1.7",
     "next": "16.2.6",
+    "ip-address": "^10.1.0",
     "node-cache": "5.1.2",
     "node-gyp": "12.2.0",
     "node-schedule": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "mime": "^4.1.0",
     "nanoid": "^5.1.7",
     "next": "16.2.6",
-    "ip-address": "^10.1.0",
+    "ip-address": "^10.2.0",
     "node-cache": "5.1.2",
     "node-gyp": "12.2.0",
     "node-schedule": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
         specifier: ^3.33.2
         version: 3.33.2
       ip-address:
-        specifier: ^10.1.0
+        specifier: ^10.2.0
         version: 10.2.0
       js-yaml:
         specifier: ^4.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       humanize-duration:
         specifier: ^3.33.2
         version: 3.33.2
+      ip-address:
+        specifier: ^10.1.0
+        version: 10.2.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -4866,6 +4869,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ip-address@9.0.5:
@@ -13282,6 +13289,8 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 3.5.5
 
   ip-address@10.1.0: {}
+
+  ip-address@10.2.0: {}
 
   ip-address@9.0.5:
     dependencies:

--- a/server/index.ts
+++ b/server/index.ts
@@ -283,10 +283,11 @@ app
     }
     httpServer.on('error', (err) => {
       logger.error('Failed to start server', {
-      label: 'Server',
-      message: err.message,
-   });
-   process.exit(1);
+        label: 'Server',
+        message: err.message,
+      });
+      process.exit(1);
+    });
   })
   .catch((err) => {
     logger.error(err.stack);

--- a/server/index.ts
+++ b/server/index.ts
@@ -267,19 +267,24 @@ app
 
     const port = Number(process.env.PORT) || 5055;
     const host = process.env.HOST;
+    let httpServer;
     if (host) {
-      server.listen(port, host, () => {
+      httpServer = server.listen(port, host, () => {
         logger.info(`Server ready on ${host} port ${port}`, {
           label: 'Server',
         });
       });
     } else {
-      server.listen(port, () => {
+      httpServer = server.listen(port, () => {
         logger.info(`Server ready on port ${port}`, {
           label: 'Server',
         });
       });
     }
+    httpServer.on('error', (err) => {
+      logger.error('Listen error:', err);
+      process.exit(1);
+    });
   })
   .catch((err) => {
     logger.error(err.stack);

--- a/server/index.ts
+++ b/server/index.ts
@@ -282,9 +282,11 @@ app
       });
     }
     httpServer.on('error', (err) => {
-      logger.error('Listen error:', err);
-      process.exit(1);
-    });
+      logger.error('Failed to start server', {
+      label: 'Server',
+      message: err.message,
+   });
+   process.exit(1);
   })
   .catch((err) => {
     logger.error(err.stack);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
 import '@app/styles/globals.css';
 import { polyfillIntl } from '@app/utils/polyfillIntl';
+import { getHostAndPort } from '@app/utils/urlHelper';
 import '@fontsource-variable/inter';
 import { MediaServerType } from '@server/constants/server';
 import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
@@ -266,9 +267,7 @@ CoreApp.getInitialProps = async (initialProps) => {
   if (ctx.res) {
     // Check if app is initialized and redirect if necessary
     const response = await axios.get<PublicSettingsResponse>(
-      `http://${process.env.HOST || 'localhost'}:${
-        process.env.PORT || 5055
-      }/api/v1/settings/public`
+      `http://${getHostAndPort()}/api/v1/settings/public`
     );
 
     currentSettings = response.data;
@@ -286,9 +285,7 @@ CoreApp.getInitialProps = async (initialProps) => {
       try {
         // Attempt to get the user by running a request to the local api
         const response = await axios.get<User>(
-          `http://${process.env.HOST || 'localhost'}:${
-            process.env.PORT || 5055
-          }/api/v1/auth/me`,
+          `http://${getHostAndPort()}/api/v1/auth/me`,
           {
             headers:
               ctx.req && ctx.req.headers.cookie

--- a/src/pages/collection/[collectionId]/index.tsx
+++ b/src/pages/collection/[collectionId]/index.tsx
@@ -1,4 +1,5 @@
 import CollectionDetails from '@app/components/CollectionDetails';
+import { getHostAndPort } from '@app/utils/urlHelper';
 import type { Collection } from '@server/models/Collection';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -15,9 +16,7 @@ export const getServerSideProps: GetServerSideProps<
   CollectionPageProps
 > = async (ctx) => {
   const response = await axios.get<Collection>(
-    `http://${process.env.HOST || 'localhost'}:${
-      process.env.PORT || 5055
-    }/api/v1/collection/${ctx.query.collectionId}`,
+    `http://${getHostAndPort()}/api/v1/collection/${ctx.query.collectionId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/movie/[movieId]/index.tsx
+++ b/src/pages/movie/[movieId]/index.tsx
@@ -1,4 +1,5 @@
 import MovieDetails from '@app/components/MovieDetails';
+import { getHostAndPort } from '@app/utils/urlHelper';
 import type { MovieDetails as MovieDetailsType } from '@server/models/Movie';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -15,9 +16,7 @@ export const getServerSideProps: GetServerSideProps<MoviePageProps> = async (
   ctx
 ) => {
   const response = await axios.get<MovieDetailsType>(
-    `http://${process.env.HOST || 'localhost'}:${
-      process.env.PORT || 5055
-    }/api/v1/movie/${ctx.query.movieId}`,
+    `http://${getHostAndPort()}/api/v1/movie/${ctx.query.movieId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/pages/tv/[tvId]/index.tsx
+++ b/src/pages/tv/[tvId]/index.tsx
@@ -1,4 +1,5 @@
 import TvDetails from '@app/components/TvDetails';
+import { getHostAndPort } from '@app/utils/urlHelper';
 import type { TvDetails as TvDetailsType } from '@server/models/Tv';
 import axios from 'axios';
 import type { GetServerSideProps, NextPage } from 'next';
@@ -15,9 +16,7 @@ export const getServerSideProps: GetServerSideProps<TvPageProps> = async (
   ctx
 ) => {
   const response = await axios.get<TvDetailsType>(
-    `http://${process.env.HOST || 'localhost'}:${
-      process.env.PORT || 5055
-    }/api/v1/tv/${ctx.query.tvId}`,
+    `http://${getHostAndPort()}/api/v1/tv/${ctx.query.tvId}`,
     {
       headers: ctx.req?.headers?.cookie
         ? { cookie: ctx.req.headers.cookie }

--- a/src/utils/urlHelper.ts
+++ b/src/utils/urlHelper.ts
@@ -5,6 +5,6 @@ export function getHostAndPort(): string {
     host = `[${host}]`;
   }
 
-  const port = process.env.PORT || 5055;
+  const port = Number(process.env.PORT) || 5055;
   return `${host}:${port}`;
 }

--- a/src/utils/urlHelper.ts
+++ b/src/utils/urlHelper.ts
@@ -1,0 +1,10 @@
+export function getHostAndPort(): string {
+  let host = process.env.HOST || 'localhost';
+  if (host.includes(':')) {
+    // If host includes a colon, it's an IPv6 literal and needs to be placed in square brackets
+    host = `[${host}]`;
+  }
+
+  const port = process.env.PORT || 5055;
+  return `${host}:${port}`;
+}

--- a/src/utils/urlHelper.ts
+++ b/src/utils/urlHelper.ts
@@ -1,7 +1,9 @@
+import { Address6 } from 'ip-address';
+
 export function getHostAndPort(): string {
   let host = process.env.HOST || 'localhost';
-  if (host.includes(':')) {
-    // If host includes a colon, it's an IPv6 literal and needs to be placed in square brackets
+  if (Address6.isValid(host)) {
+    // If host is an IPv6 literal it needs to be placed in square brackets
     host = `[${host}]`;
   }
 


### PR DESCRIPTION
## Description
When pages would build URLs for API requests, process.env.HOST would be directly concatenated with process.env.PORT (e.g., `0.0.0.0:5055`). This works for IPv4 address literals but does not work for IPv6 address literals because `:::5055` for example is invalid. This commit adds a check if process.env.HOST contains a colon (:) and if so, wraps the host in square brackets. E.g., `[::]:5055`, which is valid. This allows for users to set the HOST environment variable to IPv6 address literals.

- Fixes #2612

## How Has This Been Tested?

This was tested on a Debian 13 VM running kernel 6.12.48+deb13-amd64 for the server and a 13-inch 2022 MacBook Pro with the Arc browser Version 1.135.0 (75383), Chromium Engine Version 145.0.7632.110.

Tested by setting `HOST` env var to `::` and another IPv6 literal and ensured pages loaded as expected and the error observed in the ticket was no longer occurring.

## Screenshots / Logs (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized host/port resolution for API requests across public settings, auth, collection, movie, and TV pages, using consistent URL construction.
  * Added safe handling for IPv6 hosts when building API endpoints.

* **Chores**
  * Improved server startup resilience by handling server startup errors more explicitly, logging a clear failure message, and exiting with a non-zero status when startup fails.

* **Chores**
  * Added a runtime dependency to support IP address handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->