### PR TITLE
feat(settings): add sync button to apply default permissions to existing users

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -75,9 +75,25 @@ settingsRoutes.get('/main', (req, res, next) => {
 
 settingsRoutes.post('/main', async (req, res) => {
   const settings = getSettings();
+  const { applyToExistingUsers, ...bodyWithoutFlag } = req.body;
 
-  settings.main = merge(settings.main, req.body);
+  settings.main = merge(settings.main, bodyWithoutFlag);
   await settings.save();
+
+  if (
+    applyToExistingUsers &&
+    bodyWithoutFlag.defaultPermissions !== undefined
+  ) {
+    const userRepository = getRepository(User);
+    await userRepository
+      .createQueryBuilder()
+      .update(User)
+      .set({ permissions: bodyWithoutFlag.defaultPermissions })
+      .where('(permissions & :adminFlag) = 0', {
+        adminFlag: Permission.ADMIN,
+      })
+      .execute();
+  }
 
   return res.status(200).json(settings.main);
 });

--- a/src/components/Settings/SettingsUsers/index.tsx
+++ b/src/components/Settings/SettingsUsers/index.tsx
@@ -9,11 +9,15 @@ import useSettings from '@app/hooks/useSettings';
 import useToasts from '@app/hooks/useToasts';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownOnSquareIcon,
+  ArrowPathIcon,
+} from '@heroicons/react/24/outline';
 import { MediaServerType } from '@server/constants/server';
 import type { MainSettings } from '@server/lib/settings';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
+import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import useSWR, { mutate } from 'swr';
 import * as yup from 'yup';
@@ -40,6 +44,11 @@ const messages = defineMessages('components.Settings.SettingsUsers', {
   tvRequestLimitLabel: 'Global Series Request Limit',
   defaultPermissions: 'Default Permissions',
   defaultPermissionsTip: 'Initial permissions assigned to new users',
+  syncPermissionsButton: 'Sync to Existing Users',
+  syncPermissionsSuccess:
+    'Default permissions have been applied to all non-admin users.',
+  syncPermissionsFailure:
+    'Something went wrong while syncing permissions to existing users.',
   disabledMediaServerLoginWarning:
     'Some users may not have a {applicationTitle} password set. Disabling {mediaServerName} sign-in could lock them out. Affected users will need to set a password from their profile or via a password reset link.',
 });
@@ -53,6 +62,7 @@ const SettingsUsers = () => {
     mutate: revalidate,
   } = useSWR<MainSettings>('/api/v1/settings/main');
   const settings = useSettings();
+  const [isSyncing, setIsSyncing] = useState(false);
 
   const schema = yup
     .object()
@@ -153,6 +163,30 @@ const SettingsUsers = () => {
           }}
         >
           {({ isSubmitting, isValid, values, errors, setFieldValue }) => {
+            const handleSyncPermissions = async () => {
+              setIsSyncing(true);
+              try {
+                await axios.post('/api/v1/settings/main', {
+                  defaultPermissions: values.defaultPermissions,
+                  applyToExistingUsers: true,
+                });
+                mutate('/api/v1/settings/public');
+
+                addToast(intl.formatMessage(messages.syncPermissionsSuccess), {
+                  autoDismiss: true,
+                  appearance: 'success',
+                });
+              } catch {
+                addToast(intl.formatMessage(messages.syncPermissionsFailure), {
+                  autoDismiss: true,
+                  appearance: 'error',
+                });
+              } finally {
+                revalidate();
+                setIsSyncing(false);
+              }
+            };
+
             return (
               <Form className="section">
                 <div
@@ -301,21 +335,32 @@ const SettingsUsers = () => {
                   </div>
                 </div>
                 <div className="actions">
-                  <div className="flex justify-end">
-                    <span className="ml-3 inline-flex rounded-md shadow-sm">
-                      <Button
-                        buttonType="primary"
-                        type="submit"
-                        disabled={isSubmitting || !isValid}
-                      >
-                        <ArrowDownOnSquareIcon />
-                        <span>
-                          {isSubmitting
-                            ? intl.formatMessage(globalMessages.saving)
-                            : intl.formatMessage(globalMessages.save)}
-                        </span>
-                      </Button>
-                    </span>
+                  <div className="flex justify-end gap-3">
+                    <Button
+                      buttonType="default"
+                      type="button"
+                      disabled={isSyncing || isSubmitting}
+                      onClick={handleSyncPermissions}
+                    >
+                      <ArrowPathIcon />
+                      <span>
+                        {isSyncing
+                          ? intl.formatMessage(globalMessages.saving)
+                          : intl.formatMessage(messages.syncPermissionsButton)}
+                      </span>
+                    </Button>
+                    <Button
+                      buttonType="primary"
+                      type="submit"
+                      disabled={isSubmitting || !isValid}
+                    >
+                      <ArrowDownOnSquareIcon />
+                      <span>
+                        {isSubmitting
+                          ? intl.formatMessage(globalMessages.saving)
+                          : intl.formatMessage(globalMessages.save)}
+                      </span>
+                    </Button>
                   </div>
                 </div>
               </Form>


### PR DESCRIPTION
## Summary

- Adds a **"Sync to Existing Users"** button on the User Settings page (Settings > Users)
- When clicked, applies the current default permissions to **all non-admin users** in the database
- The existing **Save** button behaviour is unchanged — it still only affects new users
- Backend: `POST /api/v1/settings/main` now accepts an `applyToExistingUsers` flag; when `true`, a bulk `UPDATE` excludes any user with the `ADMIN` permission bit set

## Motivation

Previously, changing the default permissions in settings had no effect on existing users. Admins had to update each user manually. This adds a one-click way to propagate the change without altering the default "save-only" flow.

## Test plan

- [ ] Change default permissions and click **Save** → existing users are unaffected
- [ ] Change default permissions and click **Sync to Existing Users** → all non-admin users receive the new permissions
- [ ] Admin users are not modified by the sync
- [ ] Toast messages appear correctly for both success and error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Sync to Existing Users" action in Users Settings to apply updated default permissions to all existing non-admin users in one operation. The UI shows a progress/saving indicator, temporarily disables related controls during the operation, and displays success/error notifications. Settings and public views refresh automatically after sync.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->