### PR TITLE
docs: add TrueNAS migration guidance

### DIFF
--- a/docs/getting-started/third-parties/truenas.mdx
+++ b/docs/getting-started/third-parties/truenas.mdx
@@ -15,3 +15,12 @@ This method is not recommended for most users. It is intended for advanced users
 ## Installation
 
 Go to the 'Apps' menu, click the 'Discover Apps' button in the top right, search for 'Seerr' in the search bar, and install the app.
+
+## Migrating from Jellyseerr or Overseerr
+
+Seerr automatically migrates existing Jellyseerr or Overseerr data on first startup. Stop the existing app before installing Seerr, then choose the migration path that matches how your existing app stores data:
+
+- **Host Path:** install Seerr using the same Host Path storage that was used by Jellyseerr or Overseerr, then start Seerr and confirm the migration completed before deleting the old app.
+- **ixVolume:** create a dataset for Seerr, copy the existing ixVolume app data into that dataset, then install Seerr using the new Host Path storage and confirm the migration completed before deleting the old app.
+
+For detailed community-maintained walkthroughs, see the TrueNAS SCALE guides for [Host Path setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916418872) and [ixVolume setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916700870).

--- a/docs/getting-started/third-parties/truenas.mdx
+++ b/docs/getting-started/third-parties/truenas.mdx
@@ -15,12 +15,3 @@ This method is not recommended for most users. It is intended for advanced users
 ## Installation
 
 Go to the 'Apps' menu, click the 'Discover Apps' button in the top right, search for 'Seerr' in the search bar, and install the app.
-
-## Migrating from Jellyseerr or Overseerr
-
-Seerr automatically migrates existing Jellyseerr or Overseerr data on first startup. Stop the existing app before installing Seerr, then choose the migration path that matches how your existing app stores data:
-
-- **Host Path:** install Seerr using the same Host Path storage that was used by Jellyseerr or Overseerr, then start Seerr and confirm the migration completed before deleting the old app.
-- **ixVolume:** create a dataset for Seerr, copy the existing ixVolume app data into that dataset, then install Seerr using the new Host Path storage and confirm the migration completed before deleting the old app.
-
-For detailed community-maintained walkthroughs, see the TrueNAS SCALE guides for [Host Path setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916418872) and [ixVolume setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916700870).

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -238,6 +238,8 @@ See https://aur.archlinux.org/packages/seerr
 
 Refer to [Seerr TrueNAS Documentation](/getting-started/third-parties/truenas), all of our examples have been updated to reflect the below change.
 
+For detailed community-maintained TrueNAS SCALE walkthroughs, see the [Host Path setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916418872) and [ixVolume setup](https://github.com/truenas/apps/issues/3374#issuecomment-3916700870) guides.
+
 <Tabs groupId="truenas-migration" queryString>
   <TabItem value="hostpath" label="Host Path">
     **This guide describes how to migrate from Host Path storage (not ixVolume).**


### PR DESCRIPTION
## Description

Closes #2509

This adds TrueNAS migration guidance for Jellyseerr/Overseerr users directly to the TrueNAS installation page. It summarizes the Host Path and ixVolume migration paths and links to the community-maintained TrueNAS SCALE walkthroughs referenced in the issue.

Impact: documentation-only change; no application behavior changes.

## How Has This Been Tested?

- `node node_modules\prettier\bin\prettier.cjs --check docs/getting-started/third-parties/truenas.mdx` - passed
- `git diff --check` - passed

Note: `corepack pnpm install --frozen-lockfile` failed on the host Node.js version (`v24.12.0`; repo expects `^22.19.0`). Retried once with pnpm engine checking disabled; dependency installation exceeded the bounded timeout, but local Prettier was available and the changed MDX file passed formatting.

## Screenshots / Logs (if applicable)

N/A - documentation-only change.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced TrueNAS third-party installation section with references to community-maintained SCALE walkthroughs for Host Path and ixVolume configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->