### PR TITLE
fix: update series status to partially available when seasons are missing

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -10,6 +10,11 @@ import type { PlexMetadata } from '@server/api/plexapi';
 import PlexAPI from '@server/api/plexapi';
 import type { SonarrSeason, SonarrSeries } from '@server/api/servarr/sonarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbTvDetails,
+  TmdbTvSeasonResult,
+} from '@server/api/themoviedb/interfaces';
 import { MediaStatus, MediaType } from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import { getRepository } from '@server/datasource';
@@ -116,6 +121,85 @@ Object.defineProperty(SonarrAPI.prototype, 'getSeriesById', {
   set() {},
   configurable: true,
 });
+
+// --- Mock TheMovieDb ---
+let getTvShowImpl: (args: {
+  tvId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+let getShowByTvdbIdImpl: (args: {
+  tvdbId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+
+Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
+  get() {
+    return async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(TheMovieDb.prototype, 'getShowByTvdbId', {
+  get() {
+    return async (args: { tvdbId: number; language?: string }) =>
+      getShowByTvdbIdImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+// --- Helpers ---
+
+function fakeTmdbShow(
+  tmdbId: number,
+  seasons: TmdbTvSeasonResult[] = [
+    {
+      id: 1,
+      air_date: '2024-01-01',
+      episode_count: 10,
+      name: 'Season 1',
+      overview: '',
+      season_number: 1,
+    },
+  ]
+): TmdbTvDetails {
+  return {
+    id: tmdbId,
+    content_ratings: { results: [] },
+    created_by: [],
+    episode_run_time: [],
+    first_air_date: '2024-01-01',
+    genres: [],
+    homepage: '',
+    in_production: false,
+    languages: ['en'],
+    last_air_date: '2024-01-01',
+    name: 'Test Show',
+    networks: [],
+    number_of_episodes: 10,
+    number_of_seasons: seasons.length,
+    origin_country: ['US'],
+    original_language: 'en',
+    original_name: 'Test Show',
+    overview: '',
+    popularity: 0,
+    production_companies: [],
+    production_countries: [],
+    spoken_languages: [],
+    seasons,
+    status: 'Ended',
+    type: 'Scripted',
+    vote_average: 0,
+    vote_count: 0,
+    aggregate_credits: { cast: [] },
+    credits: { crew: [] },
+    external_ids: {},
+    keywords: { results: [] },
+    videos: { results: [] },
+  };
+}
 
 import availabilitySync from '@server/lib/availabilitySync';
 
@@ -282,8 +366,8 @@ function fakeSonarrSeasons(
     monitored: true,
     statistics: {
       episodeFileCount: seasonsWithFiles[i + 1] ?? 0,
-      totalEpisodeCount: 22,
-      episodeCount: 22,
+      totalEpisodeCount: 10,
+      episodeCount: 10,
       percentOfEpisodes: seasonsWithFiles[i + 1] ? 100 : 0,
       sizeOnDisk: seasonsWithFiles[i + 1] ? 7516192768 : 0,
       previousAiring: undefined,
@@ -304,6 +388,30 @@ describe('AvailabilitySync', () => {
     getSeriesByIdImpl = async () => {
       throw new Error('404');
     };
+    getTvShowImpl = async ({ tvId }) =>
+      fakeTmdbShow(
+        tvId,
+        Array.from({ length: 4 }, (_, i) => ({
+          id: i + 1,
+          air_date: '2024-01-01',
+          episode_count: 10,
+          name: `Season ${i + 1}`,
+          overview: '',
+          season_number: i + 1,
+        }))
+      );
+    getShowByTvdbIdImpl = async ({ tvdbId }) =>
+      fakeTmdbShow(
+        tvdbId,
+        Array.from({ length: 4 }, (_, i) => ({
+          id: i + 1,
+          air_date: '2024-01-01',
+          episode_count: 10,
+          name: `Season ${i + 1}`,
+          overview: '',
+          season_number: i + 1,
+        }))
+      );
 
     const userRepository = getRepository(User);
     const existingAdmin = await userRepository.findOne({ where: { id: 1 } });
@@ -363,7 +471,7 @@ describe('AvailabilitySync', () => {
 
       getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
         if (seasonID === 'jellyfin-season-6-id') {
-          return fakeJellyfinEpisodes(21);
+          return fakeJellyfinEpisodes(10);
         }
         return [];
       };
@@ -378,13 +486,13 @@ describe('AvailabilitySync', () => {
             monitored: true,
             statistics: {
               episodeFileCount: 21,
-              totalEpisodeCount: 177,
-              episodeCount: 177,
-              percentOfEpisodes: 11.86,
+              totalEpisodeCount: 10,
+              episodeCount: 10,
+              percentOfEpisodes: 100,
               sizeOnDisk: 0,
               seasonCount: 8,
             },
-            seasons: fakeSonarrSeasons(8, { 6: 21 }),
+            seasons: fakeSonarrSeasons(8, { 6: 10 }),
           } as unknown as SonarrSeries;
         }
         throw new Error('404');
@@ -686,6 +794,106 @@ describe('AvailabilitySync', () => {
         updated.status,
         MediaStatus.AVAILABLE,
         'Show should remain AVAILABLE when getEpisodes fails'
+      );
+    });
+
+    it('should mark show as PARTIALLY_AVAILABLE when some seasons are available and some are unknown', async () => {
+      configureJellyfin();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1412;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.jellyfinMediaId = 'jellyfin-partial-id';
+      media.externalServiceId = 103;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 3,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 4,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jellyfin-partial-id') {
+          return fakeJellyfinShow('jellyfin-partial-id', '1412');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jellyfin-partial-id') {
+          return [
+            fakeJellyfinSeason(1, 'jellyfin-partial-s1-id'),
+            fakeJellyfinSeason(2, 'jellyfin-partial-s2-id'),
+          ];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jellyfin-partial-s1-id') {
+          return fakeJellyfinEpisodes(10);
+        }
+        if (seasonID === 'jellyfin-partial-s2-id') {
+          return fakeJellyfinEpisodes(10);
+        }
+        return [];
+      };
+
+      getSeriesByIdImpl = async (id: number) => {
+        if (id === 103) {
+          return {
+            tvdbId: 99997,
+            id: 103,
+            title: 'Partial Show',
+            titleSlug: 'partial-show',
+            monitored: true,
+            statistics: {
+              episodeFileCount: 20,
+              totalEpisodeCount: 40,
+              episodeCount: 40,
+              percentOfEpisodes: 50,
+              sizeOnDisk: 0,
+              seasonCount: 4,
+            },
+            seasons: fakeSonarrSeasons(4, { 1: 10, 2: 10 }),
+          } as unknown as SonarrSeries;
+        }
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1412 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.PARTIALLY_AVAILABLE,
+        'Show should be PARTIALLY_AVAILABLE when some seasons are available and some are unknown'
       );
     });
   });

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -5,6 +5,8 @@ import PlexAPI from '@server/api/plexapi';
 import RadarrAPI, { type RadarrMovie } from '@server/api/servarr/radarr';
 import type { SonarrSeason, SonarrSeries } from '@server/api/servarr/sonarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
+import TheMovieDb from '@server/api/themoviedb';
+import type { TmdbTvDetails } from '@server/api/themoviedb/interfaces';
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import { getRepository } from '@server/datasource';
@@ -31,6 +33,8 @@ class AvailabilitySync {
   private radarrServers: RadarrSettings[];
   private sonarrServers: SonarrSettings[];
 
+  readonly tmdb = new TheMovieDb();
+
   async run() {
     const settings = getSettings();
     const mediaServerType = getSettings().main.mediaServerType;
@@ -45,7 +49,7 @@ class AvailabilitySync {
 
     try {
       logger.info(`Starting availability sync...`, {
-        label: 'Availability Sync',
+        label: 'AvailabilitySync',
       });
       const pageSize = 50;
 
@@ -149,7 +153,7 @@ class AvailabilitySync {
 
             if (existsInPlex || existsInRadarr) {
               movieExists = true;
-              logger.info(
+              logger.debug(
                 `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -159,7 +163,7 @@ class AvailabilitySync {
 
             if (existsInPlex4k || existsInRadarr4k) {
               movieExists4k = true;
-              logger.info(
+              logger.debug(
                 `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -182,7 +186,7 @@ class AvailabilitySync {
 
             if (existsInJellyfin || existsInRadarr) {
               movieExists = true;
-              logger.info(
+              logger.debug(
                 `The non-4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -192,7 +196,7 @@ class AvailabilitySync {
 
             if (existsInJellyfin4k || existsInRadarr4k) {
               movieExists4k = true;
-              logger.info(
+              logger.debug(
                 `The 4K movie [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -246,7 +250,7 @@ class AvailabilitySync {
           if (mediaServerType === MediaServerType.PLEX) {
             if (existsInPlex || existsInSonarr) {
               showExists = true;
-              logger.info(
+              logger.debug(
                 `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -258,7 +262,7 @@ class AvailabilitySync {
           if (mediaServerType === MediaServerType.PLEX) {
             if (existsInPlex4k || existsInSonarr4k) {
               showExists4k = true;
-              logger.info(
+              logger.debug(
                 `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -274,7 +278,7 @@ class AvailabilitySync {
           ) {
             if (existsInJellyfin || existsInSonarr) {
               showExists = true;
-              logger.info(
+              logger.debug(
                 `The non-4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -289,7 +293,7 @@ class AvailabilitySync {
           ) {
             if (existsInJellyfin4k || existsInSonarr4k) {
               showExists4k = true;
-              logger.info(
+              logger.debug(
                 `The 4K show [TMDB ID ${media.tmdbId}] still exists. Preventing removal.`,
                 {
                   label: 'AvailabilitySync',
@@ -353,6 +357,47 @@ class AvailabilitySync {
             ]);
           }
 
+          // We need to fetch from TMDB to get the episode count for each season
+          let tvShow: TmdbTvDetails | undefined;
+          try {
+            if (media.tmdbId) {
+              tvShow = await this.tmdb.getTvShow({
+                tvId: Number(media.tmdbId),
+              });
+            } else if (media.tvdbId) {
+              tvShow = await this.tmdb.getShowByTvdbId({
+                tvdbId: Number(media.tvdbId),
+              });
+            }
+          } catch (e) {
+            logger.debug(
+              `Failed to fetch TMDB data for show [TMDB ID ${media.tmdbId}]. Skipping season enrichment.`,
+              { label: 'AvailabilitySync', errorMessage: e.message }
+            );
+          }
+
+          if (tvShow) {
+            // fill the finalSeasons and finalSeasons4k maps with false for missing seasons
+            media.seasons.forEach((season) => {
+              if (
+                !finalSeasons.has(season.seasonNumber) &&
+                tvShow.seasons.find(
+                  (s) => s.season_number === season.seasonNumber
+                )?.episode_count
+              ) {
+                finalSeasons.set(season.seasonNumber, false);
+              }
+              if (
+                !finalSeasons4k.has(season.seasonNumber) &&
+                tvShow.seasons.find(
+                  (s) => s.season_number === season.seasonNumber
+                )?.episode_count
+              ) {
+                finalSeasons4k.set(season.seasonNumber, false);
+              }
+            });
+          }
+
           if (
             !showExists &&
             (media.status === MediaStatus.AVAILABLE ||
@@ -405,11 +450,11 @@ class AvailabilitySync {
     } catch (ex) {
       logger.error('Failed to complete availability sync.', {
         errorMessage: ex.message,
-        label: 'Availability Sync',
+        label: 'AvailabilitySync',
       });
     } finally {
       logger.info(`Availability sync complete.`, {
-        label: 'Availability Sync',
+        label: 'AvailabilitySync',
       });
       this.running = false;
     }
@@ -508,7 +553,7 @@ class AvailabilitySync {
             ? media[is4k ? 'jellyfinMediaId4k' : 'jellyfinMediaId']
             : null;
       }
-      logger.info(
+      logger.debug(
         `The ${is4k ? '4K' : 'non-4K'} ${
           media.mediaType === 'movie' ? 'movie' : 'show'
         } [TMDB ID ${media.tmdbId}] was not found in any ${
@@ -531,7 +576,7 @@ class AvailabilitySync {
         } [TMDB ID ${media.tmdbId}].`,
         {
           errorMessage: ex.message,
-          label: 'Availability Sync',
+          label: 'AvailabilitySync',
         }
       );
     }
@@ -555,48 +600,39 @@ class AvailabilitySync {
     // Retrieve the season keys to pass into our log
     const seasonKeys = [...seasonsPendingRemoval.keys()];
 
-    // let isSeasonRemoved = false;
-
     try {
       for (const mediaSeason of media.seasons) {
-        if (seasonsPendingRemoval.has(mediaSeason.seasonNumber)) {
+        if (
+          seasonsPendingRemoval.has(mediaSeason.seasonNumber) &&
+          (mediaSeason[is4k ? 'status4k' : 'status'] ===
+            MediaStatus.AVAILABLE ||
+            mediaSeason[is4k ? 'status4k' : 'status'] ===
+              MediaStatus.PARTIALLY_AVAILABLE)
+        ) {
           mediaSeason[is4k ? 'status4k' : 'status'] = MediaStatus.DELETED;
         }
       }
 
-      if (media.status === MediaStatus.AVAILABLE && !is4k) {
-        media.status = MediaStatus.PARTIALLY_AVAILABLE;
-        logger.info(
-          `Marking the non-4K show [TMDB ID ${media.tmdbId}] as PARTIALLY_AVAILABLE because season removal has occurred.`,
-          { label: 'Availability Sync' }
-        );
-      }
-
-      if (media.status4k === MediaStatus.AVAILABLE && is4k) {
-        media.status4k = MediaStatus.PARTIALLY_AVAILABLE;
-        logger.info(
-          `Marking the 4K show [TMDB ID ${media.tmdbId}] as PARTIALLY_AVAILABLE because season removal has occurred.`,
-          { label: 'Availability Sync' }
+      if (media[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE) {
+        media[is4k ? 'status4k' : 'status'] = MediaStatus.PARTIALLY_AVAILABLE;
+        logger.debug(
+          `Marking the ${
+            is4k ? '4K' : 'non-4K'
+          } show [TMDB ID ${media.tmdbId}] as PARTIALLY_AVAILABLE because season(s) [${seasonKeys}] was not found in any ${
+            media.mediaType === 'tv' ? 'Sonarr' : 'Radarr'
+          } and ${
+            mediaServerType === MediaServerType.PLEX
+              ? 'plex'
+              : mediaServerType === MediaServerType.JELLYFIN
+                ? 'jellyfin'
+                : 'emby'
+          } instance.`,
+          { label: 'AvailabilitySync' }
         );
       }
 
       media.lastSeasonChange = new Date();
       await mediaRepository.save(media);
-
-      logger.info(
-        `The ${is4k ? '4K' : 'non-4K'} season(s) [${seasonKeys}] [TMDB ID ${
-          media.tmdbId
-        }] was not found in any ${
-          media.mediaType === 'tv' ? 'Sonarr' : 'Radarr'
-        } and ${
-          mediaServerType === MediaServerType.PLEX
-            ? 'plex'
-            : mediaServerType === MediaServerType.JELLYFIN
-              ? 'jellyfin'
-              : 'emby'
-        } instance. Status will be changed to deleted.`,
-        { label: 'AvailabilitySync' }
-      );
     } catch (ex) {
       logger.debug(
         `Failure updating the ${
@@ -604,7 +640,7 @@ class AvailabilitySync {
         } season(s) [${seasonKeys}], TMDB ID ${media.tmdbId}.`,
         {
           errorMessage: ex.message,
-          label: 'Availability Sync',
+          label: 'AvailabilitySync',
         }
       );
     }
@@ -671,7 +707,7 @@ class AvailabilitySync {
             }] from Radarr.`,
             {
               errorMessage: ex.message,
-              label: 'Availability Sync',
+              label: 'AvailabilitySync',
             }
           );
         }
@@ -728,7 +764,7 @@ class AvailabilitySync {
             }] from Sonarr.`,
             {
               errorMessage: ex.message,
-              label: 'Availability Sync',
+              label: 'AvailabilitySync',
             }
           );
         }
@@ -895,7 +931,7 @@ class AvailabilitySync {
           } [TMDB ID ${media.tmdbId}] from Plex.`,
           {
             errorMessage: ex.message,
-            label: 'Availability Sync',
+            label: 'AvailabilitySync',
           }
         );
       }

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -467,24 +467,25 @@ class BaseScanner<T> {
           (s) => s.seasonNumber !== 0
         );
 
-        // Check the actual season objects instead scanner input
-        // to determine overall availability status
-        // UNKNOWN seasons are treated as neutral (no signal) rather than
-        // blockers, so a stale/orphan placeholder season can't hold the
-        // show at PARTIALLY_AVAILABLE indefinitely.
+        const standardSeasonsForRollup = nonSpecialSeasons.filter(
+          (s) =>
+            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
+              ?.totalEpisodes ?? Infinity) > 0
+        );
         const isAllStandardSeasonsAvailable =
-          nonSpecialSeasons.length > 0 &&
-          nonSpecialSeasons
-            .filter((s) => s.status !== MediaStatus.UNKNOWN)
-            .every((s) => s.status === MediaStatus.AVAILABLE) &&
-          nonSpecialSeasons.some((s) => s.status === MediaStatus.AVAILABLE);
+          standardSeasonsForRollup.length > 0 &&
+          standardSeasonsForRollup.every(
+            (s) => s.status === MediaStatus.AVAILABLE
+          );
 
+        const seasons4kForRollup = nonSpecialSeasons.filter(
+          (s) =>
+            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
+              ?.totalEpisodes ?? Infinity) > 0
+        );
         const isAll4kSeasonsAvailable =
-          nonSpecialSeasons.length > 0 &&
-          nonSpecialSeasons
-            .filter((s) => s.status4k !== MediaStatus.UNKNOWN)
-            .every((s) => s.status4k === MediaStatus.AVAILABLE) &&
-          nonSpecialSeasons.some((s) => s.status4k === MediaStatus.AVAILABLE);
+          seasons4kForRollup.length > 0 &&
+          seasons4kForRollup.every((s) => s.status4k === MediaStatus.AVAILABLE);
 
         media.status = isAllStandardSeasonsAvailable
           ? MediaStatus.AVAILABLE
@@ -529,21 +530,25 @@ class BaseScanner<T> {
           (s) => s.seasonNumber !== 0
         );
 
+        const standardSeasonsForRollup = nonSpecialNewSeasons.filter(
+          (s) =>
+            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
+              ?.totalEpisodes ?? Infinity) > 0
+        );
         const isAllStandardSeasonsAvailable =
-          nonSpecialNewSeasons.length > 0 &&
-          nonSpecialNewSeasons
-            .filter((s) => s.status !== MediaStatus.UNKNOWN)
-            .every((s) => s.status === MediaStatus.AVAILABLE) &&
-          nonSpecialNewSeasons.some((s) => s.status === MediaStatus.AVAILABLE);
-
-        const isAll4kSeasonsAvailable =
-          nonSpecialNewSeasons.length > 0 &&
-          nonSpecialNewSeasons
-            .filter((s) => s.status4k !== MediaStatus.UNKNOWN)
-            .every((s) => s.status4k === MediaStatus.AVAILABLE) &&
-          nonSpecialNewSeasons.some(
-            (s) => s.status4k === MediaStatus.AVAILABLE
+          standardSeasonsForRollup.length > 0 &&
+          standardSeasonsForRollup.every(
+            (s) => s.status === MediaStatus.AVAILABLE
           );
+
+        const seasons4kForRollup = nonSpecialNewSeasons.filter(
+          (s) =>
+            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
+              ?.totalEpisodes ?? Infinity) > 0
+        );
+        const isAll4kSeasonsAvailable =
+          seasons4kForRollup.length > 0 &&
+          seasons4kForRollup.every((s) => s.status4k === MediaStatus.AVAILABLE);
 
         const newMedia = new Media({
           mediaType: MediaType.TV,

--- a/server/lib/scanners/jellyfin/index.ts
+++ b/server/lib/scanners/jellyfin/index.ts
@@ -285,11 +285,9 @@ class JellyfinScanner
         const processableSeasons: ProcessableSeason[] = [];
 
         const settings = getSettings();
-        const filteredSeasons = (
-          settings.main.enableSpecialEpisodes
-            ? seasons
-            : seasons.filter((sn) => sn.season_number !== 0)
-        ).filter((sn) => sn.episode_count > 0);
+        const filteredSeasons = settings.main.enableSpecialEpisodes
+          ? seasons
+          : seasons.filter((sn) => sn.season_number !== 0);
 
         for (const season of filteredSeasons) {
           const matchedJellyfinSeason = jellyfinSeasons.find((md) => {

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -1,0 +1,350 @@
+import animeList from '@server/api/animelist';
+import type {
+  JellyfinLibraryItem,
+  JellyfinLibraryItemExtended,
+} from '@server/api/jellyfin';
+import JellyfinAPI from '@server/api/jellyfin';
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbTvDetails,
+  TmdbTvSeasonResult,
+} from '@server/api/themoviedb/interfaces';
+import { MediaStatus, MediaType } from '@server/constants/media';
+import { MediaServerType } from '@server/constants/server';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import Season from '@server/entity/Season';
+import { User } from '@server/entity/User';
+import type { Library } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+// --- Mock animeList.sync to avoid filesystem/network I/O in tests ---
+Object.defineProperty(animeList, 'sync', {
+  value: async () => {},
+  configurable: true,
+  writable: true,
+});
+
+// --- Mock JellyfinAPI ---
+let getLibraryContentsImpl: (
+  id: string
+) => Promise<JellyfinLibraryItem[]> = async () => [];
+let getItemDataImpl: (
+  id: string
+) => Promise<JellyfinLibraryItemExtended | undefined> = async () => undefined;
+let getSeasonsImpl: (
+  seriesID: string
+) => Promise<JellyfinLibraryItem[]> = async () => [];
+let getEpisodesImpl: (
+  seriesID: string,
+  seasonID: string
+) => Promise<JellyfinLibraryItem[]> = async () => [];
+
+Object.defineProperty(JellyfinAPI.prototype, 'getLibraryContents', {
+  get() {
+    return async (id: string) => getLibraryContentsImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(JellyfinAPI.prototype, 'getItemData', {
+  get() {
+    return async (id: string) => getItemDataImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(JellyfinAPI.prototype, 'getSeasons', {
+  get() {
+    return async (seriesID: string) => getSeasonsImpl(seriesID);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(JellyfinAPI.prototype, 'getEpisodes', {
+  get() {
+    return async (seriesID: string, seasonID: string) =>
+      getEpisodesImpl(seriesID, seasonID);
+  },
+  set() {},
+  configurable: true,
+});
+
+Object.defineProperty(JellyfinAPI.prototype, 'setUserId', {
+  get() {
+    return () => {};
+  },
+  set() {},
+  configurable: true,
+});
+
+// --- Mock TheMovieDb ---
+let getTvShowImpl: (args: {
+  tvId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async () => fakeTmdbShow(1);
+
+Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
+  get() {
+    return async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+import { jellyfinFullScanner } from '@server/lib/scanners/jellyfin';
+
+setupTestDb();
+
+// --- Helpers ---
+
+function fakeTmdbShow(
+  tmdbId: number,
+  seasons: TmdbTvSeasonResult[] = [
+    {
+      id: 1,
+      air_date: '2024-01-01',
+      episode_count: 10,
+      name: 'Season 1',
+      overview: '',
+      season_number: 1,
+    },
+  ]
+): TmdbTvDetails {
+  return {
+    id: tmdbId,
+    content_ratings: { results: [] },
+    created_by: [],
+    episode_run_time: [],
+    first_air_date: '2024-01-01',
+    genres: [],
+    homepage: '',
+    in_production: false,
+    languages: ['en'],
+    last_air_date: '2024-01-01',
+    name: 'Test Show',
+    networks: [],
+    number_of_episodes: 10,
+    number_of_seasons: seasons.length,
+    origin_country: ['US'],
+    original_language: 'en',
+    original_name: 'Test Show',
+    overview: '',
+    popularity: 0,
+    production_companies: [],
+    production_countries: [],
+    spoken_languages: [],
+    seasons,
+    status: 'Ended',
+    type: 'Scripted',
+    vote_average: 0,
+    vote_count: 0,
+    aggregate_credits: { cast: [] },
+    credits: { crew: [] },
+    external_ids: {},
+    keywords: { results: [] },
+    videos: { results: [] },
+  };
+}
+
+function fakeJellyfinSeriesItem(id: string): JellyfinLibraryItem {
+  return {
+    Name: 'Test Show',
+    Id: id,
+    Type: 'Series',
+    HasSubtitles: false,
+    LocationType: 'FileSystem',
+    MediaType: 'Video',
+  };
+}
+
+function fakeJellyfinShowMetadata(
+  id: string,
+  tmdbId: string
+): JellyfinLibraryItemExtended {
+  return {
+    Name: 'Test Show',
+    Id: id,
+    Type: 'Series',
+    HasSubtitles: false,
+    LocationType: 'FileSystem',
+    MediaType: 'Video',
+    ProviderIds: { Tmdb: tmdbId },
+  };
+}
+
+function fakeJellyfinSeason(
+  seasonNumber: number,
+  id: string
+): JellyfinLibraryItem {
+  return {
+    Name: `Season ${seasonNumber}`,
+    Id: id,
+    IndexNumber: seasonNumber,
+    Type: 'Season',
+    HasSubtitles: false,
+    LocationType: 'FileSystem',
+    MediaType: 'Video',
+  };
+}
+
+function fakeJellyfinEpisodes(count: number): JellyfinLibraryItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    Name: `Episode ${i + 1}`,
+    Id: `ep-${i}`,
+    IndexNumber: i + 1,
+    Type: 'Episode' as const,
+    HasSubtitles: false,
+    LocationType: 'FileSystem' as const,
+    MediaType: 'Video',
+  }));
+}
+
+function configureJellyfinWithLibrary(
+  libraries: Library[] = [
+    { id: 'test-library-id', name: 'TV Shows', enabled: true, type: 'show' },
+  ]
+): void {
+  const settings = getSettings();
+  settings.main.mediaServerType = MediaServerType.JELLYFIN;
+  settings.jellyfin = {
+    ...settings.jellyfin,
+    apiKey: 'test-api-key',
+    libraries,
+  };
+}
+
+describe('Jellyfin Scanner', () => {
+  beforeEach(async () => {
+    getLibraryContentsImpl = async () => [];
+    getItemDataImpl = async () => undefined;
+    getSeasonsImpl = async () => [];
+    getEpisodesImpl = async () => [];
+    getTvShowImpl = async () => fakeTmdbShow(1);
+
+    const userRepository = getRepository(User);
+    const existingAdmin = await userRepository.findOne({ where: { id: 1 } });
+    if (!existingAdmin) {
+      const admin = new User();
+      admin.id = 1;
+      admin.jellyfinUserId = 'admin-user-id';
+      admin.jellyfinDeviceId = 'admin-device-id';
+      admin.email = 'admin@test.com';
+      admin.permissions = 2;
+      admin.username = 'admin';
+      await userRepository.save(admin);
+    }
+  });
+
+  describe('empty TMDB season handling', () => {
+    it('should mark show as available when all non-empty TMDB seasons are fully scanned and an empty placeholder season exists in the DB', async () => {
+      configureJellyfinWithLibrary();
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 5000;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PARTIALLY_AVAILABLE;
+      media.jellyfinMediaId = 'jf-scanner-show-id';
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 3,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () =>
+        fakeTmdbShow(5000, [
+          {
+            id: 1,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 1',
+            overview: '',
+            season_number: 1,
+          },
+          {
+            id: 2,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 2',
+            overview: '',
+            season_number: 2,
+          },
+          {
+            id: 3,
+            air_date: '2024-01-01',
+            episode_count: 0,
+            name: 'Season 3',
+            overview: '',
+            season_number: 3,
+          },
+        ]);
+
+      // Jellyfin: S1 and S2 are fully scanned; S3 has no files.
+      getLibraryContentsImpl = async (id: string) => {
+        if (id === 'test-library-id') {
+          return [fakeJellyfinSeriesItem('jf-scanner-show-id')];
+        }
+        return [];
+      };
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jf-scanner-show-id') {
+          return fakeJellyfinShowMetadata('jf-scanner-show-id', '5000');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jf-scanner-show-id') {
+          return [
+            fakeJellyfinSeason(1, 'jf-scanner-s1-id'),
+            fakeJellyfinSeason(2, 'jf-scanner-s2-id'),
+          ];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jf-scanner-s1-id') return fakeJellyfinEpisodes(10);
+        if (seasonID === 'jf-scanner-s2-id') return fakeJellyfinEpisodes(10);
+        return [];
+      };
+
+      await jellyfinFullScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 5000 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should be AVAILABLE when all non-empty TMDB seasons are fully scanned, ignoring empty placeholder seasons'
+      );
+    });
+  });
+});

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -321,13 +321,11 @@ class PlexScanner
 
     const seasons = tvShow.seasons;
     const processableSeasons: ProcessableSeason[] = [];
-    const settings = getSettings();
 
-    const filteredSeasons = (
-      settings.main.enableSpecialEpisodes
-        ? seasons
-        : seasons.filter((sn) => sn.season_number !== 0)
-    ).filter((sn) => sn.episode_count > 0);
+    const settings = getSettings();
+    const filteredSeasons = settings.main.enableSpecialEpisodes
+      ? seasons
+      : seasons.filter((sn) => sn.season_number !== 0);
 
     for (const season of filteredSeasons) {
       const matchedPlexSeason = metadata.Children?.Metadata.find(

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -158,13 +158,31 @@ class SonarrScanner
       if (!(metadataProvider instanceof TheMovieDb)) {
         tvShow = await metadataProvider.getTvShow({ tvId: tmdbId });
       }
+
       const settings = getSettings();
 
-      const filteredSeasons = sonarrSeries.seasons.filter(
-        (sn) =>
-          tvShow.seasons.find((s) => s.season_number === sn.seasonNumber) &&
-          (!settings.main.enableSpecialEpisodes ? sn.seasonNumber !== 0 : true)
-      );
+      const filteredSeasons = tvShow.seasons
+        .filter(
+          (sn) => settings.main.enableSpecialEpisodes || sn.season_number !== 0
+        )
+        .map((season) => {
+          const sonarrSeason = sonarrSeries.seasons.find(
+            (s) => s.seasonNumber === season.season_number
+          );
+          if (!sonarrSeason) {
+            return {
+              seasonNumber: season.season_number,
+              episodeCount: season.episode_count,
+              monitored: false,
+              statistics: {
+                episodeFileCount: 0,
+                totalEpisodeCount: season.episode_count,
+              },
+            };
+          } else {
+            return sonarrSeason;
+          }
+        });
 
       for (const season of filteredSeasons) {
         const totalAvailableEpisodes = season.statistics?.episodeFileCount ?? 0;


### PR DESCRIPTION
## Description

This PR fixes the Availability scanner and the Jellyfin scanner updating series and season statuses.
Previously, a series with 1 available season and 1 unknown season was marked as "available", while it should have been marked as "partially available".

This fixes a regression introduced by #2958 that conflicted with #2412.

This also fixes some minor logging issues (`info` instead of `debug` and duplicate logs).

Tests written by Claude have been added to ensure this regression doesn't happen again for these 2 scanners.

- Re #2958
- Re #2412

## How Has This Been Tested?

Tested with
- A show with 2 available seasons out of 3 seasons.
- The show "Common Side Effects" (having a placeholder season with 0 episode) with the first season available.
(as well as the newly introduced tests)

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enriched TV availability using external season metadata to improve detection of missing seasons.

* **Bug Fixes**
  * Ignore empty/placeholder external seasons so overall show availability is more accurate.
  * Prevent unintended deletion of seasons that are not confirmed available.

* **Tests**
  * Added tests covering scanner + external metadata interactions and mixed-season availability scenarios.

* **Refactor**
  * Reduced noisy sync logging for clearer operational output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->