### PR TITLE
fix(availability-sync): keep seasons when the media server is unreachable

### DIFF
--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -798,9 +798,6 @@ describe('AvailabilitySync', () => {
     });
 
     it('should not delete seasons when the Jellyfin fetch fails with a non-404 error (e.g. server unreachable)', async () => {
-      // Mirror of the Plex outage regression test (seerr-team/seerr#1729) for
-      // the Jellyfin/Emby path, since this change applies the same fallback
-      // contract to mediaExistsInJellyfin.
       configureJellyfin();
       configureSonarr([{ syncEnabled: true }]);
 
@@ -824,15 +821,12 @@ describe('AvailabilitySync', () => {
       }
       await mediaRepository.save(media);
 
-      // Jellyfin is unreachable: item/season fetches reject with a connection
-      // error (NOT a 404/500). The media genuinely still exists in Jellyfin.
       getItemDataImpl = async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:8096');
       };
       getSeasonsImpl = async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:8096');
       };
-      // TMDB reports all three seasons as having episodes...
       getTvShowImpl = async () =>
         fakeTmdbShow(
           1412,
@@ -845,7 +839,6 @@ describe('AvailabilitySync', () => {
             season_number: n,
           }))
         );
-      // ...and Sonarr does not track the series, so it cannot vouch for them either.
       getSeriesByIdImpl = async () => {
         throw new Error('404');
       };
@@ -974,11 +967,6 @@ describe('AvailabilitySync', () => {
 
   describe('TV season availability - Plex', () => {
     it('should not delete seasons when the Plex season fetch fails with a non-404 error (e.g. server unreachable)', async () => {
-      // Regression test for seerr-team/seerr#1729: when Plex is briefly
-      // unreachable during an availability sync, the show is correctly kept
-      // ("Preventing removal"), but every season used to be marked DELETED
-      // because the empty Plex season map was treated as "confirmed absent".
-      // A connection error must NOT delete seasons we simply could not verify.
       configurePlex();
       configureSonarr([{ syncEnabled: true }]);
 
@@ -1002,15 +990,12 @@ describe('AvailabilitySync', () => {
       }
       await mediaRepository.save(media);
 
-      // Plex is unreachable: metadata fetches reject with a connection error
-      // (NOT a 404). The media genuinely still exists in Plex.
       getMetadataImpl = async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:32400');
       };
       getChildrenMetadataImpl = async () => {
         throw new Error('connect ECONNREFUSED 127.0.0.1:32400');
       };
-      // TMDB reports all three seasons as having episodes...
       getTvShowImpl = async () =>
         fakeTmdbShow(
           1434,
@@ -1023,7 +1008,6 @@ describe('AvailabilitySync', () => {
             season_number: n,
           }))
         );
-      // ...and Sonarr does not track the series, so it cannot vouch for them either.
       getSeriesByIdImpl = async () => {
         throw new Error('404');
       };

--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -797,6 +797,80 @@ describe('AvailabilitySync', () => {
       );
     });
 
+    it('should not delete seasons when the Jellyfin fetch fails with a non-404 error (e.g. server unreachable)', async () => {
+      // Mirror of the Plex outage regression test (seerr-team/seerr#1729) for
+      // the Jellyfin/Emby path, since this change applies the same fallback
+      // contract to mediaExistsInJellyfin.
+      configureJellyfin();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1412;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.jellyfinMediaId = 'jellyfin-unreachable-id';
+      media.externalServiceId = 301;
+      media.seasons = [];
+      for (let i = 1; i <= 3; i++) {
+        media.seasons.push(
+          new Season({
+            seasonNumber: i,
+            status: MediaStatus.AVAILABLE,
+            status4k: MediaStatus.UNKNOWN,
+          })
+        );
+      }
+      await mediaRepository.save(media);
+
+      // Jellyfin is unreachable: item/season fetches reject with a connection
+      // error (NOT a 404/500). The media genuinely still exists in Jellyfin.
+      getItemDataImpl = async () => {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:8096');
+      };
+      getSeasonsImpl = async () => {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:8096');
+      };
+      // TMDB reports all three seasons as having episodes...
+      getTvShowImpl = async () =>
+        fakeTmdbShow(
+          1412,
+          [1, 2, 3].map((n) => ({
+            id: n,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: `Season ${n}`,
+            overview: '',
+            season_number: n,
+          }))
+        );
+      // ...and Sonarr does not track the series, so it cannot vouch for them either.
+      getSeriesByIdImpl = async () => {
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1412 },
+        relations: ['seasons'],
+      });
+
+      for (const season of updated.seasons) {
+        assert.strictEqual(
+          season.status,
+          MediaStatus.AVAILABLE,
+          `Season ${season.seasonNumber} should remain AVAILABLE when Jellyfin is unreachable, but was ${season.status}`
+        );
+      }
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should remain AVAILABLE when Jellyfin is unreachable'
+      );
+    });
+
     it('should mark show as PARTIALLY_AVAILABLE when some seasons are available and some are unknown', async () => {
       configureJellyfin();
       configureSonarr([{ syncEnabled: true }]);

--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -899,6 +899,82 @@ describe('AvailabilitySync', () => {
   });
 
   describe('TV season availability - Plex', () => {
+    it('should not delete seasons when the Plex season fetch fails with a non-404 error (e.g. server unreachable)', async () => {
+      // Regression test for seerr-team/seerr#1729: when Plex is briefly
+      // unreachable during an availability sync, the show is correctly kept
+      // ("Preventing removal"), but every season used to be marked DELETED
+      // because the empty Plex season map was treated as "confirmed absent".
+      // A connection error must NOT delete seasons we simply could not verify.
+      configurePlex();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1434;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.ratingKey = 'plex-unreachable-rk';
+      media.externalServiceId = 300;
+      media.seasons = [];
+      for (let i = 1; i <= 3; i++) {
+        media.seasons.push(
+          new Season({
+            seasonNumber: i,
+            status: MediaStatus.AVAILABLE,
+            status4k: MediaStatus.UNKNOWN,
+          })
+        );
+      }
+      await mediaRepository.save(media);
+
+      // Plex is unreachable: metadata fetches reject with a connection error
+      // (NOT a 404). The media genuinely still exists in Plex.
+      getMetadataImpl = async () => {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:32400');
+      };
+      getChildrenMetadataImpl = async () => {
+        throw new Error('connect ECONNREFUSED 127.0.0.1:32400');
+      };
+      // TMDB reports all three seasons as having episodes...
+      getTvShowImpl = async () =>
+        fakeTmdbShow(
+          1434,
+          [1, 2, 3].map((n) => ({
+            id: n,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: `Season ${n}`,
+            overview: '',
+            season_number: n,
+          }))
+        );
+      // ...and Sonarr does not track the series, so it cannot vouch for them either.
+      getSeriesByIdImpl = async () => {
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1434 },
+        relations: ['seasons'],
+      });
+
+      for (const season of updated.seasons) {
+        assert.strictEqual(
+          season.status,
+          MediaStatus.AVAILABLE,
+          `Season ${season.seasonNumber} should remain AVAILABLE when Plex is unreachable, but was ${season.status}`
+        );
+      }
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should remain AVAILABLE when Plex is unreachable'
+      );
+    });
+
     it('should mark deleted seasons when Plex returns empty season metadata entries', async () => {
       configurePlex();
       configureSonarr([{ syncEnabled: true }]);

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -937,30 +937,27 @@ class AvailabilitySync {
       }
     }
 
-    // Here we check each season in plex for availability
-    // If the API returns an error other than a 404,
-    // we will have to prevent the season check from happening
+    // Here we check each season in plex for availability.
+    // If the API returned an error other than a 404 we could not verify the
+    // seasons, so we assume the previously-available ones still exist instead
+    // of deleting media we simply failed to reach (mirrors the show-level guard).
     if (media.mediaType === 'tv') {
       const seasonsMap: Map<number, boolean> = new Map();
 
-      if (!preventSeasonSearch) {
-        const filteredSeasons = media.seasons.filter(
-          (season) =>
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] ===
-              MediaStatus.PARTIALLY_AVAILABLE
-        );
+      const filteredSeasons = media.seasons.filter(
+        (season) =>
+          season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
+          season[is4k ? 'status4k' : 'status'] ===
+            MediaStatus.PARTIALLY_AVAILABLE
+      );
 
-        for (const season of filteredSeasons) {
-          const seasonExists = await this.seasonExistsInPlex(
-            media,
-            season,
-            is4k
-          );
+      for (const season of filteredSeasons) {
+        const seasonExists = preventSeasonSearch
+          ? true
+          : await this.seasonExistsInPlex(media, season, is4k);
 
-          if (seasonExists) {
-            seasonsMap.set(season.seasonNumber, true);
-          }
+        if (seasonExists) {
+          seasonsMap.set(season.seasonNumber, true);
         }
       }
 
@@ -1074,30 +1071,27 @@ class AvailabilitySync {
       }
     }
 
-    // Here we check each season in jellyfin for availability
-    // If the API returns an error other than a 404,
-    // we will have to prevent the season check from happening
+    // Here we check each season in jellyfin for availability.
+    // If the API returned an error other than a 404 we could not verify the
+    // seasons, so we assume the previously-available ones still exist instead
+    // of deleting media we simply failed to reach (mirrors the show-level guard).
     if (media.mediaType === 'tv') {
       const seasonsMap: Map<number, boolean> = new Map();
 
-      if (!preventSeasonSearch) {
-        const filteredSeasons = media.seasons.filter(
-          (season) =>
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] ===
-              MediaStatus.PARTIALLY_AVAILABLE
-        );
+      const filteredSeasons = media.seasons.filter(
+        (season) =>
+          season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
+          season[is4k ? 'status4k' : 'status'] ===
+            MediaStatus.PARTIALLY_AVAILABLE
+      );
 
-        for (const season of filteredSeasons) {
-          const seasonExists = await this.seasonExistsInJellyfin(
-            media,
-            season,
-            is4k
-          );
+      for (const season of filteredSeasons) {
+        const seasonExists = preventSeasonSearch
+          ? true
+          : await this.seasonExistsInJellyfin(media, season, is4k);
 
-          if (seasonExists) {
-            seasonsMap.set(season.seasonNumber, true);
-          }
+        if (seasonExists) {
+          seasonsMap.set(season.seasonNumber, true);
         }
       }
 

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -948,6 +948,8 @@ class AvailabilitySync {
             MediaStatus.PARTIALLY_AVAILABLE
       );
 
+      // If the Plex lookup failed but the show should be preserved, skip
+      // per-season lookups and keep previously available seasons available.
       if (preventSeasonSearch) {
         filteredSeasons.forEach((season) =>
           seasonsMap.set(season.seasonNumber, true)
@@ -1084,6 +1086,8 @@ class AvailabilitySync {
             MediaStatus.PARTIALLY_AVAILABLE
       );
 
+      // If the Jellyfin lookup failed but the show should be preserved, skip
+      // per-season lookups and keep previously available seasons available.
       if (preventSeasonSearch) {
         filteredSeasons.forEach((season) =>
           seasonsMap.set(season.seasonNumber, true)

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -938,9 +938,6 @@ class AvailabilitySync {
     }
 
     // Here we check each season in plex for availability.
-    // If the API returned an error other than a 404 we could not verify the
-    // seasons, so we assume the previously-available ones still exist instead
-    // of deleting media we simply failed to reach (mirrors the show-level guard).
     if (media.mediaType === 'tv') {
       const seasonsMap: Map<number, boolean> = new Map();
 
@@ -951,10 +948,15 @@ class AvailabilitySync {
             MediaStatus.PARTIALLY_AVAILABLE
       );
 
+      if (preventSeasonSearch) {
+        filteredSeasons.forEach((season) =>
+          seasonsMap.set(season.seasonNumber, true)
+        );
+        return { existsInPlex, seasonsMap };
+      }
+
       for (const season of filteredSeasons) {
-        const seasonExists = preventSeasonSearch
-          ? true
-          : await this.seasonExistsInPlex(media, season, is4k);
+        const seasonExists = await this.seasonExistsInPlex(media, season, is4k);
 
         if (seasonExists) {
           seasonsMap.set(season.seasonNumber, true);
@@ -1072,9 +1074,6 @@ class AvailabilitySync {
     }
 
     // Here we check each season in jellyfin for availability.
-    // If the API returned an error other than a 404 we could not verify the
-    // seasons, so we assume the previously-available ones still exist instead
-    // of deleting media we simply failed to reach (mirrors the show-level guard).
     if (media.mediaType === 'tv') {
       const seasonsMap: Map<number, boolean> = new Map();
 
@@ -1085,10 +1084,19 @@ class AvailabilitySync {
             MediaStatus.PARTIALLY_AVAILABLE
       );
 
+      if (preventSeasonSearch) {
+        filteredSeasons.forEach((season) =>
+          seasonsMap.set(season.seasonNumber, true)
+        );
+        return { existsInJellyfin, seasonsMap };
+      }
+
       for (const season of filteredSeasons) {
-        const seasonExists = preventSeasonSearch
-          ? true
-          : await this.seasonExistsInJellyfin(media, season, is4k);
+        const seasonExists = await this.seasonExistsInJellyfin(
+          media,
+          season,
+          is4k
+        );
 
         if (seasonExists) {
           seasonsMap.set(season.seasonNumber, true);


### PR DESCRIPTION
## Description

Fixes #1729.

This PR stops availability sync from marking TV seasons as deleted when Plex or Jellyfin is temporarily unreachable. If the media-server lookup fails with a non-404 error, seasons that were already available stay available instead of being treated as missing.

The net effect of this is that instead of Seerr showing the show that DOES exist on Plex as deleted (even though it's not deleted), NOW it will show as available (synced).

## How Has This Been Tested?

Added regression coverage for Plex and Jellyfin outage cases.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

### AI Disclosure

AI assistance was used while working on this PR. I reviewed the changes before submitting them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of TV season availability when media server connections fail with non-404 errors
  * Fixed season verification logic during availability sync to properly filter and process seasons

* **Tests**
  * Added regression tests for media server connection error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->