### PR TITLE
fix(media): clean up watchlist on error card delete

### DIFF
--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -17,7 +17,7 @@ import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import { Router } from 'express';
 import type { FindOneOptions } from 'typeorm';
-import { In, IsNull, Not } from 'typeorm';
+import { EntityNotFoundError, In, IsNull, Not } from 'typeorm';
 
 const mediaRoutes = Router();
 
@@ -187,11 +187,15 @@ mediaRoutes.delete(
 
       return res.status(204).send();
     } catch (e) {
-      logger.error('Something went wrong fetching media in delete request', {
+      if (e instanceof EntityNotFoundError) {
+        return res.status(204).send();
+      }
+      logger.error('Something went wrong deleting media', {
         label: 'Media',
+        mediaId: req.params.id,
         message: e.message,
       });
-      next({ status: 404, message: 'Media not found' });
+      next({ status: 500, message: 'Failed to delete media' });
     }
   }
 );

--- a/src/components/TitleCard/ErrorCard.tsx
+++ b/src/components/TitleCard/ErrorCard.tsx
@@ -1,4 +1,5 @@
 import Button from '@app/components/Common/Button';
+import useToasts from '@app/hooks/useToasts';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import { CheckIcon, TrashIcon } from '@heroicons/react/24/solid';
@@ -23,9 +24,28 @@ const messages = defineMessages('components.TitleCard', {
 
 const ErrorCard = ({ id, tmdbId, tvdbId, type, canExpand }: ErrorCardProps) => {
   const intl = useIntl();
+  const { addToast } = useToasts();
 
   const deleteMedia = async () => {
-    await axios.delete(`/api/v1/media/${id}`);
+    try {
+      await axios.delete(`/api/v1/watchlist/${tmdbId}?mediaType=${type}`);
+    } catch (e) {
+      if (!axios.isAxiosError(e) || e.response?.status !== 404) {
+        addToast(intl.formatMessage(globalMessages.error), {
+          appearance: 'error',
+          autoDismiss: true,
+        });
+        return;
+      }
+    }
+    await axios.delete(`/api/v1/media/${id}`).catch((e) => {
+      if (axios.isAxiosError(e) && e.response?.status === 404) return;
+      addToast(intl.formatMessage(globalMessages.error), {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    });
+    mutate('/api/v1/discover/watchlist');
     mutate('/api/v1/media?filter=allavailable&take=20&sort=mediaAdded');
     mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
   };


### PR DESCRIPTION
## Description
When dismissing an error card for unavailable media, the watchlist entry for that item was not being removed, causing it to reappear on the discover watchlist page after deletion. 

The PR fixes this by removing the watchlist entry first before deleting the media record, then mutates the watchlist discover endpoint so the UI reflects the removal immediately, and silently swallows 404s on the watchlist delete since the entry may not exist.

On the server side, concurrent or repeated delete requests for the same media record could hit a race where the entity is already gone, resulting in an unhandled `EntityNotFoundError` being logged as an error and returning 404 and this PR fixes that by catching that case and returning 204 instead since the desired end state is already achieved.

- Fixes #3046

## How Has This Been Tested?

- This PR has a preview with the tag `preview-clean-up-watchlist-error-card`

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable media deletion that also removes related watchlist entries.
  * Improved error handling with clear on-screen notifications for failures (non-not-found cases).
  * Deletion now treats missing items as no-ops instead of errors.
  * Client caches refresh correctly after deletions to keep UI in sync.
  * Server deletion responses made more accurate for different failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->