### PR TITLE
docs: add Terraform/OpenTofu provider page

### DIFF
--- a/docs/extending-seerr/terraform-provider.mdx
+++ b/docs/extending-seerr/terraform-provider.mdx
@@ -60,5 +60,3 @@ The provider also includes resources and data sources for common Seerr integrati
 - Issues
 - Background job schedules
 - And many more.
-
-See the [provider documentation](https://search.opentofu.org/provider/josh-archer/seerr/latest/docs) for the full resource and data source reference.

--- a/docs/extending-seerr/terraform-provider.mdx
+++ b/docs/extending-seerr/terraform-provider.mdx
@@ -1,0 +1,64 @@
+---
+title: Terraform/OpenTofu Provider (Advanced)
+description: Manage Seerr settings and integrations with the community Terraform/OpenTofu provider.
+sidebar_position: 4
+---
+
+# Terraform/OpenTofu Provider (Advanced)
+
+:::warning
+This provider is maintained by the community, not by the Seerr team. Please report bugs or feature requests in the [provider repository](https://github.com/Josh-Archer/terraform-provider-seerr).
+:::
+
+The community-maintained [Seerr Terraform/OpenTofu provider](https://search.opentofu.org/provider/josh-archer/seerr/latest) can manage Seerr settings and integrations from infrastructure-as-code workflows.
+
+## Basic Example
+
+Configure the provider with your Seerr URL and API key, then manage Seerr resources in the same configuration as the rest of your infrastructure.
+
+```hcl
+terraform {
+  required_providers {
+    seerr = {
+      source = "registry.opentofu.org/josh-archer/seerr"
+    }
+  }
+}
+
+variable "seerr_api_key" {
+  type      = string
+  sensitive = true
+}
+
+provider "seerr" {
+  url                  = "https://seerr.example.com"
+  api_key              = var.seerr_api_key
+  insecure_skip_verify = false # Set to true for self-signed certificates.
+}
+
+resource "seerr_main_settings" "main" {
+  app_title               = "Seerr"
+  application_url         = "https://seerr.example.com"
+  locale                  = "en"
+  movie_requests_enabled  = true
+  series_requests_enabled = true
+}
+```
+
+The provider also includes resources and data sources for common Seerr integrations:
+
+- Plex
+- Jellyfin
+- Emby
+- Radarr
+- Sonarr
+- Tautulli
+- Notifications
+- Users
+- Permissions
+- Requests
+- Issues
+- Background job schedules
+- And many more.
+
+See the [provider documentation](https://search.opentofu.org/provider/josh-archer/seerr/latest/docs) for the full resource and data source reference.


### PR DESCRIPTION
## Description

Adds a page under Extending Seerr that links to the community Terraform/OpenTofu provider and shows a basic provider configuration example.

This follows the request from the maintainer comment on #2644 to add a link and basic example once the provider is stable enough to document.

- Fixes #2644

## How Has This Been Tested?

Using Node v22.21.1 and pnpm v10.24.0:

- `pnpm exec prettier --check docs/extending-seerr/terraform-provider.mdx`
- `pnpm build`
- `pnpm i18n:extract`

`pnpm i18n:extract` completed successfully and did not leave any documentation-related changes to commit.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)

**AI Disclosure:** Codex was used to draft the documentation page and PR text. I reviewed the generated content against the provider examples and Seerr contribution guide before submitting this draft PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an advanced docs page for the community-maintained Terraform/OpenTofu provider: includes a maintenance notice, provider configuration examples (URL, API key handling, TLS verification), a sample resource for managing core settings, a list of supported integrations and resource areas (Plex/Jellyfin/Emby, Radarr/Sonarr, notifications, users/permissions/requests/issues, job schedules), and a link to the provider reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->