### PR TITLE
fix(auth): await session.save() before responding to prevent missing Set-Cookie header

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -203,6 +203,7 @@ authRoutes.post('/plex', async (req, res, next) => {
     // Set logged in session
     if (req.session) {
       req.session.userId = user.id;
+      await new Promise<void>((resolve) => req.session.save(resolve));
     }
 
     return res.status(200).json(user?.filter() ?? {});
@@ -505,6 +506,7 @@ authRoutes.post('/jellyfin', async (req, res, next) => {
     // Set logged in session
     if (req.session) {
       req.session.userId = user?.id;
+      await new Promise<void>((resolve) => req.session.save(resolve));
     }
 
     return res.status(200).json(user?.filter() ?? {});
@@ -628,6 +630,7 @@ authRoutes.post('/local', async (req, res, next) => {
     // Set logged in session
     if (user && req.session) {
       req.session.userId = user.id;
+      await new Promise<void>((resolve) => req.session.save(resolve));
     }
 
     return res.status(200).json(user?.filter() ?? {});


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

All three login endpoints (/plex, /jellyfin, /local) set req.session.userId but immediately call res.json() without awaiting session.save(). With saveUninitialized: false and an async TypeormStore backend, the session write races against the HTTP response — the Set-Cookie: connect.sid header is never sent to the browser. Every subsequent GET /api/v1/auth/me returns 401 even after a successful credential check, leaving the user permanently stuck on the login page.

Root cause: express-session with an async store requires session.save() to complete before headers are flushed. Without an explicit await, res.json() exits before the store callback fires.

Fix: added await new Promise<void>((resolve) => req.session.save(resolve)) in all three auth handlers before returning the 200 response.

Fixes login returning HTTP 200 with user data but no Set-Cookie header
Fixes all subsequent /api/v1/auth/me calls returning 401 after successful login

This PR was debugged and authored with AI assistance (Cursor). I have reviewed the code, understand the fix, and verified it manually on a running v3.1.0 instance.

- Fixes #XXXX

## How Has This Been Tested?

Reproduced and verified on v3.1.0 with Jellyfin auth + TypeormStore (SQLite):

Sent POST /api/v1/auth/jellyfin with valid credentials — confirmed response had no Set-Cookie header before fix, Set-Cookie: connect.sid=... present after fix
Verified session row count in SQLite session table increments on login after fix (previously unchanged)
Confirmed GET /api/v1/auth/me returns 200 with valid session cookie after fix
Tested all three handlers: /plex, /jellyfin, /local

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session persistence during authentication to ensure user login sessions are reliably saved across Plex, Jellyfin, and local authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->