### PR TITLE
fix(watchlistsync): re-request deleted media from watchlist

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -151,18 +151,26 @@ export class MediaRequest {
         throw new BlocklistedMediaError('This media is blocklisted.');
       }
 
-      if (media.status === MediaStatus.UNKNOWN && !requestBody.is4k) {
+      if (
+        (media.status === MediaStatus.UNKNOWN ||
+          media.status === MediaStatus.DELETED) &&
+        !requestBody.is4k
+      ) {
         media.status = MediaStatus.PENDING;
       }
 
-      if (media.status4k === MediaStatus.UNKNOWN && requestBody.is4k) {
+      if (
+        (media.status4k === MediaStatus.UNKNOWN ||
+          media.status4k === MediaStatus.DELETED) &&
+        requestBody.is4k
+      ) {
         media.status4k = MediaStatus.PENDING;
       }
     }
 
     const existing = await requestRepository
       .createQueryBuilder('request')
-      .leftJoin('request.media', 'media')
+      .leftJoinAndSelect('request.media', 'media')
       .leftJoinAndSelect('request.requestedBy', 'user')
       .where('request.is4k = :is4k', { is4k: requestBody.is4k })
       .andWhere('media.tmdbId = :tmdbId', { tmdbId: tmdbMedia.id })
@@ -192,9 +200,13 @@ export class MediaRequest {
 
       // If an existing auto-request for this media exists from the same user,
       // don't allow a new one.
+      const statusKey = requestBody.is4k ? 'status4k' : 'status';
       if (
         existing.find(
-          (r) => r.requestedBy.id === requestUser.id && r.isAutoRequest
+          (r) =>
+            r.requestedBy.id === requestUser.id &&
+            r.isAutoRequest &&
+            r.media?.[statusKey] !== MediaStatus.DELETED
         )
       ) {
         throw new DuplicateMediaRequestError(

--- a/server/lib/watchlistsync.test.ts
+++ b/server/lib/watchlistsync.test.ts
@@ -1,0 +1,199 @@
+import type { PlexWatchlistItem } from '@server/api/plextv';
+import PlexTvAPI from '@server/api/plextv';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { UserSettings } from '@server/entity/UserSettings';
+import { Permission } from '@server/lib/permissions';
+import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+
+let watchlistItems: PlexWatchlistItem[] = [];
+
+Object.defineProperty(PlexTvAPI.prototype, 'getWatchlist', {
+  get() {
+    return async () => ({
+      offset: 0,
+      size: 20,
+      totalSize: watchlistItems.length,
+      items: watchlistItems,
+    });
+  },
+  set() {},
+  configurable: true,
+});
+
+let requestCalls: { mediaId: number; mediaType: MediaType }[] = [];
+
+Object.defineProperty(MediaRequest, 'request', {
+  value: async (body: { mediaId: number; mediaType: MediaType }) => {
+    requestCalls.push({ mediaId: body.mediaId, mediaType: body.mediaType });
+    return {} as MediaRequest;
+  },
+  writable: true,
+  configurable: true,
+});
+
+import watchlistSync from '@server/lib/watchlistsync';
+
+setupTestDb();
+
+async function configureSyncUser(): Promise<User> {
+  const userRepository = getRepository(User);
+  const admin = await userRepository.findOneOrFail({ where: { id: 1 } });
+
+  admin.plexToken = 'test-plex-token';
+  admin.permissions = Permission.AUTO_REQUEST;
+  await userRepository.save(admin);
+
+  const userSettingsRepository = getRepository(UserSettings);
+  await userSettingsRepository.save(
+    new UserSettings({
+      user: admin,
+      watchlistSyncMovies: true,
+      watchlistSyncTv: true,
+    })
+  );
+
+  return admin;
+}
+
+async function seedMedia(
+  tmdbId: number,
+  mediaType: MediaType,
+  status: MediaStatus
+): Promise<void> {
+  const mediaRepository = getRepository(Media);
+  await mediaRepository.save(
+    new Media({
+      tmdbId,
+      mediaType,
+      status,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+}
+
+function movieItem(tmdbId: number, title: string): PlexWatchlistItem {
+  return { ratingKey: `rk-${tmdbId}`, tmdbId, title, type: 'movie' };
+}
+
+function showItem(tmdbId: number, title: string): PlexWatchlistItem {
+  return {
+    ratingKey: `rk-${tmdbId}`,
+    tmdbId,
+    tvdbId: tmdbId * 1000,
+    title,
+    type: 'show',
+  };
+}
+
+describe('WatchlistSync re-request gating', () => {
+  beforeEach(() => {
+    requestCalls = [];
+    watchlistItems = [];
+  });
+
+  it('re-requests DELETED watchlist items and skips non-requestable ones', async () => {
+    await configureSyncUser();
+
+    await seedMedia(100, MediaType.MOVIE, MediaStatus.DELETED);
+    await seedMedia(101, MediaType.MOVIE, MediaStatus.UNKNOWN);
+    await seedMedia(102, MediaType.MOVIE, MediaStatus.AVAILABLE);
+    await seedMedia(103, MediaType.MOVIE, MediaStatus.BLOCKLISTED);
+
+    await seedMedia(200, MediaType.TV, MediaStatus.DELETED);
+    await seedMedia(201, MediaType.TV, MediaStatus.AVAILABLE);
+
+    watchlistItems = [
+      movieItem(100, 'Deleted Movie'),
+      movieItem(101, 'Unknown Movie'),
+      movieItem(102, 'Available Movie'),
+      movieItem(103, 'Blocklisted Movie'),
+      showItem(200, 'Deleted Show'),
+      showItem(201, 'Available Show'),
+    ];
+
+    await watchlistSync.syncWatchlist();
+
+    const requestedArray = requestCalls.map(
+      (c) => `${c.mediaType}:${c.mediaId}`
+    );
+    const requested = new Set(requestedArray);
+
+    assert.strictEqual(
+      requestedArray.length,
+      requested.size,
+      'Each item should be requested exactly once'
+    );
+
+    assert.ok(
+      requested.has(`${MediaType.MOVIE}:100`),
+      'DELETED movie on the watchlist should be re-requested'
+    );
+
+    assert.ok(
+      requested.has(`${MediaType.MOVIE}:101`),
+      'UNKNOWN movie should be requested'
+    );
+    assert.ok(
+      !requested.has(`${MediaType.MOVIE}:102`),
+      'AVAILABLE movie should NOT be requested'
+    );
+    assert.ok(
+      !requested.has(`${MediaType.MOVIE}:103`),
+      'BLOCKLISTED movie should NOT be requested'
+    );
+
+    assert.ok(
+      requested.has(`${MediaType.TV}:200`),
+      'DELETED show should be re-requested'
+    );
+    assert.ok(
+      !requested.has(`${MediaType.TV}:201`),
+      'AVAILABLE show should NOT be requested'
+    );
+  });
+
+  it('re-requests DELETED watchlist items even when a stale auto-request exists', async () => {
+    const user = await configureSyncUser();
+
+    await seedMedia(100, MediaType.MOVIE, MediaStatus.DELETED);
+
+    const media = await getRepository(Media).findOneOrFail({
+      where: { tmdbId: 100, mediaType: MediaType.MOVIE },
+    });
+
+    await getRepository(MediaRequest).save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.COMPLETED,
+        media,
+        requestedBy: user,
+        is4k: false,
+        isAutoRequest: true,
+      })
+    );
+
+    watchlistItems = [movieItem(100, 'Deleted Movie')];
+
+    await watchlistSync.syncWatchlist();
+
+    const calls = requestCalls.filter(
+      (c) => c.mediaType === MediaType.MOVIE && c.mediaId === 100
+    );
+
+    assert.strictEqual(
+      calls.length,
+      1,
+      'DELETED movie should be re-requested even when a stale auto-request exists'
+    );
+  });
+});

--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -91,7 +91,9 @@ class WatchlistSync {
 
     const autoRequestedTmdbIds = new Set(
       existingAutoRequests
-        .filter((r) => r.media != null)
+        .filter(
+          (r) => r.media != null && r.media.status !== MediaStatus.DELETED
+        )
         .map((r) => `${r.media.mediaType}:${r.media.tmdbId}`)
     );
 
@@ -106,7 +108,8 @@ class WatchlistSync {
             m.mediaType === itemMediaType &&
             (m.status === MediaStatus.BLOCKLISTED ||
               (itemMediaType === MediaType.MOVIE &&
-                m.status !== MediaStatus.UNKNOWN) ||
+                m.status !== MediaStatus.UNKNOWN &&
+                m.status !== MediaStatus.DELETED) ||
               (itemMediaType === MediaType.TV &&
                 m.status === MediaStatus.AVAILABLE))
         )


### PR DESCRIPTION
## Description
When a movie or show was deleted from the media server, its status was set to `DELETED` but the existing completed auto-request record remained in the database. This caused watchlist sync to skip re-requesting it entirely and the `autoRequestedTmdbIds` set included the stale auto-request, short-circuiting the filter before it even reached the status check. Even if that was fixed, the `unavailableItems` filter for movies excluded anything with a status other than `UNKNOWN`, so `DELETED` media was never eligible. On top of that, manually requesting the deleted media also failed because `MediaRequest.request()` found the stale auto-request and threw a `DuplicateMediaRequestError`.

This PR excludes `DELETED` media from `autoRequestedTmdbIds`, adds `DELETED` alongside `UNKNOWN` in the `unavailableItems` movie filter, updates the duplicate auto-request guard to ignore stale requests where the media is `DELETED`, and ensures the media status is correctly reset to `PENDING` when a new request is created for deleted media.

## How Has This Been Tested?
- Manually verified by deleting a movie from the media server, confirming it showed as `DELETED`, then waiting for watchlist sync to run and confirming it re-requested it automatically
- Manually confirmed that requesting deleted media through the UI no longer returns a 409 error
- Covered by the integration test in which fails on develop and passes with the fix

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media requests now mark deleted or unknown variants as pending so re-requests can proceed, and stale/deleted auto-requests no longer block new auto-requests.

* **Tests**
  * Added watchlist sync tests verifying re-request behavior for DELETED, UNKNOWN, AVAILABLE, and BLOCKLISTED items, including cases with existing stale auto-request records to ensure correct re-request gating.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->