### PR TITLE
feat(details): click poster open lightbox fullscreen

### DIFF
--- a/src/components/Common/PosterLightbox/index.tsx
+++ b/src/components/Common/PosterLightbox/index.tsx
@@ -1,0 +1,94 @@
+import CachedImage from '@app/components/Common/CachedImage';
+import { useLockBodyScroll } from '@app/hooks/useLockBodyScroll';
+import { Transition } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { Fragment, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+
+interface PosterLightboxProps {
+  show: boolean;
+  posterPath?: string | null;
+  alt?: string;
+  onClose: () => void;
+}
+
+const PosterLightbox = ({
+  show,
+  posterPath,
+  alt = '',
+  onClose,
+}: PosterLightboxProps) => {
+  useLockBodyScroll(show);
+
+  useEffect(() => {
+    if (!show) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [show, onClose]);
+
+  if (typeof window === 'undefined') return null;
+
+  return ReactDOM.createPortal(
+    <Transition
+      as={Fragment}
+      show={show}
+      enter="transition-opacity duration-150"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition-opacity duration-150"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+    >
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4 sm:p-8"
+        onClick={onClose}
+        role="dialog"
+        aria-modal="true"
+        aria-label={alt || 'Poster preview'}
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 z-10 rounded-full bg-gray-800/80 p-2 text-white hover:bg-gray-700/80 focus:outline-none focus:ring-2 focus:ring-white"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          aria-label="Close poster preview"
+        >
+          <XMarkIcon className="h-6 w-6" />
+        </button>
+        <div
+          className="relative flex h-full w-full items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <CachedImage
+            type="tmdb"
+            src={
+              posterPath
+                ? `https://image.tmdb.org/t/p/original${posterPath}`
+                : '/images/seerr_poster_not_found.png'
+            }
+            alt={alt}
+            width={1000}
+            height={1500}
+            sizes="100vw"
+            style={{
+              width: 'auto',
+              height: 'auto',
+              maxWidth: '100%',
+              maxHeight: '100%',
+              objectFit: 'contain',
+            }}
+            priority
+          />
+        </div>
+      </div>
+    </Transition>,
+    document.body
+  );
+};
+
+export default PosterLightbox;

--- a/src/components/Common/PosterLightbox/index.tsx
+++ b/src/components/Common/PosterLightbox/index.tsx
@@ -43,27 +43,26 @@ const PosterLightbox = ({
       leaveTo="opacity-0"
     >
       <div
-        className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4 sm:p-8"
-        onClick={onClose}
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8"
         role="dialog"
         aria-modal="true"
         aria-label={alt || 'Poster preview'}
       >
         <button
           type="button"
-          className="absolute right-4 top-4 z-10 rounded-full bg-gray-800/80 p-2 text-white hover:bg-gray-700/80 focus:outline-none focus:ring-2 focus:ring-white"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
+          className="absolute inset-0 z-0 cursor-zoom-out bg-black/90 focus:outline-none"
+          onClick={onClose}
+          aria-label="Close poster preview"
+        />
+        <button
+          type="button"
+          className="absolute right-4 top-4 z-20 rounded-full bg-gray-800/80 p-2 text-white hover:bg-gray-700/80 focus:outline-none focus:ring-2 focus:ring-white"
+          onClick={onClose}
           aria-label="Close poster preview"
         >
           <XMarkIcon className="h-6 w-6" />
         </button>
-        <div
-          className="relative flex h-full w-full items-center justify-center"
-          onClick={(e) => e.stopPropagation()}
-        >
+        <div className="pointer-events-none relative z-10 flex h-full w-full items-center justify-center">
           <CachedImage
             type="tmdb"
             src={

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -12,6 +12,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import type { PlayButtonLink } from '@app/components/Common/PlayButton';
 import PlayButton from '@app/components/Common/PlayButton';
+import PosterLightbox from '@app/components/Common/PosterLightbox';
 import Tag from '@app/components/Common/Tag';
 import Tooltip from '@app/components/Common/Tooltip';
 import ExternalLinkBlock from '@app/components/ExternalLinkBlock';
@@ -131,6 +132,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
   const [isBlocklistUpdating, setIsBlocklistUpdating] =
     useState<boolean>(false);
   const [showBlocklistModal, setShowBlocklistModal] = useState(false);
+  const [showPosterLightbox, setShowPosterLightbox] = useState(false);
   const { addToast } = useToasts();
 
   const {
@@ -485,8 +487,19 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
         onComplete={onClickHideItemBtn}
         isUpdating={isBlocklistUpdating}
       />
+      <PosterLightbox
+        show={showPosterLightbox}
+        posterPath={data.posterPath}
+        alt={data.title}
+        onClose={() => setShowPosterLightbox(false)}
+      />
       <div className="media-header">
-        <div className="media-poster">
+        <button
+          type="button"
+          className="media-poster cursor-zoom-in border-0 bg-transparent p-0 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          onClick={() => setShowPosterLightbox(true)}
+          aria-label={`Expand ${data.title} poster`}
+        >
           <CachedImage
             type="tmdb"
             src={
@@ -501,7 +514,7 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
             height={900}
             priority
           />
-        </div>
+        </button>
         <div className="media-title">
           <div className="media-status">
             <StatusBadge

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -12,6 +12,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import PageTitle from '@app/components/Common/PageTitle';
 import type { PlayButtonLink } from '@app/components/Common/PlayButton';
 import PlayButton from '@app/components/Common/PlayButton';
+import PosterLightbox from '@app/components/Common/PosterLightbox';
 import StatusBadgeMini from '@app/components/Common/StatusBadgeMini';
 import Tag from '@app/components/Common/Tag';
 import Tooltip from '@app/components/Common/Tooltip';
@@ -127,6 +128,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   const [isBlocklistUpdating, setIsBlocklistUpdating] =
     useState<boolean>(false);
   const [showBlocklistModal, setShowBlocklistModal] = useState(false);
+  const [showPosterLightbox, setShowPosterLightbox] = useState(false);
   const { addToast } = useToasts();
 
   const {
@@ -527,8 +529,19 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
         revalidate={() => revalidate()}
         show={showManager}
       />
+      <PosterLightbox
+        show={showPosterLightbox}
+        posterPath={data.posterPath}
+        alt={data.name}
+        onClose={() => setShowPosterLightbox(false)}
+      />
       <div className="media-header">
-        <div className="media-poster">
+        <button
+          type="button"
+          className="media-poster cursor-zoom-in border-0 bg-transparent p-0 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          onClick={() => setShowPosterLightbox(true)}
+          aria-label={`Expand ${data.name} poster`}
+        >
           <CachedImage
             type="tmdb"
             src={
@@ -543,7 +556,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
             height={900}
             priority
           />
-        </div>
+        </button>
         <div className="media-title">
           <div className="media-status">
             <StatusBadge


### PR DESCRIPTION
## Description

Small QoL addition: clicking the poster on `/movie/[id]` or `/tv/[id]` opens it fullscreen instead of doing nothing. I was browsing details pages on a 4K monitor and the 600x900 poster felt cramped, wanted a quick way to see the artwork properly.

It's a new `PosterLightbox` component (React portal + black backdrop + Esc-to-close + body scroll lock) that pulls the TMDB `original` size image. Wired into `MovieDetails` and `TvDetails` — the poster `<div>` becomes a `<button>` that opens the lightbox.

No new deps. No API or DB changes. Behavior elsewhere untouched (TitleCards in grids still navigate to the details page like before).

Not linked to a specific issue — scratching my own itch, happy to drop it if it's out of scope.

## How Has This Been Tested?

- Built and ran the prod image (`docker build` from `Dockerfile`, node 22.22.2-alpine) on a Proxmox CT — opened a handful of movie and TV pages, clicked posters, tested Esc, X button, and click-outside-image to close
- `next build` (which runs ESLint) and `tsc` (server + client) both green on the final commit
- `prettier --check` clean on the three touched files
- Manual a11y pass: backdrop is a proper `<button>` so `jsx-a11y` rules pass without role hacks; image wrapper is `pointer-events-none` so clicks pass through to the backdrop button
- No new translation strings added — aria-labels stay in English to match the existing pattern (`SlideOver`, `ButtonWithDropdown`, pagination nav, etc.)

Tested on Chrome and on the phone work's like expected.

## Screenshots / Logs (if applicable)

<img width="1920" height="912" alt="chrome_ZPucz8H9TJ" src="https://github.com/user-attachments/assets/b6dea46d-39ff-4a9e-b4b6-9002db06e1b7" />
<img width="1920" height="912" alt="chrome_KXToziWDHf" src="https://github.com/user-attachments/assets/0e3d0971-b7c4-4e0e-820c-435ca637ba7a" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) — Claude Code helped me scaffold the component and the integration; I reviewed every line and made the a11y refactor myself.
- [ ] I have updated the documentation accordingly. — no docs changes needed
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` — no new strings
- [ ] Database migration (if required) — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poster expand functionality: Click movie and TV show posters to open a fullscreen lightbox overlay with a larger preview.
  * Improved usability: The overlay locks background scrolling and supports multiple close methods (Escape key, click outside, or a dedicated close button).
  * Accessibility: Added clear aria labels for the poster expand control and the lightbox dialog content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->