### PR TITLE
fix(api): erroneous setting nesting in MetadataSettings

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -522,17 +522,14 @@ components:
     MetadataSettings:
       type: object
       properties:
-        settings:
-          type: object
-          properties:
-            tv:
-              type: string
-              enum: [tvdb, tmdb]
-              example: 'tvdb'
-            anime:
-              type: string
-              enum: [tvdb, tmdb]
-              example: 'tvdb'
+        tv:
+          type: string
+          enum: [tvdb, tmdb]
+          example: 'tvdb'
+        anime:
+          type: string
+          enum: [tvdb, tmdb]
+          example: 'tvdb'
     TautulliSettings:
       type: object
       properties:


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes the api `settings/metadatas` route in the OpenAPI schema. The request and response bodies were previously incorrect (nested inside settings, but this doesn't exist in the API code @ https://github.com/seerr-team/seerr/blob/develop/server/routes/settings/metadata.ts).

## How Has This Been Tested?

Visually verified to be correct.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured metadata settings API response format to simplify data access by removing an intermediate wrapper layer and promoting configuration properties to the top level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->