### PR TITLE
fix(scanners): ignore unknown seasons in availability rollup and skip empty placeholder seasons

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -450,13 +450,22 @@ class BaseScanner<T> {
 
         // Check the actual season objects instead scanner input
         // to determine overall availability status
+        // UNKNOWN seasons are treated as neutral (no signal) rather than
+        // blockers, so a stale/orphan placeholder season can't hold the
+        // show at PARTIALLY_AVAILABLE indefinitely.
         const isAllStandardSeasonsAvailable =
           nonSpecialSeasons.length > 0 &&
-          nonSpecialSeasons.every((s) => s.status === MediaStatus.AVAILABLE);
+          nonSpecialSeasons
+            .filter((s) => s.status !== MediaStatus.UNKNOWN)
+            .every((s) => s.status === MediaStatus.AVAILABLE) &&
+          nonSpecialSeasons.some((s) => s.status === MediaStatus.AVAILABLE);
 
         const isAll4kSeasonsAvailable =
           nonSpecialSeasons.length > 0 &&
-          nonSpecialSeasons.every((s) => s.status4k === MediaStatus.AVAILABLE);
+          nonSpecialSeasons
+            .filter((s) => s.status4k !== MediaStatus.UNKNOWN)
+            .every((s) => s.status4k === MediaStatus.AVAILABLE) &&
+          nonSpecialSeasons.some((s) => s.status4k === MediaStatus.AVAILABLE);
 
         media.status = isAllStandardSeasonsAvailable
           ? MediaStatus.AVAILABLE
@@ -503,11 +512,17 @@ class BaseScanner<T> {
 
         const isAllStandardSeasonsAvailable =
           nonSpecialNewSeasons.length > 0 &&
-          nonSpecialNewSeasons.every((s) => s.status === MediaStatus.AVAILABLE);
+          nonSpecialNewSeasons
+            .filter((s) => s.status !== MediaStatus.UNKNOWN)
+            .every((s) => s.status === MediaStatus.AVAILABLE) &&
+          nonSpecialNewSeasons.some((s) => s.status === MediaStatus.AVAILABLE);
 
         const isAll4kSeasonsAvailable =
           nonSpecialNewSeasons.length > 0 &&
-          nonSpecialNewSeasons.every(
+          nonSpecialNewSeasons
+            .filter((s) => s.status4k !== MediaStatus.UNKNOWN)
+            .every((s) => s.status4k === MediaStatus.AVAILABLE) &&
+          nonSpecialNewSeasons.some(
             (s) => s.status4k === MediaStatus.AVAILABLE
           );
 

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -285,9 +285,11 @@ class JellyfinScanner
         const processableSeasons: ProcessableSeason[] = [];
 
         const settings = getSettings();
-        const filteredSeasons = settings.main.enableSpecialEpisodes
-          ? seasons
-          : seasons.filter((sn) => sn.season_number !== 0);
+        const filteredSeasons = (
+          settings.main.enableSpecialEpisodes
+            ? seasons
+            : seasons.filter((sn) => sn.season_number !== 0)
+        ).filter((sn) => sn.episode_count > 0);
 
         for (const season of filteredSeasons) {
           const matchedJellyfinSeason = jellyfinSeasons.find((md) => {

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -323,9 +323,11 @@ class PlexScanner
     const processableSeasons: ProcessableSeason[] = [];
     const settings = getSettings();
 
-    const filteredSeasons = settings.main.enableSpecialEpisodes
-      ? seasons
-      : seasons.filter((sn) => sn.season_number !== 0);
+    const filteredSeasons = (
+      settings.main.enableSpecialEpisodes
+        ? seasons
+        : seasons.filter((sn) => sn.season_number !== 0)
+    ).filter((sn) => sn.episode_count > 0);
 
     for (const season of filteredSeasons) {
       const matchedPlexSeason = metadata.Children?.Metadata.find(


### PR DESCRIPTION
## Description
Shows with empty placeholder seasons on TMDB (e.g. an unaired Season 2 stub created when a returning series is announced) were getting stuck at `PARTIALLY_AVAILABLE` even when every actual season was fully scanned and available. The Plex and Jellyfin scanners were iterating every TMDB season, persisting empty ones into the DB, and the show-level rollup in `processShow` then refused to promote the title because those orphan seasons sat there with no signal.

This PR addresses the issue from two angles.
- The Plex and Jellyfin scanners now skip TMDB seasons with no episode count, so empty placeholders never enter the DB in the first place. 
- The rollup in `processShow` now treats `UNKNOWN` seasons as neutral rather than blockers, with a guard ensuring at least one season is genuinely available so an all-`UNKNOWN` show is never falsely promoted. 
Sonarr is unaffected since it already gates on what Sonarr actively tracks.

The scanner filter prevents future orphans while the rollup change self-heals existing affected rows on the next scan. When an orphan placeholder later gets real episodes upstream, the existing transition logic picks it up normally.

This PR lands in tandem with #2757 and #2850, which target related but distinct symptoms of DB state drifting from media-server reality. #2757 resets orphaned processing shows and movies whose Radarr/Sonarr entries have been deleted, producing more legitimate UNKNOWN states that benefit directly from the neutral rollup treatment here. #2850 tightens the season existence check in availability sync so ghost seasons get correctly transitioned to deleted. 

**Each PR is independently mergeable**, but would highly recommend merging all three together for the cleanest end-state.

## How Has This Been Tested?
- I ran this change directly on my prod on a tv series with an empty placeholder season:
<img width="1311" height="757" alt="image" src="https://github.com/user-attachments/assets/79d17901-8a6a-4a04-a714-997368e93f4a" />
- Ran jellyfin full scan and now its marked as available instead of partially available.


## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV show availability detection by better handling unknown status states and requiring at least one available season to be present.
  * Fixed show processing for Jellyfin and Plex sources by excluding seasons with no episodes from being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->