### PR TITLE
chore: cleanup intl polyfills and dev config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ module.exports = {
       { hostname: 'plex.tv' },
     ],
   },
+  transpilePackages: ['country-flag-icons'],
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "postinstall": "next telemetry disable",
-    "dev": "nodemon -e ts --watch server --watch seerr-api.yml -e .json,.ts,.yml -x ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts",
+    "dev": "nodemon -e ts,json,yml --watch server --watch seerr-api.yml --exec 'ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts'",
     "build:server": "tsc --project server/tsconfig.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && copyfiles -u 2 \"server/i18n/locale/*.json\" dist/i18n && tsc-alias -p server/tsconfig.json",
     "build:next": "next build",
     "build": "pnpm build:next && pnpm build:server",
@@ -37,9 +37,7 @@
     "@dr.pogodin/csurf": "^1.16.9",
     "@fontsource-variable/inter": "^5.2.8",
     "@formatjs/intl": "^4.1.4",
-    "@formatjs/intl-displaynames": "7.3.2",
     "@formatjs/intl-locale": "5.3.2",
-    "@formatjs/intl-pluralrules": "6.3.2",
     "@headlessui/react": "1.7.19",
     "@heroicons/react": "2.2.0",
     "@react-spring/web": "^10.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,15 +21,9 @@ importers:
       '@formatjs/intl':
         specifier: ^4.1.4
         version: 4.1.4(typescript@5.4.5)
-      '@formatjs/intl-displaynames':
-        specifier: 7.3.2
-        version: 7.3.2
       '@formatjs/intl-locale':
         specifier: 5.3.2
         version: 5.3.2
-      '@formatjs/intl-pluralrules':
-        specifier: 6.3.2
-        version: 6.3.2
       '@headlessui/react':
         specifier: 1.7.19
         version: 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1322,9 +1316,6 @@ packages:
   '@formatjs/bigdecimal@0.2.0':
     resolution: {integrity: sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==}
 
-  '@formatjs/bigdecimal@0.2.1':
-    resolution: {integrity: sha512-WbdsKlM5RH2boxpIQH5Rd1Ph7cqTP6oG7S+1heE1+voUHBQpzq1NfxBuQ7kTitHGPiK+6OtwKJo0IwhQ2qtPPQ==}
-
   '@formatjs/ecma402-abstract@2.3.6':
     resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
 
@@ -1358,9 +1349,6 @@ packages:
   '@formatjs/icu-skeleton-parser@2.1.4':
     resolution: {integrity: sha512-8bSFZbrlvGX11ywMZxtgkPBt5Q8/etyts7j7j+GWpOVK1g43zwMIH3LZxk43HAtEP7L/jtZ+OZaMiFTOiBj9CA==}
 
-  '@formatjs/intl-displaynames@7.3.2':
-    resolution: {integrity: sha512-ZJzJJ/GI6KihaoXBLvxr0lpTclVwg9Ia8bmExfUX4lka+camqj6AnF5ZdJvvqYa/ggkfzqQhvoCx2tWjwYoamA==}
-
   '@formatjs/intl-getcanonicallocales@3.2.3':
     resolution: {integrity: sha512-h6rLO0ny+SVffeAZWrmqwipgGpNFUHdTy09XM5YdXAlzqK/QXbMcuwMcocofXcBhA5Jy46B45qMHVOp3/7CtOA==}
 
@@ -1372,12 +1360,6 @@ packages:
 
   '@formatjs/intl-localematcher@0.8.2':
     resolution: {integrity: sha512-q05KMYGJLyqFNFtIb8NhWLF5X3aK/k0wYt7dnRFuy6aLQL+vUwQ1cg5cO4qawEiINybeCPXAWlprY2mSBjSXAQ==}
-
-  '@formatjs/intl-localematcher@0.8.3':
-    resolution: {integrity: sha512-pHUjWb9NuhnMs8+PxQdzBtZRFJHlGhrURGAbm6Ltwl82BFajeuiIR3jblSa7ia3r62rXe/0YtVpUG3xWr5bFCA==}
-
-  '@formatjs/intl-pluralrules@6.3.2':
-    resolution: {integrity: sha512-RF+zofaCz4k2hPp2rXsoOglQuNxRy2nADxGegT+bpgeg3Rn8JI6Tf1lBbIj5OJcmBpCgYVSAxq4esXMeor9Hmg==}
 
   '@formatjs/intl-supportedvaluesof@2.3.1':
     resolution: {integrity: sha512-zSlTDGVHZJFEKRimtEhtsXOMrfjdz/Yvuvt8AfqXuLoUXkMaIH2ThMRbfQuy/VLyMNyRhqDv2V4NWJXushaVNw==}
@@ -9425,8 +9407,6 @@ snapshots:
 
   '@formatjs/bigdecimal@0.2.0': {}
 
-  '@formatjs/bigdecimal@0.2.1': {}
-
   '@formatjs/ecma402-abstract@2.3.6':
     dependencies:
       '@formatjs/fast-memoize': 2.2.7
@@ -9474,10 +9454,6 @@ snapshots:
 
   '@formatjs/icu-skeleton-parser@2.1.4': {}
 
-  '@formatjs/intl-displaynames@7.3.2':
-    dependencies:
-      '@formatjs/intl-localematcher': 0.8.3
-
   '@formatjs/intl-getcanonicallocales@3.2.3': {}
 
   '@formatjs/intl-locale@5.3.2':
@@ -9492,15 +9468,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.8.2':
     dependencies:
       '@formatjs/fast-memoize': 3.1.1
-
-  '@formatjs/intl-localematcher@0.8.3':
-    dependencies:
-      '@formatjs/fast-memoize': 3.1.2
-
-  '@formatjs/intl-pluralrules@6.3.2':
-    dependencies:
-      '@formatjs/bigdecimal': 0.2.1
-      '@formatjs/intl-localematcher': 0.8.3
 
   '@formatjs/intl-supportedvaluesof@2.3.1':
     dependencies:

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -323,7 +323,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     : currentSettings.locale;
 
   const messages = await loadLocaleData(locale as AvailableLocale);
-  await polyfillIntl(locale);
+  await polyfillIntl();
 
   return { ...appInitialProps, user, messages, locale, currentSettings };
 };

--- a/src/utils/polyfillIntl.ts
+++ b/src/utils/polyfillIntl.ts
@@ -1,6 +1,4 @@
-import { shouldPolyfill as shouldPolyfillDisplayNames } from '@formatjs/intl-displaynames/should-polyfill.js';
 import { shouldPolyfill as shouldPolyfillLocale } from '@formatjs/intl-locale/should-polyfill.js';
-import { shouldPolyfill as shouldPolyfillPluralrules } from '@formatjs/intl-pluralrules/should-polyfill.js';
 
 const polyfillLocale = async () => {
   if (shouldPolyfillLocale()) {
@@ -8,34 +6,6 @@ const polyfillLocale = async () => {
   }
 };
 
-const polyfillPluralRules = async (locale: string) => {
-  const unsupportedLocale = shouldPolyfillPluralrules(locale);
-  // This locale is supported
-  if (!unsupportedLocale) {
-    return;
-  }
-  // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-pluralrules/polyfill-force.js');
-  await import(
-    `@formatjs/intl-pluralrules/locale-data/${unsupportedLocale}.js`
-  );
-};
-
-const polyfillDisplayNames = async (locale: string) => {
-  const unsupportedLocale = shouldPolyfillDisplayNames(locale);
-  // This locale is supported
-  if (!unsupportedLocale) {
-    return;
-  }
-  // Load the polyfill 1st BEFORE loading data
-  await import('@formatjs/intl-displaynames/polyfill-force.js');
-  await import(
-    `@formatjs/intl-displaynames/locale-data/${unsupportedLocale}.js`
-  );
-};
-
-export const polyfillIntl = async (locale: string) => {
+export const polyfillIntl = async () => {
   await polyfillLocale();
-  await polyfillPluralRules(locale);
-  await polyfillDisplayNames(locale);
 };


### PR DESCRIPTION
## Description

This PR fixes the JavaScript heap out-of-memory error on the dev server introduced by #2874 when compiling `/`. The OOM was caused by `intl-pluralrules` and `intl-displaynames` loading large locale data files on every request via `polyfillIntl()` in `_app.tsx`, exhausting heap memory during development.

Both polyfills were unnecessary to begin with. `intl-pluralrules` was removed because all browsers we support have natively supported Intl.PluralRules since a long time ago.
<img width="874" height="1178" alt="image" src="https://github.com/user-attachments/assets/3398ce36-36d3-4689-b49f-991e945caf64" />

`intl-displaynames` because the only known browser issue affects `{ format: 'script' }` (https://github.com/formatjs/formatjs/issues/5889), which we don't use. `polyfillIntl` now only polyfills `Intl.Locale` which has a legitimate compatibility reason to exist.

Also fixes the nodemon `dev` script which had `-e` specified twice with conflicting values and used the legacy `-x` flag instead of `--exec`. Finally adds `transpilePackages: ['country-flag-icons']` to suppress a webpack cache warning on every build caused by the package using CommonJS as its main entry point, which confused webpack's JSON module resolution.

## How Has This Been Tested?
- Ran `pnpm dev`
- Visited `/` and waited for it to compile and load successfully without javscript heap memory OOMing.
- Without this fix, javascript heap memory OOM'd consistently.  

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated Next.js configuration to improve country-flag-icons build handling
- Streamlined internationalization polyfill logic and removed unused components to reduce bundle size
- Enhanced development server configuration with improved TypeScript file processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->