### PR TITLE
fix(users): correct auth middleware for web push subscription

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -324,8 +324,8 @@ router.post<
   }
 });
 
-router.get<{ userId: string }>(
-  '/:userId/pushSubscriptions',
+router.get<{ id: string }>(
+  '/:id/pushSubscriptions',
   isOwnProfileOrAdmin(),
   async (req, res, next) => {
     try {
@@ -333,7 +333,7 @@ router.get<{ userId: string }>(
 
       const userPushSubs = await userPushSubRepository.find({
         relations: { user: true },
-        where: { user: { id: Number(req.params.userId) } },
+        where: { user: { id: Number(req.params.id) } },
       });
 
       return res.status(200).json(userPushSubs);
@@ -343,8 +343,8 @@ router.get<{ userId: string }>(
   }
 );
 
-router.get<{ userId: string; endpoint: string }>(
-  '/:userId/pushSubscription/:endpoint',
+router.get<{ id: string; endpoint: string }>(
+  '/:id/pushSubscription/:endpoint',
   isOwnProfileOrAdmin(),
   async (req, res, next) => {
     try {
@@ -355,7 +355,7 @@ router.get<{ userId: string; endpoint: string }>(
           user: true,
         },
         where: {
-          user: { id: Number(req.params.userId) },
+          user: { id: Number(req.params.id) },
           endpoint: req.params.endpoint,
         },
       });
@@ -367,8 +367,8 @@ router.get<{ userId: string; endpoint: string }>(
   }
 );
 
-router.delete<{ userId: string; endpoint: string }>(
-  '/:userId/pushSubscription/:endpoint',
+router.delete<{ id: string; endpoint: string }>(
+  '/:id/pushSubscription/:endpoint',
   isOwnProfileOrAdmin(),
   async (req, res, next) => {
     try {
@@ -377,7 +377,7 @@ router.delete<{ userId: string; endpoint: string }>(
       const userPushSub = await userPushSubRepository.findOne({
         relations: { user: true },
         where: {
-          user: { id: Number(req.params.userId) },
+          user: { id: Number(req.params.id) },
           endpoint: req.params.endpoint,
         },
       });


### PR DESCRIPTION
## Description

Web push subscription was not working properly for non-admin users because the `/user/{id}/pushSubscriptions` were using `{userId}` instead of `{id}`.

- Fixes #2955

## How Has This Been Tested?

1. Create user without admin permissions
2. Log in to newly created user account
3. Enable web push on the device
4. Refresh page

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized push subscription API endpoint parameters for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->