### PR TITLE
docs(nixpkgs): add documentation for nixpkgs 26.05

### DIFF
--- a/docs/getting-started/nixpkg.mdx
+++ b/docs/getting-started/nixpkg.mdx
@@ -12,15 +12,11 @@ import TabItem from '@theme/TabItem';
 # Nix Package Manager
 :::warning
 This method is not recommended for most users. It is intended for advanced users who are using NixOS distribution.
+The Seerr service and package are available as of the 26.05 release.
 :::
 
-:::danger
-The seerr service and package are available in the unstable channel only and will be officially included in the 26.05 release.
-:::
+Refer to [NixOS documentation](https://search.nixos.org/options?channel=26.05&query=seerr)
 
-Refer to [NixOS documentation](https://search.nixos.org/options?channel=unstable&query=seerr)
-
-<!--
 export const VersionMismatchWarning = () => {
   let seerrVersion = null;
   let nixpkgVersions = null;
@@ -72,7 +68,6 @@ export const VersionMismatchWarning = () => {
 };
 
 <VersionMismatchWarning />
--->
 
 ## Installation
 To get up and running with seerr using Nix, you can add the following to your `configuration.nix`:

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -222,7 +222,7 @@ Summary of changes :
 
 Refer to [Seerr Documentation](/getting-started/nixpkg), all of our examples have been updated to reflect the below change.
 
-The seerr service and package are available in the unstable channel and will be officially included in the 26.05 release.
+The Seerr service and package are available as of the 26.05 release.
 
 ## Third-party installation methods
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add documentation for nixpkgs 26.05

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

n/a

## Screenshots / Logs (if applicable)

Tested the warning message by hardcoding `seerrVersion = "1.0.0"` instead of `seerrVersion = SeerrVersion();`
<img width="985" height="146" alt="2026-05-29-220832_hyprshot" src="https://github.com/user-attachments/assets/b52e9d33-9b33-4e97-ad50-7e446d98560c" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Nix getting-started note: Seerr is available in the 26.05 release, replacing the prior "unstable channel only" wording and restoring the version-mismatch warning immediately before Installation.
  * Updated migration guide to reflect Seerr’s availability in 26.05.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seerr-team/seerr/pull/3089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->