### PR TITLE
fix(tag): use inset ring to avoid clipped outlines

### DIFF
--- a/src/components/Common/Tag/index.tsx
+++ b/src/components/Common/Tag/index.tsx
@@ -8,7 +8,7 @@ type TagProps = {
 
 const Tag = ({ children, iconSvg }: TagProps) => {
   return (
-    <div className="inline-flex cursor-pointer items-center rounded-full bg-gray-800 px-2 py-1 text-sm text-gray-200 ring-1 ring-gray-600 transition hover:bg-gray-700">
+    <div className="inline-flex cursor-pointer items-center rounded-full bg-gray-800 px-2 py-1 text-sm leading-snug text-gray-200 ring-1 ring-inset ring-gray-600 transition hover:bg-gray-700">
       {iconSvg ? (
         React.cloneElement(iconSvg, {
           className: 'mr-1 h-4 w-4',


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes tags being cut off on the last row by keeping the ring inside and slightly adjusting the text spacing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go to **Family Guy** series details page and see.

## Screenshots / Logs (if applicable)

### Before
<img width="1284" height="104" alt="image" src="https://github.com/user-attachments/assets/826bb34c-0198-4f10-8c7b-304f0906ff12" />

### After
<img width="1296" height="91" alt="image" src="https://github.com/user-attachments/assets/c2244ba6-e810-42fd-b077-dc1049ff59cd" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced Tag component styling with refined typography spacing and border refinements for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->