### PR TITLE
Pass COMMIT_TAG build arg through fork CI and release

### DIFF
--- a/.github/workflows/fork-build-test.yml
+++ b/.github/workflows/fork-build-test.yml
@@ -1,0 +1,20 @@
+# Fork CI gate. Calls the shared reusable workflow in NotCavnfox/.github.
+name: fork-build-test
+
+on:
+  pull_request:
+  push:
+    branches: [develop]
+
+jobs:
+  ci:
+    uses: NotCavnfox/.github/.github/workflows/build-test.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image_name: ghcr.io/notcavnfox/seerr
+      smoke_port: 5055
+      smoke_path: /api/v1/status
+      compose_test: true
+      publish_edge: true

--- a/.github/workflows/fork-build-test.yml
+++ b/.github/workflows/fork-build-test.yml
@@ -18,3 +18,8 @@ jobs:
       smoke_path: /api/v1/status
       compose_test: true
       publish_edge: true
+      # Seerr bakes the build commit into committag.json; without it the UI
+      # polls /api/v1/status, sees an empty commitTag, and loops on a
+      # "Seerr Updated — reload" prompt that never clears.
+      build_args: |
+        COMMIT_TAG=${{ github.sha }}

--- a/.github/workflows/fork-claude.yml
+++ b/.github/workflows/fork-claude.yml
@@ -1,0 +1,54 @@
+# Async "@claude" assistant for this fork. Deployed into forks as
+# `fork-claude.yml` (the `fork-` prefix avoids clobbering any upstream workflow).
+#
+# Comment `@claude <ask>` on an issue or PR and Claude implements it on a branch
+# and opens / updates a PR — which you still review and merge (the human gate).
+#
+# REQUIRES a repo (or org) secret `CLAUDE_CODE_OAUTH_TOKEN`, generated locally
+# with `claude setup-token`. This bills @claude runs against your Claude Pro/Max
+# subscription usage — NOT the pay-as-you-go Anthropic API. Until the secret
+# exists the job never runs. (To use metered API billing instead, swap the
+# `claude_code_oauth_token` input below for `anthropic_api_key` + an
+# `ANTHROPIC_API_KEY` secret.)
+#
+# The `if:` gate restricts triggering to the repo OWNER/collaborators so an
+# outside contributor cannot spend your API budget. Loosen at your own cost.
+name: fork-claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run on an explicit @claude mention AND only for trusted authors.
+    if: >
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      ) && (
+        github.event.sender.login == 'NotCavnfox' ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Keep runs bounded so a runaway thread can't burn plan usage.
+          claude_args: "--max-turns 12"

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -42,6 +42,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Seerr bakes this into committag.json; empty value loops the UI on a
+          # "Seerr Updated — reload" prompt.
+          build-args: |
+            COMMIT_TAG=${{ github.ref_name }}
           sbom: true
           provenance: mode=max
           cache-from: type=gha

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -1,0 +1,48 @@
+# Tag v* -> build image, push to GHCR with SBOM + provenance.
+name: fork-release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  IMAGE: ghcr.io/notcavnfox/seerr
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Derive tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/fork-sync-upstream.yml
+++ b/.github/workflows/fork-sync-upstream.yml
@@ -1,0 +1,69 @@
+# Nightly: rebase the patch-overlay onto the latest upstream release, open a PR.
+name: fork-sync-upstream
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: "Upstream ref to rebase onto (default: latest release tag)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  UPSTREAM_URL: https://github.com/seerr-team/seerr.git
+  BASE_BRANCH: develop
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure git
+        run: |
+          git config user.name "fork-sync-bot"
+          git config user.email "fork-sync-bot@users.noreply.github.com"
+      - name: Fetch upstream
+        run: |
+          git remote add upstream "$UPSTREAM_URL" 2>/dev/null || git remote set-url upstream "$UPSTREAM_URL"
+          git fetch upstream --tags --prune
+      - name: Resolve target ref
+        id: target
+        run: |
+          REF="${{ github.event.inputs.upstream_ref }}"
+          if [ -z "$REF" ]; then
+            REF=$(git tag -l --sort=-v:refname | grep -E '^v?[0-9]' | head -n1)
+            [ -z "$REF" ] && REF="upstream/HEAD"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "branch=sync/upstream-$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+      - name: Rebase patch-overlay
+        id: rebase
+        run: |
+          git checkout -B "${{ steps.target.outputs.branch }}"
+          if git rebase "${{ steps.target.outputs.ref }}"; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+          else
+            git rebase --abort || true
+            echo "status=conflict" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -f origin "${{ steps.target.outputs.branch }}"
+          BODY="Automated upstream sync onto \`${{ steps.target.outputs.ref }}\`."
+          if [ "${{ steps.rebase.outputs.status }}" = "conflict" ]; then
+            BODY="$BODY\n\n:warning: Rebase hit conflicts — resolve manually before merge."
+          fi
+          gh pr create --base "$BASE_BRANCH" --head "${{ steps.target.outputs.branch }}" \
+            --title "sync: upstream ${{ steps.target.outputs.ref }}" \
+            --body "$(printf '%b' "$BODY")" \
+            --label "upstream-sync" || echo "PR may already exist"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NotCavnfox

--- a/FORK.md
+++ b/FORK.md
@@ -1,0 +1,17 @@
+# Fork notes
+
+This is a homelab fork of `https://github.com/seerr-team/seerr.git`, maintained to add features and accept
+contributions. Image published to `ghcr.io/notcavnfox/seerr`.
+
+- **Working branch:** `develop` (protected — PR + green `ci / fork-build-test` + 1 review).
+- **Patch-overlay:** keep changes minimal; `fork-sync-upstream` rebases onto each
+  upstream release nightly and opens a PR.
+- **Tests:** `test/smoke.sh` (boot + HTTP 5055/api/v1/status) and `test/compose.test.yml`
+  must stay green — that gate protects the live homelab.
+
+## Local loop
+```bash
+docker build -t localbuild:ci .
+PORT=5055 HEALTH_PATH=/api/v1/status IMAGE=localbuild:ci bash test/smoke.sh
+IMAGE=localbuild:ci docker compose -f test/compose.test.yml up -d --wait
+```

--- a/test/compose.test.yml
+++ b/test/compose.test.yml
@@ -1,0 +1,10 @@
+# Ephemeral integration stand-up (single service, sqlite/no external deps).
+services:
+  app:
+    image: ${IMAGE:-localbuild:ci}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5055/api/v1/status || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+      start_period: 20s

--- a/test/compose.test.yml
+++ b/test/compose.test.yml
@@ -1,10 +1,6 @@
-# Ephemeral integration stand-up (single service, sqlite/no external deps).
+# Ephemeral integration stand-up (single service; readiness polled from host).
 services:
   app:
     image: ${IMAGE:-localbuild:ci}
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:5055/api/v1/status || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 24
-      start_period: 20s
+    ports:
+      - "127.0.0.1:5055:5055"

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Boot the built image, wait for it to answer, assert HTTP < 400.
+set -euo pipefail
+IMAGE="${IMAGE:-localbuild:ci}"
+PORT="${PORT:?set PORT}"
+HEALTH_PATH="${HEALTH_PATH:-/}"
+NAME="smoke-$$"
+cleanup() { docker logs "$NAME" 2>&1 | tail -n 50 || true; docker rm -f "$NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+echo "running $IMAGE"
+docker run -d --name "$NAME" -p "127.0.0.1:${PORT}:${PORT}" "$IMAGE" >/dev/null
+echo "waiting for http://127.0.0.1:${PORT}${HEALTH_PATH}"
+for i in $(seq 1 60); do
+  if ! docker ps --filter "name=$NAME" --filter status=running -q | grep -q .; then
+    echo "container exited early"; exit 1
+  fi
+  code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}${HEALTH_PATH}" || echo 000)
+  if [ "$code" -ge 200 ] && [ "$code" -lt 400 ]; then echo "smoke ok (HTTP $code after ${i}s)"; exit 0; fi
+  sleep 2
+done
+echo "no healthy response within timeout (last: ${code:-none})"; exit 1


### PR DESCRIPTION
## Problem
Seerr/Overseerr bakes the build commit into `/app/committag.json`. The fork's `:edge` and tagged images are built **without** `COMMIT_TAG`, so the file is empty, `/api/v1/status` returns an empty `commitTag`, and the web UI loops on a "Seerr Updated — reload" modal while reporting "Out of Date".

## Fix
- `fork-build-test.yml`: supply `build_args: COMMIT_TAG=${{ github.sha }}` to the reusable build-test workflow (powers the `:edge` build).
- `fork-release.yml`: add `build-args: COMMIT_TAG=${{ github.ref_name }}` to the build-and-push step (powers tagged releases).

## Dependency / merge order
Depends on NotCavnfox/.github#1, which adds the `build_args` input to the reusable workflow. **Merge that PR first** — until then `fork-build-test.yml` would pass an input the reusable workflow doesn't accept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated testing infrastructure including smoke and integration tests.
  * Automated Docker image builds and releases for tagged versions.
  * Nightly upstream synchronization workflow.
  * Code review automation support.

* **Documentation**
  * Added fork maintenance guide with testing requirements and contribution expectations.

* **Chores**
  * Configured repository code ownership and GitHub Actions CI/CD workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->