### PR TITLE
feat(helm): add service annotations

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.5.2
+version: 3.6.0
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.2.0'
 maintainers:

--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.5.1
+version: 3.5.2
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.2.0'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.0](https://img.shields.io/badge/AppVersion-v3.2.0-informational?style=flat-square)
+![Version: 3.6.0](https://img.shields.io/badge/Version-3.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.0](https://img.shields.io/badge/AppVersion-v3.2.0-informational?style=flat-square)
 
 Seerr helm chart for Kubernetes
 

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 3.5.1](https://img.shields.io/badge/Version-3.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.0](https://img.shields.io/badge/AppVersion-v3.2.0-informational?style=flat-square)
+![Version: 3.5.2](https://img.shields.io/badge/Version-3.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.2.0](https://img.shields.io/badge/AppVersion-v3.2.0-informational?style=flat-square)
 
 Seerr helm chart for Kubernetes
 
@@ -101,6 +101,7 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | service.port | int | `80` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.annotations | object | {} |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |

--- a/charts/seerr-chart/templates/service.yaml
+++ b/charts/seerr-chart/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "seerr.fullname" . }}
   labels:
     {{- include "seerr.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -70,8 +70,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
-  annotations:
-    tailscale.com/expose: 'true'
+  annotations: {}
 
 # -- Creating PVC to store configuration
 config:

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -70,6 +70,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
+  annotations:
+    tailscale.com/expose: 'true'
 
 # -- Creating PVC to store configuration
 config:


### PR DESCRIPTION
## Description

Service annotations are not currently supported by the chart. My main goal is to use [Tailscale operator](https://tailscale.com/docs/features/kubernetes-operator), which requires exposing a service with an annotation `tailscale.com/expose: "true"`. So this change allows helm chart user to do just that.

## How Has This Been Tested?

Change has been ran in kind and in k3s cluster.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional support for user-defined Service annotations to customize Kubernetes Service metadata.
  * Documentation updated to describe the new annotations option.

* **Chores**
  * Bumped Helm chart version to 3.6.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->