### PR TITLE
fix(request): restore media status correctly when deleting requests

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -265,3 +265,273 @@ describe('POST /request/:requestId/retry', () => {
     assert.ok(persisted.updatedAt > failed.updatedAt);
   });
 });
+
+describe('DELETE /request/:requestId, deleted media status restoration', () => {
+  async function seedDeletedMediaScenario() {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const admin = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 99001,
+        status: MediaStatus.DELETED,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const staleRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.COMPLETED,
+        media,
+        requestedBy: admin,
+        is4k: false,
+        isAutoRequest: true,
+      })
+    );
+
+    media.status = MediaStatus.PENDING;
+    await mediaRepo.save(media);
+
+    const newRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.APPROVED,
+        media,
+        requestedBy: admin,
+        is4k: false,
+      })
+    );
+
+    return { media, staleRequest, newRequest, admin };
+  }
+
+  it('restores media status to DELETED when the re-request is deleted and a stale completed request remains', async () => {
+    const mediaRepo = getRepository(Media);
+    const { media, newRequest } = await seedDeletedMediaScenario();
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${newRequest.id}`);
+
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status, MediaStatus.DELETED);
+  });
+
+  it('restores media status4k to DELETED when the re-request is deleted and a stale completed request remains', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const admin = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 99003,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.DELETED,
+      })
+    );
+
+    await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.COMPLETED,
+        media,
+        requestedBy: admin,
+        is4k: true,
+        isAutoRequest: true,
+      })
+    );
+
+    media.status4k = MediaStatus.PENDING;
+    await mediaRepo.save(media);
+
+    const newRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.APPROVED,
+        media,
+        requestedBy: admin,
+        is4k: true,
+      })
+    );
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${newRequest.id}`);
+
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status4k, MediaStatus.DELETED);
+  });
+
+  it('resets media status to UNKNOWN when the stale completed request is also deleted', async () => {
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+    const { media, newRequest, staleRequest } =
+      await seedDeletedMediaScenario();
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+
+    await agent.delete(`/request/${newRequest.id}`);
+
+    const res = await agent.delete(`/request/${staleRequest.id}`);
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
+
+    const remaining = await requestRepo.find({
+      where: { media: { id: media.id } },
+    });
+    assert.strictEqual(remaining.length, 0);
+  });
+
+  it('resets media status4k to UNKNOWN when the stale completed 4K request is also deleted', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const admin = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 99004,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.DELETED,
+      })
+    );
+
+    const staleRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.COMPLETED,
+        media,
+        requestedBy: admin,
+        is4k: true,
+        isAutoRequest: true,
+      })
+    );
+
+    media.status4k = MediaStatus.PENDING;
+    await mediaRepo.save(media);
+
+    const newRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.APPROVED,
+        media,
+        requestedBy: admin,
+        is4k: true,
+      })
+    );
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+
+    await agent.delete(`/request/${newRequest.id}`);
+
+    const res = await agent.delete(`/request/${staleRequest.id}`);
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status4k, MediaStatus.UNKNOWN);
+  });
+
+  it('does not reset media status when other active requests still exist', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const admin = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 99002,
+        status: MediaStatus.PENDING,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const req1 = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.PENDING,
+        media,
+        requestedBy: admin,
+        is4k: false,
+      })
+    );
+
+    await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.PENDING,
+        media,
+        requestedBy: admin,
+        is4k: false,
+      })
+    );
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${req1.id}`);
+
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status, MediaStatus.PENDING);
+  });
+
+  it('does not reset media status when status is PARTIALLY_AVAILABLE and only completed requests remain', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const admin = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 99005,
+        status: MediaStatus.PARTIALLY_AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const completedRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.COMPLETED,
+        media,
+        requestedBy: admin,
+        is4k: false,
+      })
+    );
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.delete(`/request/${completedRequest.id}`);
+
+    assert.strictEqual(res.status, 204);
+
+    const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
+    assert.strictEqual(updated.status, MediaStatus.PARTIALLY_AVAILABLE);
+  });
+});

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -952,13 +952,28 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       relations: { requests: true },
     });
 
+    const hasActive = fullMedia.requests.some(
+      (request) =>
+        !request.is4k &&
+        request.status !== MediaRequestStatus.COMPLETED &&
+        request.status !== MediaRequestStatus.DECLINED
+    );
+    const hasActive4k = fullMedia.requests.some(
+      (request) =>
+        request.is4k &&
+        request.status !== MediaRequestStatus.COMPLETED &&
+        request.status !== MediaRequestStatus.DECLINED
+    );
+
     const needsStatusUpdate =
-      !fullMedia.requests.some((request) => !request.is4k) &&
-      fullMedia.status !== MediaStatus.AVAILABLE;
+      !hasActive &&
+      fullMedia.status !== MediaStatus.AVAILABLE &&
+      fullMedia.status !== MediaStatus.PARTIALLY_AVAILABLE;
 
     const needs4kStatusUpdate =
-      !fullMedia.requests.some((request) => request.is4k) &&
-      fullMedia.status4k !== MediaStatus.AVAILABLE;
+      !hasActive4k &&
+      fullMedia.status4k !== MediaStatus.AVAILABLE &&
+      fullMedia.status4k !== MediaStatus.PARTIALLY_AVAILABLE;
 
     if (needsStatusUpdate || needs4kStatusUpdate) {
       // Re-fetch WITHOUT requests to avoid cascade issues on save
@@ -967,10 +982,21 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       });
 
       if (needsStatusUpdate) {
-        cleanMedia.status = MediaStatus.UNKNOWN;
+        const hadCompleted = fullMedia.requests.some(
+          (r) => !r.is4k && r.status === MediaRequestStatus.COMPLETED
+        );
+        cleanMedia.status = hadCompleted
+          ? MediaStatus.DELETED
+          : MediaStatus.UNKNOWN;
       }
+
       if (needs4kStatusUpdate) {
-        cleanMedia.status4k = MediaStatus.UNKNOWN;
+        const hadCompleted4k = fullMedia.requests.some(
+          (r) => r.is4k && r.status === MediaRequestStatus.COMPLETED
+        );
+        cleanMedia.status4k = hadCompleted4k
+          ? MediaStatus.DELETED
+          : MediaStatus.UNKNOWN;
       }
 
       await manager.save(cleanMedia);


### PR DESCRIPTION
## Description
When a movie is deleted from the media server, its status is set to `DELETED` and existing completed requests remain in the database. If a new request is then created for that media and subsequently that request is deleted, the media status would stay as `PENDING/REQUESTED` instead of reverting to DELETED. This happened because previously it counted all remaining requests including stale completed ones when deciding whether to reset the status, and always reset to `UNKNOWN` regardless of prior history. 

The PR fixes this by narrowing that check to active requests only and restores to `DELETED` when completed requests exist (indicating the media was previously downloaded), or `UNKNOWN` when there is no prior history.

## How Has This Been Tested?
- Manually verified the full lifecycle: 
  - created a request, marked it available, deleted it from the media server, re-requested it, then deleted that request and observed status correctly restored to `DELETED`.
- Manually confirmed deleting the stale completed request after resets status to `UNKNOWN`
- Also covered by supertest integration tests in `server/routes/request.test.ts`

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected media availability updates when requests are deleted, including proper restoration to Deleted or Unknown based on remaining requests and preserving Partial/Pending states when appropriate.
  * Ensures 4K-specific status is handled consistently alongside standard media status.

* **Tests**
  * Added comprehensive tests covering deletion scenarios to validate media status restoration and prevention of incorrect resets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->