### PR TITLE
fix(tvrequest): allow special episodes when partial series requests are disabled

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -202,8 +202,7 @@ const TvRequestModal = ({
         seasons: settings.currentSettings.partialRequestsEnabled
           ? selectedSeasons.sort((a, b) => a - b)
           : getAllSeasons().filter(
-              (season) =>
-                !getAllRequestedSeasons().includes(season) && season !== 0
+              (season) => !getAllRequestedSeasons().includes(season)
             ),
         ...overrideParams,
       });
@@ -303,10 +302,8 @@ const TvRequestModal = ({
     }
   };
 
-  const unrequestedSeasons = getAllSeasons().filter((season) =>
-    !settings.currentSettings.partialRequestsEnabled
-      ? !getAllRequestedSeasons().includes(season) && season !== 0
-      : !getAllRequestedSeasons().includes(season)
+  const unrequestedSeasons = getAllSeasons().filter(
+    (season) => !getAllRequestedSeasons().includes(season)
   );
 
   const toggleAllSeasons = (): void => {
@@ -318,16 +315,12 @@ const TvRequestModal = ({
       return;
     }
 
-    const standardUnrequestedSeasons = unrequestedSeasons.filter(
-      (seasonNumber) => seasonNumber !== 0
-    );
-
     if (
       data &&
       selectedSeasons.length >= 0 &&
-      selectedSeasons.length < standardUnrequestedSeasons.length
+      selectedSeasons.length < unrequestedSeasons.length
     ) {
-      setSelectedSeasons(standardUnrequestedSeasons);
+      setSelectedSeasons(unrequestedSeasons);
     } else {
       setSelectedSeasons([]);
     }
@@ -581,13 +574,9 @@ const TvRequestModal = ({
                   {data?.seasons
                     .filter(
                       (season) =>
-                        (!settings.currentSettings.enableSpecialEpisodes
-                          ? season.seasonNumber !== 0
-                          : true) &&
-                        (!settings.currentSettings.partialRequestsEnabled
-                          ? season.episodeCount !== 0 &&
-                            season.seasonNumber !== 0
-                          : season.episodeCount !== 0)
+                        season.episodeCount !== 0 &&
+                        (settings.currentSettings.enableSpecialEpisodes ||
+                          season.seasonNumber !== 0)
                     )
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(


### PR DESCRIPTION
## Description

This PR modifies the seasons filter when requesting a series. The special season was previously hidden when partial series requests were disabled, even though it was enabled in the settings.

- Fixes #2969

## How Has This Been Tested?

Disable Partial Series and enabled Special Episodes, then try to request a series with special episodes.

## Screenshots / Logs (if applicable)

New behavior:

Partial Series = Disabled ; Special Episodes = Disabled
<img width="837" height="438" alt="image" src="https://github.com/user-attachments/assets/af8d90b3-25d3-42f2-9f7a-2ee4e8997b3b" />

Partial Series = Disabled ; Special Episodes = Enabled
<img width="837" height="497" alt="image" src="https://github.com/user-attachments/assets/7a2d7abb-cfa7-494d-bc30-bab6906da1b2" />

Partial Series = Enabled ; Special Episodes = Disabled
<img width="837" height="455" alt="image" src="https://github.com/user-attachments/assets/e5a50be1-d302-4adc-a6ef-3a4790a5df2b" />

Partial Series = Enabled ; Special Episodes = Enabled
<img width="837" height="519" alt="image" src="https://github.com/user-attachments/assets/123bcd75-0718-4294-b637-b1bc5a0ffd09" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TV request modal: season selection and filtering improved. Already-requested seasons are consistently excluded, special (season 0) visibility now respects the "enable special episodes" setting, and empty seasons remain hidden. "Select all" correctly includes all available (unrequested) seasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->