### PR TITLE
fix(scanners): reset orphaned processing media from deleted Radarr/Sonarr entries

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -41,6 +41,7 @@ interface ProcessOptions {
   externalServiceSlug?: string;
   title?: string;
   processing?: boolean;
+  hasFile?: boolean;
 }
 
 export interface ProcessableSeason {
@@ -104,6 +105,7 @@ class BaseScanner<T> {
       externalServiceSlug,
       processing = false,
       title = 'Unknown Title',
+      hasFile = true,
     }: ProcessOptions = {}
   ): Promise<void> {
     const mediaRepository = getRepository(Media);
@@ -115,11 +117,20 @@ class BaseScanner<T> {
         let changedExisting = false;
 
         if (existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE) {
-          existing[is4k ? 'status4k' : 'status'] = !processing
-            ? MediaStatus.AVAILABLE
-            : existing[is4k ? 'status4k' : 'status'] === MediaStatus.DELETED
-              ? MediaStatus.DELETED
-              : MediaStatus.PROCESSING;
+          existing[is4k ? 'status4k' : 'status'] =
+            !processing && hasFile
+              ? MediaStatus.AVAILABLE
+              : !processing &&
+                  !hasFile &&
+                  existing[is4k ? 'status4k' : 'status'] ===
+                    MediaStatus.PROCESSING
+                ? MediaStatus.UNKNOWN
+                : processing
+                  ? existing[is4k ? 'status4k' : 'status'] ===
+                    MediaStatus.DELETED
+                    ? MediaStatus.DELETED
+                    : MediaStatus.PROCESSING
+                  : existing[is4k ? 'status4k' : 'status'];
           if (mediaAddedAt) {
             existing.mediaAddedAt = mediaAddedAt;
           }
@@ -192,6 +203,10 @@ class BaseScanner<T> {
           this.log(`Title already exists and no changes detected for ${title}`);
         }
       } else {
+        if (!processing && !hasFile) {
+          return;
+        }
+
         const newMedia = new Media();
         newMedia.tmdbId = tmdbId;
         newMedia.imdbId = imdbId;

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -117,24 +117,28 @@ class BaseScanner<T> {
         let changedExisting = false;
 
         if (existing[is4k ? 'status4k' : 'status'] !== MediaStatus.AVAILABLE) {
-          existing[is4k ? 'status4k' : 'status'] =
+          const statusField = is4k ? 'status4k' : 'status';
+          const previousStatus = existing[statusField];
+
+          existing[statusField] =
             !processing && hasFile
               ? MediaStatus.AVAILABLE
               : !processing &&
                   !hasFile &&
-                  existing[is4k ? 'status4k' : 'status'] ===
-                    MediaStatus.PROCESSING
+                  previousStatus === MediaStatus.PROCESSING
                 ? MediaStatus.UNKNOWN
                 : processing
-                  ? existing[is4k ? 'status4k' : 'status'] ===
-                    MediaStatus.DELETED
+                  ? previousStatus === MediaStatus.DELETED
                     ? MediaStatus.DELETED
                     : MediaStatus.PROCESSING
-                  : existing[is4k ? 'status4k' : 'status'];
-          if (mediaAddedAt) {
-            existing.mediaAddedAt = mediaAddedAt;
+                  : previousStatus;
+
+          if (existing[statusField] !== previousStatus) {
+            if (mediaAddedAt) {
+              existing.mediaAddedAt = mediaAddedAt;
+            }
+            changedExisting = true;
           }
-          changedExisting = true;
         }
 
         if (!changedExisting && !existing.mediaAddedAt && mediaAddedAt) {

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -88,6 +88,24 @@ class RadarrScanner
         }
       }
 
+      // Only run cleanup if all servers of this profile type have sync enabled.
+      // If any server is skipped, we can't distinguish truly orphaned media from
+      // media that exists on an unscanned server (e.g. separate instances for
+      // anime, regional content, or different languages).
+      const allStandardScanned = this.servers
+        .filter((s) => !this.enable4kMovie || !s.is4k)
+        .every((s) => s.syncEnabled);
+      const all4kScanned = this.servers
+        .filter((s) => this.enable4kMovie && s.is4k)
+        .every((s) => s.syncEnabled);
+
+      if (!allStandardScanned) {
+        this.didScanStandard = false;
+      }
+      if (!all4kScanned) {
+        this.didScan4k = false;
+      }
+
       await this.cleanupOrphanedMovies();
       this.log('Radarr scan complete', 'info');
     } catch (e) {

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -25,6 +25,9 @@ class RadarrScanner
   private currentServer: RadarrSettings;
   private radarrApi: RadarrAPI;
   private scannedTmdbIds: Set<number> = new Set();
+  private scanned4kTmdbIds: Set<number> = new Set();
+  private didScanStandard = false;
+  private didScan4k = false;
 
   constructor() {
     super('Radarr Scan', { bundleSize: 50 });
@@ -44,6 +47,9 @@ class RadarrScanner
     const settings = getSettings();
     const sessionId = this.startRun();
     this.scannedTmdbIds.clear();
+    this.scanned4kTmdbIds.clear();
+    this.didScanStandard = false;
+    this.didScan4k = false;
 
     try {
       this.servers = uniqWith(settings.radarr, (radarrA, radarrB) => {
@@ -69,6 +75,13 @@ class RadarrScanner
 
           this.items = await this.radarrApi.getMovies();
 
+          const server4k = this.enable4kMovie && server.is4k;
+          if (server4k) {
+            this.didScan4k = true;
+          } else {
+            this.didScanStandard = true;
+          }
+
           await this.loop(this.processRadarrMovie.bind(this), { sessionId });
         } else {
           this.log(`Sync not enabled. Skipping Radarr server: ${server.name}`);
@@ -85,10 +98,14 @@ class RadarrScanner
   }
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
-    this.scannedTmdbIds.add(radarrMovie.tmdbId);
+    const server4k = this.enable4kMovie && this.currentServer.is4k;
+    if (server4k) {
+      this.scanned4kTmdbIds.add(radarrMovie.tmdbId);
+    } else {
+      this.scannedTmdbIds.add(radarrMovie.tmdbId);
+    }
 
     try {
-      const server4k = this.enable4kMovie && this.currentServer.is4k;
       await this.processMovie(radarrMovie.tmdbId, {
         is4k: server4k,
         serviceId: this.currentServer.id,
@@ -109,22 +126,29 @@ class RadarrScanner
   private async cleanupOrphanedMovies(): Promise<void> {
     const mediaRepository = getRepository(Media);
 
-    const processingMovies = await mediaRepository.find({
-      where: { mediaType: MediaType.MOVIE, status: MediaStatus.PROCESSING },
-    });
+    if (this.didScanStandard) {
+      const processingMovies = await mediaRepository.find({
+        where: { mediaType: MediaType.MOVIE, status: MediaStatus.PROCESSING },
+      });
 
-    for (const media of processingMovies) {
-      if (!this.scannedTmdbIds.has(media.tmdbId)) {
-        media.status = MediaStatus.UNKNOWN;
-        await mediaRepository.save(media);
-        this.log(
-          `Movie ${media.tmdbId} not found in any Radarr server. Status reset to UNKNOWN.`,
-          'info'
-        );
+      for (const media of processingMovies) {
+        if (!this.scannedTmdbIds.has(media.tmdbId)) {
+          media.status = MediaStatus.UNKNOWN;
+          await mediaRepository.save(media);
+          this.log(
+            `Movie ${media.tmdbId} not found in any Radarr server. Status reset to UNKNOWN.`,
+            'info'
+          );
+        }
       }
+    } else {
+      this.log(
+        'Skipping orphaned movie cleanup: no standard Radarr servers were scanned.',
+        'info'
+      );
     }
 
-    if (this.enable4kMovie) {
+    if (this.didScan4k) {
       const processing4kMovies = await mediaRepository.find({
         where: {
           mediaType: MediaType.MOVIE,
@@ -133,15 +157,20 @@ class RadarrScanner
       });
 
       for (const media of processing4kMovies) {
-        if (!this.scannedTmdbIds.has(media.tmdbId)) {
+        if (!this.scanned4kTmdbIds.has(media.tmdbId)) {
           media.status4k = MediaStatus.UNKNOWN;
           await mediaRepository.save(media);
           this.log(
-            `Movie ${media.tmdbId} not found in any Radarr server. 4K status reset to UNKNOWN.`,
+            `Movie ${media.tmdbId} not found in any 4K Radarr server. 4K status reset to UNKNOWN.`,
             'info'
           );
         }
       }
+    } else if (this.enable4kMovie) {
+      this.log(
+        'Skipping orphaned 4K movie cleanup: no 4K Radarr servers were scanned.',
+        'info'
+      );
     }
   }
 }

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -1,5 +1,8 @@
 import type { RadarrMovie } from '@server/api/servarr/radarr';
 import RadarrAPI from '@server/api/servarr/radarr';
+import { MediaStatus, MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
 import type {
   RunnableScanner,
   StatusBase,
@@ -21,6 +24,7 @@ class RadarrScanner
   private servers: RadarrSettings[];
   private currentServer: RadarrSettings;
   private radarrApi: RadarrAPI;
+  private scannedTmdbIds: Set<number> = new Set();
 
   constructor() {
     super('Radarr Scan', { bundleSize: 50 });
@@ -39,6 +43,7 @@ class RadarrScanner
   public async run(): Promise<void> {
     const settings = getSettings();
     const sessionId = this.startRun();
+    this.scannedTmdbIds.clear();
 
     try {
       this.servers = uniqWith(settings.radarr, (radarrA, radarrB) => {
@@ -70,6 +75,7 @@ class RadarrScanner
         }
       }
 
+      await this.cleanupOrphanedMovies();
       this.log('Radarr scan complete', 'info');
     } catch (e) {
       this.log('Scan interrupted', 'error', { errorMessage: e.message });
@@ -79,16 +85,7 @@ class RadarrScanner
   }
 
   private async processRadarrMovie(radarrMovie: RadarrMovie): Promise<void> {
-    if (!radarrMovie.monitored && !radarrMovie.hasFile) {
-      this.log(
-        'Title is unmonitored and has not been downloaded. Skipping item.',
-        'debug',
-        {
-          title: radarrMovie.title,
-        }
-      );
-      return;
-    }
+    this.scannedTmdbIds.add(radarrMovie.tmdbId);
 
     try {
       const server4k = this.enable4kMovie && this.currentServer.is4k;
@@ -98,13 +95,53 @@ class RadarrScanner
         externalServiceId: radarrMovie.id,
         externalServiceSlug: radarrMovie.titleSlug,
         title: radarrMovie.title,
-        processing: !radarrMovie.hasFile,
+        processing: !radarrMovie.hasFile && radarrMovie.monitored,
+        hasFile: radarrMovie.hasFile,
       });
     } catch (e) {
       this.log('Failed to process Radarr media', 'error', {
         errorMessage: e.message,
         title: radarrMovie.title,
       });
+    }
+  }
+
+  private async cleanupOrphanedMovies(): Promise<void> {
+    const mediaRepository = getRepository(Media);
+
+    const processingMovies = await mediaRepository.find({
+      where: { mediaType: MediaType.MOVIE, status: MediaStatus.PROCESSING },
+    });
+
+    for (const media of processingMovies) {
+      if (!this.scannedTmdbIds.has(media.tmdbId)) {
+        media.status = MediaStatus.UNKNOWN;
+        await mediaRepository.save(media);
+        this.log(
+          `Movie ${media.tmdbId} not found in any Radarr server. Status reset to UNKNOWN.`,
+          'info'
+        );
+      }
+    }
+
+    if (this.enable4kMovie) {
+      const processing4kMovies = await mediaRepository.find({
+        where: {
+          mediaType: MediaType.MOVIE,
+          status4k: MediaStatus.PROCESSING,
+        },
+      });
+
+      for (const media of processing4kMovies) {
+        if (!this.scannedTmdbIds.has(media.tmdbId)) {
+          media.status4k = MediaStatus.UNKNOWN;
+          await mediaRepository.save(media);
+          this.log(
+            `Movie ${media.tmdbId} not found in any Radarr server. 4K status reset to UNKNOWN.`,
+            'info'
+          );
+        }
+      }
     }
   }
 }

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -1,0 +1,399 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+import type { RadarrMovie } from '@server/api/servarr/radarr';
+import RadarrAPI from '@server/api/servarr/radarr';
+import { MediaStatus, MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import type { RadarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+
+let getMoviesImpl: () => Promise<RadarrMovie[]> = async () => [];
+Object.defineProperty(RadarrAPI.prototype, 'getMovies', {
+  set() {},
+  get() {
+    return async () => getMoviesImpl();
+  },
+  configurable: true,
+});
+
+import { radarrScanner } from '@server/lib/scanners/radarr';
+
+setupTestDb();
+
+function configureRadarr(overrides: Partial<RadarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.radarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Radarr ${i}`,
+    hostname: 'localhost',
+    port: 7878,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/movies',
+    is4k: false,
+    minimumAvailability: 'released',
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as RadarrSettings[];
+  settings.sonarr = [];
+}
+
+function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
+  return {
+    tmdbId: 550,
+    id: 1,
+    title: 'Test Movie',
+    titleSlug: 'test-movie',
+    monitored: true,
+    hasFile: true,
+    isAvailable: true,
+    imdbId: 'tt0137523',
+    folderName: '/movies/Test Movie (2024)',
+    path: '/movies/Test Movie (2024)',
+    profileId: 1,
+    qualityProfileId: 1,
+    added: '2024-01-01T00:00:00Z',
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('Radarr Scanner', () => {
+  beforeEach(() => {
+    getMoviesImpl = async () => [];
+  });
+
+  describe('unmonitored movie handling', () => {
+    it('resets PROCESSING to UNKNOWN when movie is unmonitored and has no file', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 550;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ monitored: false, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 550 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
+    });
+
+    it('does not create new media entry when movie is unmonitored and has no file', async () => {
+      const mediaRepository = getRepository(Media);
+      configureRadarr([{ syncEnabled: true }]);
+
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 777, monitored: false, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const media = await mediaRepository.findOne({
+        where: { tmdbId: 777 },
+      });
+      assert.strictEqual(media, null);
+    });
+
+    it('sets AVAILABLE when movie has a file', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 551;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 551, monitored: true, hasFile: true }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 551 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+    });
+
+    it('sets PROCESSING when movie is monitored but has no file', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 552;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.UNKNOWN;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 552, monitored: true, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 552 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('preserves DELETED status when movie is monitored but has no file', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 553;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.DELETED;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 553, monitored: true, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 553 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.DELETED);
+    });
+
+    it('keeps AVAILABLE status even when movie is unmonitored', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 554;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.AVAILABLE;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 554, monitored: false, hasFile: true }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 554 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+    });
+  });
+
+  describe('orphaned movie cleanup', () => {
+    it('skips cleanup when a standard server has sync disabled', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 950;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([
+        { syncEnabled: true, id: 0, hostname: 'server-a' },
+        { syncEnabled: false, id: 1, hostname: 'server-b' },
+      ]);
+
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 950 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('resets PROCESSING to UNKNOWN when movie is not in any Radarr server', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 999;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      // Radarr returns empty meaning movie was deleted
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 999 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset AVAILABLE movie when missing from Radarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 888;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.AVAILABLE;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 888 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+    });
+
+    it('does not reset PROCESSING movie that still exists in Radarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 700;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 700 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('does not reset TV media that is missing from Radarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      // TV show stuck in processing so Radarr scanner should not touch it
+      const media = new Media();
+      media.tmdbId = 800;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 800 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('only resets orphaned movies not found across all servers', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const orphan = new Media();
+      orphan.tmdbId = 901;
+      orphan.mediaType = MediaType.MOVIE;
+      orphan.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(orphan);
+
+      const existing = new Media();
+      existing.tmdbId = 902;
+      existing.mediaType = MediaType.MOVIE;
+      existing.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(existing);
+
+      // Two servers but movie exists on server 1 only
+      configureRadarr([
+        { syncEnabled: true, id: 0, hostname: 'server-a' },
+        { syncEnabled: true, id: 1, hostname: 'server-b' },
+      ]);
+
+      let callCount = 0;
+      getMoviesImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          return [fakeRadarrMovie({ tmdbId: 902, id: 10 })];
+        }
+        return [];
+      };
+
+      await radarrScanner.run();
+
+      const updatedOrphan = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 901 },
+      });
+      assert.strictEqual(updatedOrphan.status, MediaStatus.UNKNOWN);
+
+      const updatedExisting = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 902 },
+      });
+      assert.strictEqual(updatedExisting.status, MediaStatus.AVAILABLE);
+    });
+  });
+
+  describe('4k orphaned movie cleanup', () => {
+    it('resets 4k PROCESSING to UNKNOWN when movie is not in any Radarr server', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 960;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.UNKNOWN;
+      media.status4k = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true, is4k: true }]);
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 960 },
+      });
+      assert.strictEqual(updated.status4k, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset 4k AVAILABLE when movie is missing from Radarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 961;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.UNKNOWN;
+      media.status4k = MediaStatus.AVAILABLE;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true, is4k: true }]);
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 961 },
+      });
+      assert.strictEqual(updated.status4k, MediaStatus.AVAILABLE);
+    });
+  });
+});

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -96,6 +96,24 @@ class SonarrScanner
         }
       }
 
+      // Only run cleanup if all servers of this profile type have sync enabled.
+      // If any server is skipped, we can't distinguish truly orphaned media from
+      // media that exists on an unscanned server (e.g. separate instances for
+      // anime, regional content, or different languages).
+      const allStandardScanned = this.servers
+        .filter((s) => !this.enable4kShow || !s.is4k)
+        .every((s) => s.syncEnabled);
+      const all4kScanned = this.servers
+        .filter((s) => this.enable4kShow && s.is4k)
+        .every((s) => s.syncEnabled);
+
+      if (!allStandardScanned) {
+        this.didScanStandard = false;
+      }
+      if (!all4kScanned) {
+        this.didScan4k = false;
+      }
+
       await this.cleanupOrphanedShows();
       this.log('Sonarr scan complete', 'info');
     } catch (e) {

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -7,6 +7,7 @@ import type {
   TmdbKeyword,
   TmdbTvDetails,
 } from '@server/api/themoviedb/interfaces';
+import { MediaStatus, MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import type {
@@ -31,6 +32,7 @@ class SonarrScanner
   private servers: SonarrSettings[];
   private currentServer: SonarrSettings;
   private sonarrApi: SonarrAPI;
+  private scannedTvdbIds: Set<number> = new Set();
 
   constructor() {
     super('Sonarr Scan', { bundleSize: 50 });
@@ -49,6 +51,7 @@ class SonarrScanner
   public async run(): Promise<void> {
     const settings = getSettings();
     const sessionId = this.startRun();
+    this.scannedTvdbIds.clear();
 
     try {
       this.servers = uniqWith(settings.sonarr, (sonarrA, sonarrB) => {
@@ -80,6 +83,7 @@ class SonarrScanner
         }
       }
 
+      await this.cleanupOrphanedShows();
       this.log('Sonarr scan complete', 'info');
     } catch (e) {
       this.log('Scan interrupted', 'error', { errorMessage: e.message });
@@ -89,6 +93,8 @@ class SonarrScanner
   }
 
   private async processSonarrSeries(sonarrSeries: SonarrSeries) {
+    this.scannedTvdbIds.add(sonarrSeries.tvdbId);
+
     try {
       const mediaRepository = getRepository(Media);
       const server4k = this.enable4kShow && this.currentServer.is4k;
@@ -150,6 +156,54 @@ class SonarrScanner
         errorMessage: e.message,
         title: sonarrSeries.title,
       });
+    }
+  }
+
+  private async cleanupOrphanedShows(): Promise<void> {
+    const mediaRepository = getRepository(Media);
+
+    const processingShows = await mediaRepository.find({
+      where: { mediaType: MediaType.TV, status: MediaStatus.PROCESSING },
+      relations: ['seasons'],
+    });
+
+    for (const media of processingShows) {
+      if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
+        media.status = MediaStatus.UNKNOWN;
+        for (const season of media.seasons) {
+          if (season.status === MediaStatus.PROCESSING) {
+            season.status = MediaStatus.UNKNOWN;
+          }
+        }
+        await mediaRepository.save(media);
+        this.log(
+          `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any Sonarr server. Status reset to UNKNOWN.`,
+          'info'
+        );
+      }
+    }
+
+    if (this.enable4kShow) {
+      const processing4kShows = await mediaRepository.find({
+        where: { mediaType: MediaType.TV, status4k: MediaStatus.PROCESSING },
+        relations: ['seasons'],
+      });
+
+      for (const media of processing4kShows) {
+        if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
+          media.status4k = MediaStatus.UNKNOWN;
+          for (const season of media.seasons) {
+            if (season.status4k === MediaStatus.PROCESSING) {
+              season.status4k = MediaStatus.UNKNOWN;
+            }
+          }
+          await mediaRepository.save(media);
+          this.log(
+            `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any 4K Sonarr server. 4K status reset to UNKNOWN.`,
+            'info'
+          );
+        }
+      }
     }
   }
 }

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -33,6 +33,9 @@ class SonarrScanner
   private currentServer: SonarrSettings;
   private sonarrApi: SonarrAPI;
   private scannedTvdbIds: Set<number> = new Set();
+  private scanned4kTvdbIds: Set<number> = new Set();
+  private didScanStandard = false;
+  private didScan4k = false;
 
   constructor() {
     super('Sonarr Scan', { bundleSize: 50 });
@@ -52,6 +55,9 @@ class SonarrScanner
     const settings = getSettings();
     const sessionId = this.startRun();
     this.scannedTvdbIds.clear();
+    this.scanned4kTvdbIds.clear();
+    this.didScanStandard = false;
+    this.didScan4k = false;
 
     try {
       this.servers = uniqWith(settings.sonarr, (sonarrA, sonarrB) => {
@@ -77,6 +83,13 @@ class SonarrScanner
 
           this.items = await this.sonarrApi.getSeries();
 
+          const server4k = this.enable4kShow && server.is4k;
+          if (server4k) {
+            this.didScan4k = true;
+          } else {
+            this.didScanStandard = true;
+          }
+
           await this.loop(this.processSonarrSeries.bind(this), { sessionId });
         } else {
           this.log(`Sync not enabled. Skipping Sonarr server: ${server.name}`);
@@ -93,11 +106,15 @@ class SonarrScanner
   }
 
   private async processSonarrSeries(sonarrSeries: SonarrSeries) {
-    this.scannedTvdbIds.add(sonarrSeries.tvdbId);
+    const server4k = this.enable4kShow && this.currentServer.is4k;
+    if (server4k) {
+      this.scanned4kTvdbIds.add(sonarrSeries.tvdbId);
+    } else {
+      this.scannedTvdbIds.add(sonarrSeries.tvdbId);
+    }
 
     try {
       const mediaRepository = getRepository(Media);
-      const server4k = this.enable4kShow && this.currentServer.is4k;
       const processableSeasons: ProcessableSeason[] = [];
       let tvShow: TmdbTvDetails;
 
@@ -162,35 +179,42 @@ class SonarrScanner
   private async cleanupOrphanedShows(): Promise<void> {
     const mediaRepository = getRepository(Media);
 
-    const processingShows = await mediaRepository.find({
-      where: { mediaType: MediaType.TV, status: MediaStatus.PROCESSING },
-      relations: ['seasons'],
-    });
+    if (this.didScanStandard) {
+      const processingShows = await mediaRepository.find({
+        where: { mediaType: MediaType.TV, status: MediaStatus.PROCESSING },
+        relations: ['seasons'],
+      });
 
-    for (const media of processingShows) {
-      if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
-        media.status = MediaStatus.UNKNOWN;
-        for (const season of media.seasons) {
-          if (season.status === MediaStatus.PROCESSING) {
-            season.status = MediaStatus.UNKNOWN;
+      for (const media of processingShows) {
+        if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
+          media.status = MediaStatus.UNKNOWN;
+          for (const season of media.seasons) {
+            if (season.status === MediaStatus.PROCESSING) {
+              season.status = MediaStatus.UNKNOWN;
+            }
           }
+          await mediaRepository.save(media);
+          this.log(
+            `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any Sonarr server. Status reset to UNKNOWN.`,
+            'info'
+          );
         }
-        await mediaRepository.save(media);
-        this.log(
-          `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any Sonarr server. Status reset to UNKNOWN.`,
-          'info'
-        );
       }
+    } else {
+      this.log(
+        'Skipping orphaned show cleanup: no standard Sonarr servers were scanned.',
+        'info'
+      );
     }
 
-    if (this.enable4kShow) {
+    if (this.didScan4k) {
       const processing4kShows = await mediaRepository.find({
         where: { mediaType: MediaType.TV, status4k: MediaStatus.PROCESSING },
         relations: ['seasons'],
       });
 
       for (const media of processing4kShows) {
-        if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
+        if (media.tvdbId && !this.scanned4kTvdbIds.has(media.tvdbId)) {
           media.status4k = MediaStatus.UNKNOWN;
           for (const season of media.seasons) {
             if (season.status4k === MediaStatus.PROCESSING) {
@@ -204,6 +228,11 @@ class SonarrScanner
           );
         }
       }
+    } else if (this.enable4kShow) {
+      this.log(
+        'Skipping orphaned 4K show cleanup: no 4K Sonarr servers were scanned.',
+        'info'
+      );
     }
   }
 }

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -1,0 +1,522 @@
+import type { SonarrSeries } from '@server/api/servarr/sonarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbTvDetails,
+  TmdbTvSeasonResult,
+} from '@server/api/themoviedb/interfaces';
+import { MediaStatus, MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import Season from '@server/entity/Season';
+import type { SonarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+let getSeriesImpl: () => Promise<SonarrSeries[]> = async () => [];
+Object.defineProperty(SonarrAPI.prototype, 'getSeries', {
+  set() {},
+  get() {
+    return async () => getSeriesImpl();
+  },
+  configurable: true,
+});
+
+function fakeTmdbShow(
+  tmdbId: number,
+  seasons: TmdbTvSeasonResult[] = [
+    {
+      id: 1,
+      air_date: '2024-01-01',
+      episode_count: 10,
+      name: 'Season 1',
+      overview: '',
+      season_number: 1,
+    },
+  ]
+): TmdbTvDetails {
+  return {
+    id: tmdbId,
+    content_ratings: { results: [] },
+    created_by: [],
+    episode_run_time: [],
+    first_air_date: '2024-01-01',
+    genres: [],
+    homepage: '',
+    in_production: false,
+    languages: ['en'],
+    last_air_date: '2024-01-01',
+    name: 'Test Show',
+    networks: [],
+    number_of_episodes: 10,
+    number_of_seasons: 1,
+    origin_country: ['US'],
+    original_language: 'en',
+    original_name: 'Test Show',
+    overview: '',
+    popularity: 0,
+    production_companies: [],
+    production_countries: [],
+    spoken_languages: [],
+    seasons,
+    status: 'Ended',
+    type: 'Scripted',
+    vote_average: 0,
+    vote_count: 0,
+    aggregate_credits: { cast: [] },
+    credits: { crew: [] },
+    external_ids: {},
+    keywords: { results: [] },
+    videos: { results: [] },
+  };
+}
+
+let getShowByTvdbIdImpl: (args: {
+  tvdbId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+
+TheMovieDb.prototype.getShowByTvdbId = async function (args) {
+  return getShowByTvdbIdImpl(args);
+};
+
+let getTvShowImpl: (args: {
+  tvId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+
+Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
+  set() {},
+  get() {
+    return async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args);
+  },
+  configurable: true,
+});
+
+import { sonarrScanner } from '@server/lib/scanners/sonarr';
+
+setupTestDb();
+
+function fakeSonarrSeries(overrides: Partial<SonarrSeries> = {}): SonarrSeries {
+  return {
+    tvdbId: 100,
+    id: 1,
+    title: 'Test Show',
+    titleSlug: 'test-show',
+    monitored: true,
+    seasons: [
+      {
+        seasonNumber: 1,
+        monitored: true,
+        statistics: {
+          episodeFileCount: 10,
+          totalEpisodeCount: 10,
+          episodeCount: 10,
+          percentOfEpisodes: 100,
+          sizeOnDisk: 0,
+          previousAiring: undefined,
+        },
+      },
+    ],
+    ...overrides,
+  } as SonarrSeries;
+}
+
+function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.sonarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Sonarr ${i}`,
+    hostname: 'localhost',
+    port: 8989,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/tv',
+    activeLanguageProfileId: 1,
+    activeAnimeProfileId: undefined,
+    activeAnimeDirectory: '',
+    activeAnimeLanguageProfileId: undefined,
+    animeTags: [],
+    is4k: false,
+    enableSeasonFolders: true,
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as SonarrSettings[];
+  settings.radarr = [];
+}
+
+describe('Sonarr Scanner', () => {
+  beforeEach(() => {
+    getSeriesImpl = async () => [];
+    getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
+    getTvShowImpl = async () => fakeTmdbShow(1);
+  });
+
+  describe('orphaned show cleanup', () => {
+    it('skips cleanup when a standard server has sync disabled', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1050;
+      media.tvdbId = 550;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([
+        { syncEnabled: true, id: 0, hostname: 'server-a' },
+        { syncEnabled: false, id: 1, hostname: 'server-b' },
+      ]);
+
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1050 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+      assert.strictEqual(updated.seasons[0].status, MediaStatus.PROCESSING);
+    });
+
+    it('resets PROCESSING to UNKNOWN when show is not in any Sonarr server', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1000;
+      media.tvdbId = 500;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1000 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
+      assert.strictEqual(updated.seasons[0].status, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset AVAILABLE show when missing from Sonarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1001;
+      media.tvdbId = 501;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1001 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.AVAILABLE);
+    });
+
+    it('does not reset PROCESSING show that still exists in Sonarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1;
+      media.tvdbId = 200;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [
+        fakeSonarrSeries({
+          tvdbId: 200,
+          seasons: [
+            {
+              seasonNumber: 1,
+              monitored: true,
+              statistics: {
+                episodeFileCount: 0,
+                totalEpisodeCount: 10,
+                episodeCount: 10,
+                percentOfEpisodes: 0,
+                sizeOnDisk: 0,
+                previousAiring: undefined,
+              },
+            },
+          ],
+        }),
+      ];
+
+      getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
+      getTvShowImpl = async () => fakeTmdbShow(1);
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('only resets season statuses that are PROCESSING on orphaned shows', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1003;
+      media.tvdbId = 503;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1003 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
+
+      const s1 = updated.seasons.find((s) => s.seasonNumber === 1);
+      const s2 = updated.seasons.find((s) => s.seasonNumber === 2);
+      assert.strictEqual(s1?.status, MediaStatus.AVAILABLE);
+      assert.strictEqual(s2?.status, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset movie media that is missing from Sonarr', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1004;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1004 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('only resets orphaned shows not found across all servers', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const orphan = new Media();
+      orphan.tmdbId = 1010;
+      orphan.tvdbId = 510;
+      orphan.mediaType = MediaType.TV;
+      orphan.status = MediaStatus.PROCESSING;
+      orphan.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(orphan);
+
+      const existing = new Media();
+      existing.tmdbId = 2;
+      existing.tvdbId = 511;
+      existing.mediaType = MediaType.TV;
+      existing.status = MediaStatus.PROCESSING;
+      existing.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+      await mediaRepository.save(existing);
+
+      configureSonarr([
+        { syncEnabled: true, id: 0, hostname: 'server-a' },
+        { syncEnabled: true, id: 1, hostname: 'server-b' },
+      ]);
+
+      let callCount = 0;
+      getSeriesImpl = async () => {
+        callCount++;
+        if (callCount === 2) {
+          return [fakeSonarrSeries({ tvdbId: 511 })];
+        }
+        return [];
+      };
+
+      getShowByTvdbIdImpl = async () => fakeTmdbShow(2);
+      getTvShowImpl = async () => fakeTmdbShow(2);
+
+      await sonarrScanner.run();
+
+      const updatedOrphan = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1010 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updatedOrphan.status, MediaStatus.UNKNOWN);
+
+      const updatedExisting = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 2 },
+        relations: ['seasons'],
+      });
+      assert.notStrictEqual(updatedExisting.status, MediaStatus.UNKNOWN);
+    });
+
+    it('skips shows without a tvdbId during cleanup', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1020;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      media.seasons = [];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1020 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+  });
+
+  describe('4k orphaned show cleanup', () => {
+    it('resets 4k PROCESSING to UNKNOWN when show is not in any Sonarr server', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1030;
+      media.tvdbId = 530;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.UNKNOWN;
+      media.status4k = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.PROCESSING,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true, is4k: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1030 },
+        relations: ['seasons'],
+      });
+      assert.strictEqual(updated.status4k, MediaStatus.UNKNOWN);
+      assert.strictEqual(updated.seasons[0].status4k, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset 4k AVAILABLE season when show is orphaned', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1031;
+      media.tvdbId = 531;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.UNKNOWN;
+      media.status4k = MediaStatus.PROCESSING;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.AVAILABLE,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.PROCESSING,
+        }),
+      ];
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true, is4k: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1031 },
+        relations: ['seasons'],
+      });
+      const s1 = updated.seasons.find((s) => s.seasonNumber === 1);
+      const s2 = updated.seasons.find((s) => s.seasonNumber === 2);
+      assert.strictEqual(s1?.status4k, MediaStatus.AVAILABLE);
+      assert.strictEqual(s2?.status4k, MediaStatus.UNKNOWN);
+    });
+  });
+});


### PR DESCRIPTION
## Description
 
 This PR addresses a long-standing issue where media stuck in "Processing" status would never get cleared if the corresponding entry was deleted from Radarr or Sonarr entirely, or if a Radarr movie was unmonitored without a file. It supersedes #817 with an approach that matches #2311 so it can handle both the scanners.
 
 Previously, the Radarr scanner skipped unmonitored movies with no file entirely, meaning their status in Seerr was never updated. Now, these movies are still processed and their status is correctly reset to `Unknown` when they are no longer being actively tracked. The processing flag is also refined so that only monitored movies without a file are marked as `Processing`, rather than any movie without a file regardless of monitor state.
 
 For media that has been completely removed from Radarr or Sonarr (as raised by https://github.com/seerr-team/seerr/pull/2756#issuecomment-4113904699), I have added a post-scan cleanup step that checks for any media still in `Processing` status that was not seen during the scan across all configured servers. If a movie or show is not found in any servarr, its status (and season statuses for shows) are now correctly reset to `Unknown`. 
 
 This cleanup only targets `Processing` status, so media marked as `Available` by Plex or Jellyfin scanners is never affected.
 
 This PR builds on the season-level fix from #2311 which handles the case where a show still exists in Sonarr but specific seasons have zero episodes and are no longer processing. 
 
 TLDR; seasons cleaned up within an existing show, unmonitored Radarr movies, and media deleted entirely from either service are now properly processed.
 
 ## How Has This Been Tested?
 > [!note]
 > I have only tested this via unit testing instead of manually by mocking radarr/sonarr api and movies/series. I have not pushed the unit tests to this PR yet. **It should still work as expected though in theory**.
 
 ## Screenshots / Logs (if applicable)
 
 ## Checklist:
 
 - [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
 - [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
 - [ ] I have updated the documentation accordingly.
 - [X] All new and existing tests passed.
 - [X] Successful build `pnpm build`
 - [ ] Translation keys `pnpm i18n:extract`
 - [ ] Database migration (if required)
 
 
 <!-- This is an auto-generated comment: release notes by coderabbit.ai --> ## Summary by CodeRabbit  * **Bug Fixes**   * Refined status transitions: media without files are marked UNKNOWN (not AVAILABLE) in more cases; deleted state is preserved; mediaAddedAt/changed flags only update when status actually changes; scanners no longer create new media when no file exists. * **New Features**   * Per-run tracking (standard vs 4K) with automatic orphan cleanup of items stuck in PROCESSING when a full scan completes; cleanup is skipped if profile type wasn’t fully scanned. * **Tests**   * Added comprehensive scanner tests covering monitored/unmonitored behavior and orphaned cleanup for standard and 4K. <!-- end of auto-generated comment: release notes by coderabbit.ai -->