### PR TITLE
feat: add optional userId field to issue creation endpoint

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -7576,7 +7576,11 @@ paths:
     post:
       summary: Create new issue
       description: |
-        Creates a new issue
+        Creates a new issue.
+        **Note:**:
+        - To create an issue **for yourself**, you need `CREATE_ISSUES` or `MANAGE_ISSUES`.
+        - To create an issue **on behalf of another user** (using `userId`), you need `MANAGE_ISSUES`.
+        If `userId` is omitted, the issue is attributed to the authenticated user.
       tags:
         - issue
       requestBody:
@@ -7585,6 +7589,10 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - mediaId
+                - issueType
+                - message
               properties:
                 issueType:
                   type: number
@@ -7592,6 +7600,10 @@ paths:
                   type: string
                 mediaId:
                   type: number
+                userId:
+                  type: number
+                  description:
+                  nullable: true
       responses:
         '201':
           description: Succesfully created the issue

--- a/server/routes/issue.ts
+++ b/server/routes/issue.ts
@@ -2,6 +2,7 @@ import { IssueStatus, IssueType } from '@server/constants/issue';
 import { getRepository } from '@server/datasource';
 import Issue from '@server/entity/Issue';
 import IssueComment from '@server/entity/IssueComment';
+import { User } from '@server/entity/User';
 import Media from '@server/entity/Media';
 import type { IssueResultsResponse } from '@server/interfaces/api/issueInterfaces';
 import { Permission } from '@server/lib/permissions';
@@ -104,6 +105,7 @@ issueRoutes.post<
     issueType: number;
     problemSeason: number;
     problemEpisode: number;
+    userId?: number;
   }
 >(
   '/',
@@ -118,6 +120,7 @@ issueRoutes.post<
 
     const issueRepository = getRepository(Issue);
     const mediaRepository = getRepository(Media);
+    const userRepository = getRepository(User);
 
     const media = await mediaRepository.findOne({
       where: { id: req.body.mediaId },
@@ -127,15 +130,31 @@ issueRoutes.post<
       return next({ status: 404, message: 'Media does not exist.' });
     }
 
+    let createdByUser = req.user;
+    if (req.body.userId) {
+      if (!req.user.hasPermission(Permission.MANAGE_ISSUES)) {
+        return next({
+          status: 403,
+          message: 'You do not have permission to create an issue on behalf of another user.',
+        });
+      }
+
+      const targetUser = await userRepository.findOne({ where: { id: req.body.userId } });
+      if (!targetUser) {
+        return next({ status: 404, message: 'Target user not found.' });
+      }
+      createdByUser = targetUser;
+    }
+
     const issue = new Issue({
-      createdBy: req.user,
+      createdBy: createdByUser,
       issueType: req.body.issueType,
       problemSeason: req.body.problemSeason,
       problemEpisode: req.body.problemEpisode,
       media,
       comments: [
         new IssueComment({
-          user: req.user,
+          user: createdByUser,
           message: req.body.message,
         }),
       ],


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description
This PR solves #3094 by adding the optional `userId` field to `/issue` endpoint when creating a new issue to match the behavior of the `create new request` api 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #3094

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using python `requests` on local built docker image to verify behaviour of the API

## Screenshots / Logs (if applicable)

## AI Disclosure:
Used Deepseek to understand how to format the updated api documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required) - Not required
