### PR TITLE
fix(discover): preserve keyword filter input focus after selection

### DIFF
--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -295,7 +295,7 @@ export const KeywordSelector = ({
 }: BaseSelectorMultiProps | BaseSelectorSingleProps) => {
   const intl = useIntl();
   const [selectedValue, setSelectedValue] = useState<
-    MultiValue<SingleVal> | SingleValue<SingleVal> | null
+    MultiValue<SingleVal> | SingleValue<SingleVal>
   >(null);
 
   useEffect(() => {

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -295,7 +295,7 @@ export const KeywordSelector = ({
 }: BaseSelectorMultiProps | BaseSelectorSingleProps) => {
   const intl = useIntl();
   const [selectedValue, setSelectedValue] = useState<
-    MultiValue<SingleVal> | SingleValue<SingleVal>
+    MultiValue<SingleVal> | SingleValue<SingleVal> | null
   >(null);
 
   useEffect(() => {

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -294,9 +294,6 @@ export const KeywordSelector = ({
   onChange,
 }: BaseSelectorMultiProps | BaseSelectorSingleProps) => {
   const intl = useIntl();
-  const [defaultDataValue, setDefaultDataValue] = useState<
-    { label: string; value: number }[] | null
-  >(null);
   const [selectedValue, setSelectedValue] = useState<
     MultiValue<SingleVal> | SingleValue<SingleVal> | null
   >(null);
@@ -304,7 +301,6 @@ export const KeywordSelector = ({
   useEffect(() => {
     const loadDefaultKeywords = async (): Promise<void> => {
       if (!defaultValue) {
-        setDefaultDataValue(null);
         setSelectedValue(null);
         return;
       }
@@ -327,7 +323,6 @@ export const KeywordSelector = ({
         value: keyword.id,
       }));
 
-      setDefaultDataValue(nextValue);
       setSelectedValue(isMulti ? nextValue : (nextValue[0] ?? null));
     };
 
@@ -362,7 +357,6 @@ export const KeywordSelector = ({
           ? intl.formatMessage(messages.starttyping)
           : intl.formatMessage(messages.nooptions)
       }
-      defaultValue={defaultDataValue}
       value={selectedValue}
       loadOptions={loadKeywordOptions}
       placeholder={intl.formatMessage(messages.searchKeywords)}

--- a/src/components/Selector/index.tsx
+++ b/src/components/Selector/index.tsx
@@ -297,10 +297,15 @@ export const KeywordSelector = ({
   const [defaultDataValue, setDefaultDataValue] = useState<
     { label: string; value: number }[] | null
   >(null);
+  const [selectedValue, setSelectedValue] = useState<
+    MultiValue<SingleVal> | SingleValue<SingleVal> | null
+  >(null);
 
   useEffect(() => {
     const loadDefaultKeywords = async (): Promise<void> => {
       if (!defaultValue) {
+        setDefaultDataValue(null);
+        setSelectedValue(null);
         return;
       }
 
@@ -317,16 +322,17 @@ export const KeywordSelector = ({
         (keyword): keyword is Keyword => keyword !== null
       );
 
-      setDefaultDataValue(
-        validKeywords.map((keyword) => ({
-          label: keyword.name,
-          value: keyword.id,
-        }))
-      );
+      const nextValue = validKeywords.map((keyword) => ({
+        label: keyword.name,
+        value: keyword.id,
+      }));
+
+      setDefaultDataValue(nextValue);
+      setSelectedValue(isMulti ? nextValue : (nextValue[0] ?? null));
     };
 
     loadDefaultKeywords();
-  }, [defaultValue]);
+  }, [defaultValue, isMulti]);
 
   const loadKeywordOptions = async (inputValue: string) => {
     const results = await axios.get<TmdbKeywordSearchResponse>(
@@ -346,7 +352,6 @@ export const KeywordSelector = ({
 
   return (
     <AsyncSelect
-      key={`keyword-select-${defaultDataValue}`}
       inputId="data"
       isMulti={isMulti}
       isDisabled={isDisabled}
@@ -358,9 +363,11 @@ export const KeywordSelector = ({
           : intl.formatMessage(messages.nooptions)
       }
       defaultValue={defaultDataValue}
+      value={selectedValue}
       loadOptions={loadKeywordOptions}
       placeholder={intl.formatMessage(messages.searchKeywords)}
       onChange={(value) => {
+        setSelectedValue(value);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onChange(value as any);
       }}


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The PR fixes an annoying issue in Discover where the keyword and exclude-keyword filters would lose focus every time you selected a value. This happened because the selector component was being remounted on each update.

- Fixes #2830

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Typed a keyword, hit enter, repeated without loosing input focus.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyword selector now reliably syncs selection state between single- and multi-select modes and with external handlers.
  * Default-value handling improved: missing defaults clear the current selection; when defaults are present they load correctly without forcing component remounts, and user choices update state immediately before external change handlers are called.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/2962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->