### PR TITLE
fix(ntfy): save priority field as number instead of string

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -1561,6 +1561,10 @@ components:
               type: boolean
             token:
               type: string
+            priority:
+              type: number
+            locale:
+              type: string
     NotificationEmailSettings:
       type: object
       properties:

--- a/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsNtfy/index.tsx
@@ -123,7 +123,7 @@ const NotificationsNtfy = () => {
               password: values.password,
               authMethodToken: values.authMethodToken,
               token: values.token,
-              priority: values.priority,
+              priority: Number(values.priority),
               locale: values.locale,
             },
           });
@@ -176,7 +176,7 @@ const NotificationsNtfy = () => {
                 password: values.password,
                 authMethodToken: values.authMethodToken,
                 token: values.token,
-                priority: values.priority,
+                priority: Number(values.priority),
                 locale: values.locale,
               },
             });


### PR DESCRIPTION
## Description

Because the `priority` field of the ntfy.sh settings was set using a HTML <Select>, the saved value was a string instead of the expected number. This PR converts the string value of the <Select> into a number.

- Fixes #2929

## How Has This Been Tested?

Send a test notification with a priority set.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added priority and locale configuration options for ntfy notifications.

* **Bug Fixes**
  * Fixed priority value type handling in ntfy notification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->