### PR TITLE
fix: add accept-encoding: identity to TMDB api calls

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -139,6 +139,9 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
       },
       {
         nodeCache: cacheManager.getCache('tmdb').data,
+        headers: {
+          'Accept-Encoding': 'identity',
+        },
         rateLimit: {
           maxRequests: 20,
           maxRPS: 50,


### PR DESCRIPTION
## Description

TMDB started returning gzip'd responses without including the gzip encoding response header today. This is a small hack to work around it. Codex helped diagnose.

## How Has This Been Tested?

Ran locally

## Screenshots / Logs (if applicable)

Before:

<img width="1196" height="564" alt="Screenshot 2026-05-19 at 6 09 53 PM" src="https://github.com/user-attachments/assets/5f1bde72-ab8e-40f7-81d3-1c893fd101c6" />


After:

<img width="937" height="542" alt="image" src="https://github.com/user-attachments/assets/66d029ad-2e1d-4e9e-ae7b-077cf5d8aec8" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API request handling for improved compatibility with external service communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->