### PR TITLE
fix(plex-watchlist-sync): handle MediaContainer.Video fallback in watchlist sync  

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -107,24 +107,18 @@ interface WatchlistResponse {
   };
 }
 
+type PlexMetadataItem = {
+  ratingKey: string;
+  type: 'movie' | 'show';
+  title: string;
+  Guid?: {
+    id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
+  }[];
+};
 interface MetadataResponse {
   MediaContainer: {
-    Metadata?: {
-      ratingKey: string;
-      type: 'movie' | 'show';
-      title: string;
-      Guid?: {
-        id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
-      }[];
-    }[];
-    Video?: {
-      ratingKey: string;
-      type: 'movie' | 'show';
-      title: string;
-      Guid?: {
-        id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
-      }[];
-    }[];
+    Metadata?: PlexMetadataItem[];
+    Video?: PlexMetadataItem[];
   };
 }
 

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -109,7 +109,15 @@ interface WatchlistResponse {
 
 interface MetadataResponse {
   MediaContainer: {
-    Metadata: {
+    Metadata?: {
+      ratingKey: string;
+      type: 'movie' | 'show';
+      title: string;
+      Guid?: {
+        id: `imdb://tt${number}` | `tmdb://${number}` | `tvdb://${number}`;
+      }[];
+    }[];
+    Video?: {
       ratingKey: string;
       type: 'movie' | 'show';
       title: string;
@@ -332,7 +340,17 @@ class PlexTvAPI extends ExternalAPI {
               }
             }
 
-            const metadata = detailedResponse.MediaContainer.Metadata[0];
+            const metadata =
+              detailedResponse.MediaContainer.Metadata?.[0] ??
+              detailedResponse.MediaContainer.Video?.[0];
+
+            if (!metadata) {
+              logger.warn(
+                `Item with ratingKey ${watchlistItem.ratingKey} returned no metadata, skipping.`,
+                { label: 'Plex.TV Metadata API' }
+              );
+              return null;
+            }
 
             const tmdbString = metadata.Guid?.find((guid) =>
               guid.id.startsWith('tmdb')


### PR DESCRIPTION
## Description

Plex Discover occasionally returns metadata under `<Video>` instead of `<Metadata>` inside MediaContainer. The previous code accessed `Metadata[0]` directly, throwing when the field was absent and causing the entire Plex Watchlist Sync job to fail silently.                                                                                        
                                                                                                                                                  
  - Make `Metadata` optional and add `Video` with the same shape to the `MetadataResponse` interface                                                                                                                  
  - Resolve the item from whichever field is present via optional chaining and nullish coalescing (`Metadata?.[0] ?? Video?.[0]`)
  - Skip items gracefully with a warning log when neither field exists

- Fixes #2948 

## How Has This Been Tested?

- *Build & Setup*: Project built successfully locally and initial setup completed without issues.
- *Automated Tests*: All test suites were executed and passed successfully using the pnpm test command.
- *Manual Verification*: Manually tested in local environment with pnpm dev: added "Marty Supreme" (`ratingKey 669748dc85be974cd2ab194c`) to the Plex Watchlist, triggered the `Plex Watchlist Sync job`, and confirmed the movie appeared correctly in the "Your Watchlist" column on the Seerr home page with no errors in the logs.

## Screenshots / Logs

<img width="1920" height="1048" alt="Screenshot from 2026-05-04 13-51-35" src="https://github.com/user-attachments/assets/fe2c797a-97b4-4c40-8eae-759caa319eb0" />

<img width="1920" height="1048" alt="Screenshot from 2026-05-04 13-51-46" src="https://github.com/user-attachments/assets/b0468d69-6aee-49a1-9d11-9c8716988000" />

<img width="1920" height="1048" alt="Screenshot from 2026-05-04 13-52-23" src="https://github.com/user-attachments/assets/5f77defc-fc6c-48a6-8f85-6b2654e36e07" />

<img width="1920" height="1048" alt="Screenshot from 2026-05-04 14-03-18" src="https://github.com/user-attachments/assets/af7d4400-7379-4b18-88c1-0abd2e17889a" />

```
usuario01@usuario01-Inspiron-15-7000-Gaming:~/seerr$ pnpm dev

> seerr@0.1.0 dev /home/usuario01/seerr
> nodemon -e ts,json,yml --watch server --watch seerr-api.yml --exec 'ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts'

[nodemon] 3.1.14
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): server/**/* seerr-api.yml
[nodemon] watching extensions: ts,json,yml
[nodemon] starting `ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts`
2026-05-04T16:42:50.684Z [info]: Starting Seerr version develop-local 
2026-05-04T16:42:53.025Z [debug][Settings Migrator]: Checking migration '0001_migrate_hostname.ts'... 
2026-05-04T16:42:53.029Z [debug][Settings Migrator]: Checking migration '0002_migrate_apitokens.ts'... 
2026-05-04T16:42:53.042Z [debug][Settings Migrator]: Checking migration '0003_emby_media_server_type.ts'... 
2026-05-04T16:42:53.045Z [debug][Settings Migrator]: Checking migration '0004_migrate_region_setting.ts'... 
2026-05-04T16:42:53.048Z [debug][Settings Migrator]: Checking migration '0005_migrate_network_settings.ts'... 
2026-05-04T16:42:53.053Z [debug][Settings Migrator]: Checking migration '0006_remove_lunasea.ts'... 
2026-05-04T16:42:53.057Z [debug][Settings Migrator]: Checking migration '0007_migrate_arr_tags.ts'... 
2026-05-04T16:42:53.070Z [debug][Settings Migrator]: Checking migration '0008_migrate_blacklist_to_blocklist.ts'... 
2026-05-04T16:42:53.109Z [info][Notifications]: Registered notification agents 
2026-05-04T16:42:53.137Z [info][Jobs]: Scheduled jobs loaded 
2026-05-04T16:42:53.204Z [info][Server]: Server ready on port 5055 
2026-05-04T16:43:00.004Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:44:00.005Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:45:00.004Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:45:00.011Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T16:45:00.019Z [info][Jobs]: Starting scheduled job: Plex Recently Added Scan 
2026-05-04T16:45:00.019Z [info][Plex Scan]: Scan starting {"sessionId":"ceab70ad-11cb-45d8-89ea-632e4feacf85"}
2026-05-04T16:45:00.046Z [info][Plex Scan]: Beginning to process recently added for library: Movies {"lastScan":1776875100025}
2026-05-04T16:45:00.056Z [info][Plex Scan]: Recently Added Scan Complete 
2026-05-04T16:46:00.006Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:47:00.006Z [debug][Jobs]: Starting scheduled job: Download Sync 
 ○ Compiling / ...
 ✓ Compiled / in 12.4s (2640 modules)
2026-05-04T16:48:00.693Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:48:00.702Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
 GET / 200 in 15661ms
2026-05-04T16:49:00.008Z [debug][Jobs]: Starting scheduled job: Download Sync 
 ○ Compiling /search ...
 ✓ Compiled /search in 1882ms (2652 modules)
 ○ Compiling /movie/[movieId] ...
 ✓ Compiled /movie/[movieId] in 1984ms (2785 modules)
 GET /_next/data/development/movie/1317288.json?movieId=1317288 200 in 1472ms
2026-05-04T16:50:00.005Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:50:00.014Z [info][Jobs]: Starting scheduled job: Plex Recently Added Scan 
2026-05-04T16:50:00.015Z [info][Plex Scan]: Scan starting {"sessionId":"67e3b0e4-0069-4e4e-8f60-fc1bc37a76a7"}
2026-05-04T16:50:00.022Z [info][Plex Scan]: Beginning to process recently added for library: Movies {"lastScan":1777913100055}
2026-05-04T16:50:00.026Z [info][Plex Scan]: Recently Added Scan Complete 
2026-05-04T16:51:00.013Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:51:00.024Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
 ○ Compiling /settings ...
 ✓ Compiled /settings in 1426ms (1788 modules)
2026-05-04T16:52:00.004Z [debug][Jobs]: Starting scheduled job: Download Sync 
 ○ Compiling /settings/jobs ...
 ✓ Compiled /settings/jobs in 825ms (1836 modules)
2026-05-04T16:52:16.715Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T16:53:00.004Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:54:00.006Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:54:00.012Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T16:55:00.007Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:55:00.011Z [info][Jobs]: Starting scheduled job: Plex Recently Added Scan 
2026-05-04T16:55:00.012Z [info][Plex Scan]: Scan starting {"sessionId":"27bff448-3757-400f-ac06-a3e96bf4b1c3"}
2026-05-04T16:55:00.023Z [info][Plex Scan]: Beginning to process recently added for library: Movies {"lastScan":1777913400026}
2026-05-04T16:55:00.028Z [info][Plex Scan]: Recently Added Scan Complete 
2026-05-04T16:56:00.006Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:57:00.007Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:57:00.012Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T16:58:00.003Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T16:59:00.008Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T17:00:00.006Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T17:00:00.012Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T17:00:00.018Z [info][Jobs]: Starting scheduled job: Plex Recently Added Scan 
2026-05-04T17:00:00.019Z [info][Plex Scan]: Scan starting {"sessionId":"481f9a83-dc5f-4f23-8136-9d591ab08ddb"}
2026-05-04T17:00:00.027Z [info][Plex Scan]: Beginning to process recently added for library: Movies {"lastScan":1777913700027}
2026-05-04T17:00:00.034Z [info][Plex Scan]: Recently Added Scan Complete 
2026-05-04T17:01:00.011Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T17:01:50.649Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T17:02:00.004Z [debug][Jobs]: Starting scheduled job: Download Sync 
 ○ Compiling /discover/movies ...
 ✓ Compiled /discover/movies in 1313ms (1999 modules)
 ○ Compiling /requests ...
 ✓ Compiled /requests in 2.4s (1938 modules)
 ○ Compiling / ...
 ✓ Compiled / in 1019ms (2955 modules)
 ✓ Compiled /settings in 322ms (2974 modules)
2026-05-04T17:03:00.009Z [debug][Jobs]: Starting scheduled job: Download Sync 
2026-05-04T17:03:00.015Z [info][Jobs]: Starting scheduled job: Plex Watchlist Sync 
2026-05-04T17:04:00.003Z [debug][Jobs]: Starting scheduled job: Download Sync 
^C[nodemon] still waiting for 1 sub-process to finish...
 ELIFECYCLE  Command failed.
```

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata retrieval so watchlist items are now resilient to missing or alternate metadata sources.
  * Items without recoverable metadata are now safely skipped and produce diagnostic warnings instead of causing errors.
  * Increased stability and visibility when metadata cannot be found via enhanced logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->