### PR TITLE
fix(slider): add async to spring animation

### DIFF
--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -33,6 +33,7 @@ const Slider = ({
   const [scrollPos, setScrollPos] = useState({ isStart: true, isEnd: false });
 
   const handleScroll = useCallback(() => {
+    const margin = 5;
     const scrollWidth = containerRef.current?.scrollWidth ?? 0;
     const clientWidth =
       containerRef.current?.getBoundingClientRect().width ?? 0;
@@ -44,10 +45,10 @@ const Slider = ({
       setScrollPos({ isStart: true, isEnd: true });
     } else if (
       scrollPosition >=
-      (containerRef.current?.scrollWidth ?? 0) - clientWidth
+      (containerRef.current?.scrollWidth ?? 0) - clientWidth - margin
     ) {
       setScrollPos({ isStart: false, isEnd: true });
-    } else if (scrollPosition > 0) {
+    } else if (scrollPosition > margin) {
       setScrollPos({ isStart: false, isEnd: false });
     } else {
       setScrollPos({ isStart: true, isEnd: false });
@@ -83,14 +84,9 @@ const Slider = ({
   const [, setX] = useSpring(() => ({
     from: { x: 0 },
     to: { x: 0 },
-    onChange: (results) => {
-      if (containerRef.current) {
-        containerRef.current.scrollLeft = results.value.x;
-      }
-    },
   }));
 
-  const slide = (direction: Direction) => {
+  const slide = async (direction: Direction) => {
     const clientWidth =
       containerRef.current?.getBoundingClientRect().width ?? 0;
     const cardWidth =
@@ -105,7 +101,7 @@ const Slider = ({
         scrollPosition - scrollOffset - visibleItems * cardWidth,
         0
       );
-      setX.start({
+      await setX.start({
         from: { x: scrollPosition },
         to: { x: newX },
         onChange: (results) => {
@@ -115,7 +111,7 @@ const Slider = ({
         },
         reset: true,
         config: { friction: 60, tension: 500, velocity: 20 },
-      });
+      })[0];
 
       if (newX === 0) {
         setScrollPos({ isStart: true, isEnd: false });
@@ -127,7 +123,7 @@ const Slider = ({
         scrollPosition - scrollOffset + visibleItems * cardWidth,
         containerRef.current?.scrollWidth ?? 0 - clientWidth
       );
-      setX.start({
+      await setX.start({
         from: { x: scrollPosition },
         to: { x: newX },
         onChange: (results) => {
@@ -137,7 +133,7 @@ const Slider = ({
         },
         reset: true,
         config: { friction: 60, tension: 500, velocity: 20 },
-      });
+      })[0];
 
       if (newX >= (containerRef.current?.scrollWidth ?? 0) - clientWidth) {
         setScrollPos({ isStart: false, isEnd: true });


### PR DESCRIPTION

## Description

Due to the update of `react-spring` to v10 in #2874, the buttons of the slider in the Discover page where not working anymore.
This PRs fixes this and also adds a small `margin` to enable/disable the buttons when the scroll is very near the beginning/end of the scrollWidth.

## How Has This Been Tested?

Click on the slider buttons on the homepage

## Screenshots / Logs (if applicable)

These buttons where not working anymore.
<img width="2203" height="1118" alt="image" src="https://github.com/user-attachments/assets/fa6308ff-4e41-4612-89eb-194587d163af" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved slider animation handling by restructuring internal scroll update logic.
  * Enhanced scroll position threshold detection with refined boundary offset calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->