### PR TITLE
fix(search): replace "TV" with "Series" in search placeholder

### DIFF
--- a/src/components/Layout/SearchInput/index.tsx
+++ b/src/components/Layout/SearchInput/index.tsx
@@ -5,7 +5,7 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/solid';
 import { useIntl } from 'react-intl';
 
 const messages = defineMessages('components.Layout.SearchInput', {
-  searchPlaceholder: 'Search Movies & TV',
+  searchPlaceholder: 'Search Movies & Series',
 });
 
 const SearchInput = () => {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -221,7 +221,7 @@
   "components.LanguageSelector.languageServerDefault": "Default ({language})",
   "components.LanguageSelector.originalLanguageDefault": "All Languages",
   "components.Layout.LanguagePicker.displaylanguage": "Display Language",
-  "components.Layout.SearchInput.searchPlaceholder": "Search Movies & TV",
+  "components.Layout.SearchInput.searchPlaceholder": "Search Movies & Series",
   "components.Layout.Sidebar.blocklist": "Blocklist",
   "components.Layout.Sidebar.browsemovies": "Movies",
   "components.Layout.Sidebar.browsetv": "Series",


### PR DESCRIPTION
## Description

Currently throughout the web-app, every mention for a TV Show (or Series) uses the wording "Series", be it "Upcoming Series", "Series" in the left-hand navbar and so forth. The only place I can notice "TV" is mentioned is the "searchPlaceholder" and it's bugging my OCD.

The change looks at the file at: src/components/Layout/SearchInput/index.tsx

It's a text change from: "TV" to "Series".
After this, `pnpm i18n:extract` is run to be able to have it translate into the "en.json" file automatically.

This is not related to any currently open change / issue.

## How Has This Been Tested?

To test this: `pnpm build` is used to test to see if the app will build successfully.
Next `pnpm dev` is used to create the web-app and host it locally on port 5055.
With this, I browse to the web-app & configure to join to Plex (my server of choice).
Visual inspection of the change and confirm it's working.
See image below.

## Screenshots / Logs
<img width="789" height="170" alt="image" src="https://github.com/user-attachments/assets/b4d0fc31-7a05-4f60-9f4b-22157cf80572" />

<img width="1111" height="670" alt="image" src="https://github.com/user-attachments/assets/1696462f-558f-4e1e-af77-707b4230c0a9" />

## Checklist:
- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`

Not needed:
- I have updated the documentation accordingly.
- Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search input placeholder text from "Search Movies & TV" to "Search Movies & Series" across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->