### PR TITLE
fix(docs): Fixed Getting Started link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With more features on the way! Check out our [issue tracker](/../../issues) to s
 
 Check out our documentation for instructions on how to install and run Seerr:
 
-https://docs.seerr.dev/getting-started/
+https://docs.seerr.dev/getting-started
 
 ## Preview
 


### PR DESCRIPTION
## Description

The README.md file had a broken link to https://docs.seerr.dev/getting-started due to a trailing slash in the url (https://docs.seerr.dev/getting-started/). This caused it to go to the wrong page

## How Has This Been Tested?

It now goes to the correct page

## Screenshots / Logs (if applicable)

<img width="2257" height="1478" alt="image" src="https://github.com/user-attachments/assets/5dc7a8ef-ae90-4ff9-8581-ee713ff16bfc" />
<img width="2257" height="1478" alt="image" src="https://github.com/user-attachments/assets/b37b1ac2-65d6-4ae7-9335-9ad4a39f3b7b" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [n/a] All new and existing tests passed.
- [n/a] Successful build `pnpm build`
- [n/a] Translation keys `pnpm i18n:extract`
- [n/a] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the "Getting Started" documentation link formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->