### PR TITLE
feat(notifications): add Thread ID to discord notification

### DIFF
--- a/docs/using-seerr/notifications/discord.md
+++ b/docs/using-seerr/notifications/discord.md
@@ -26,6 +26,10 @@ If a role ID is specified, it will be included in the webhook message. See [Disc
 
 If you would like to override the name you configured for your bot in Discord, you may set this value to whatever you like!
 
+### Thread ID (optional)
+
+Instead of posting notifications to the webhook's channel you can specify a thready ID to post notifications to a specific thread in that channel.
+
 ### Bot Avatar URL (optional)
 
 Similar to the bot username, you can override the avatar for your bot.

--- a/docs/using-seerr/notifications/discord.md
+++ b/docs/using-seerr/notifications/discord.md
@@ -28,7 +28,7 @@ If you would like to override the name you configured for your bot in Discord, y
 
 ### Thread ID (optional)
 
-Instead of posting notifications to the webhook's channel you can specify a thready ID to post notifications to a specific thread in that channel.
+Instead of posting notifications to the webhook's channel you can specify a thread ID to post notifications to a specific thread in that channel.
 
 ### Bot Avatar URL (optional)
 

--- a/server/lib/notifications/agents/discord.ts
+++ b/server/lib/notifications/agents/discord.ts
@@ -315,7 +315,12 @@ class DiscordAgent
         ? (payload.notifyUser?.settings?.locale as AvailableLocale)
         : (settings.options.locale as AvailableLocale);
 
-      await axios.post(settings.options.webhookUrl, {
+      // https://docs.discord.com/developers/resources/webhook#execute-webhook
+      const webhookUrl = settings.options.webhookThreadId
+        ? `${settings.options.webhookUrl}?thread_id=${settings.options.webhookThreadId}`
+        : settings.options.webhookUrl;
+
+      await axios.post(webhookUrl, {
         username: settings.options.botUsername
           ? settings.options.botUsername
           : getSettings().main.applicationTitle,

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -229,7 +229,7 @@ export interface NotificationAgentDiscord extends NotificationAgentConfig {
     botAvatarUrl?: string;
     webhookUrl: string;
     webhookRoleId?: string;
-    webhookThreadId?: number;
+    webhookThreadId?: string;
     enableMentions: boolean;
     locale: AvailableLocale;
     useUserLocale: boolean;

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -229,6 +229,7 @@ export interface NotificationAgentDiscord extends NotificationAgentConfig {
     botAvatarUrl?: string;
     webhookUrl: string;
     webhookRoleId?: string;
+    webhookThreadId?: number;
     enableMentions: boolean;
     locale: AvailableLocale;
     useUserLocale: boolean;

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -35,6 +35,7 @@ const messages = defineMessages('components.Settings.Notifications', {
   validationWebhookRoleId: 'You must provide a valid Discord Role ID',
   validationTypes: 'You must select at least one notification type',
   enableMentions: 'Enable Mentions',
+  messageThreadId: 'Thread/Topic ID',
 });
 
 const NotificationsDiscord = () => {
@@ -84,6 +85,7 @@ const NotificationsDiscord = () => {
         botAvatarUrl: data?.options.botAvatarUrl,
         webhookUrl: data.options.webhookUrl,
         webhookRoleId: data?.options.webhookRoleId,
+        webhookThreadId: data?.options.webhookThreadId,
         enableMentions: data?.options.enableMentions,
         locale: data?.options.locale || 'en',
         useUserLocale: data?.options.useUserLocale ?? false,
@@ -100,6 +102,7 @@ const NotificationsDiscord = () => {
               botAvatarUrl: values.botAvatarUrl,
               webhookUrl: values.webhookUrl,
               webhookRoleId: values.webhookRoleId,
+              webhookThreadId: values.webhookThreadId,
               enableMentions: values.enableMentions,
               locale: values.locale,
               useUserLocale: values.useUserLocale,
@@ -152,6 +155,7 @@ const NotificationsDiscord = () => {
                 botAvatarUrl: values.botAvatarUrl,
                 webhookUrl: values.webhookUrl,
                 webhookRoleId: values.webhookRoleId,
+                webhookThreadId: values.webhookThreadId,
                 enableMentions: values.enableMentions,
                 locale: values.locale,
                 useUserLocale: values.useUserLocale,
@@ -254,6 +258,26 @@ const NotificationsDiscord = () => {
                   touched.botUsername &&
                   typeof errors.botUsername === 'string' && (
                     <div className="error">{errors.botUsername}</div>
+                  )}
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="threadId" className="text-label">
+                {intl.formatMessage(messages.messageThreadId)}
+              </label>
+              <div className="form-input-area">
+                <div className="form-input-field">
+                  <Field
+                    id="webhookThreadId"
+                    name="webhookThreadId"
+                    type="text"
+                    inputMode="numeric"
+                  />
+                </div>
+                {errors.webhookThreadId &&
+                  touched.webhookThreadId &&
+                  typeof errors.webhookThreadId === 'string' && (
+                    <div className="error">{errors.webhookThreadId}</div>
                   )}
               </div>
             </div>

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -36,6 +36,7 @@ const messages = defineMessages('components.Settings.Notifications', {
   validationTypes: 'You must select at least one notification type',
   enableMentions: 'Enable Mentions',
   messageThreadId: 'Thread/Topic ID',
+  validationWebhookThreadId: 'You must provide a valid Discord Thread ID',
 });
 
 const NotificationsDiscord = () => {
@@ -63,6 +64,12 @@ const NotificationsDiscord = () => {
         otherwise: (schema) => schema.nullable(),
       })
       .url(intl.formatMessage(messages.validationUrl)),
+    webhookThreadId: Yup.string()
+      .nullable()
+      .matches(
+        /^\d{17,19}$/,
+        intl.formatMessage(messages.validationWebhookThreadId)
+      ),
     webhookRoleId: Yup.string()
       .nullable()
       .matches(

--- a/src/components/Settings/Notifications/NotificationsDiscord.tsx
+++ b/src/components/Settings/Notifications/NotificationsDiscord.tsx
@@ -262,7 +262,7 @@ const NotificationsDiscord = () => {
               </div>
             </div>
             <div className="form-row">
-              <label htmlFor="threadId" className="text-label">
+              <label htmlFor="webhookThreadId" className="text-label">
                 {intl.formatMessage(messages.messageThreadId)}
               </label>
               <div className="form-input-area">

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1306,7 +1306,7 @@
   "components.Setup.librarieserror": "Validation failed. Please toggle the libraries again to continue.",
   "components.Setup.servertype": "Choose Server Type",
   "components.Setup.setup": "Setup",
-  "components.Setup.signin": "Sign In",
+  "components.Setup.signin": "Sign in to your account",
   "components.Setup.signinMessage": "Get started by signing in",
   "components.Setup.signinWithEmby": "Enter your Emby details",
   "components.Setup.signinWithJellyfin": "Enter your Jellyfin details",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -788,6 +788,7 @@
   "components.Settings.Notifications.validationTypes": "You must select at least one notification type",
   "components.Settings.Notifications.validationUrl": "You must provide a valid URL",
   "components.Settings.Notifications.validationWebhookRoleId": "You must provide a valid Discord Role ID",
+  "components.Settings.Notifications.validationWebhookThreadId": "You must provide a valid Discord Thread ID",
   "components.Settings.Notifications.webhookRoleId": "Notification Role ID",
   "components.Settings.Notifications.webhookRoleIdTip": "The role ID to mention in the webhook message. Leave empty to disable mentions",
   "components.Settings.Notifications.webhookUrl": "Webhook URL",


### PR DESCRIPTION
- Fixes #2719

## Description

- Added an option to post Discord notifications to a thread by specifying a thread ID.

## How Has This Been Tested?

- I have tested manually

_I have not found any tests testing DIscord webhooks specifically_


## Screenshots / Logs (if applicable)

<img width="411" height="408" alt="image" src="https://github.com/user-attachments/assets/534902e4-2183-4251-ae4a-c7350e0dd380" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

AI Disclosure: I have consulted copilot to find all files which should be modified as this is my first PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord notifications can be sent to a specific thread; settings UI accepts a Thread/Topic ID and includes it when saving or sending test notifications.

* **Documentation**
  * Discord notifications guide updated with thread configuration details and clarification that Notification Language only applies when recipient locale is disabled.

* **Style**
  * Sign-in copy updated to "Sign in to your account."

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3013)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->