### PR TITLE
fix(request-button): show visible media status on details

### DIFF
--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -35,6 +35,7 @@ const messages = defineMessages('components.RequestButton', {
     'Approve {requestCount, plural, one {4K Request} other {{requestCount} 4K Requests}}',
   decline4krequests:
     'Decline {requestCount, plural, one {4K Request} other {{requestCount} 4K Requests}}',
+  standardstatus: 'Standard: {status}',
 });
 
 interface ButtonOption {
@@ -360,6 +361,59 @@ const RequestButton = ({
     });
   }
 
+  const has4kRequestAction = buttons.some((button) =>
+    ['request4k', 'request-more-4k'].includes(button.id)
+  );
+
+  const visibleStatusLabel = (() => {
+    if (!media) {
+      return undefined;
+    }
+
+    switch (media.status) {
+      case MediaStatus.PENDING:
+        return intl.formatMessage(globalMessages.pending);
+      case MediaStatus.PROCESSING:
+        return intl.formatMessage(globalMessages.requested);
+      case MediaStatus.PARTIALLY_AVAILABLE:
+        return intl.formatMessage(globalMessages.partiallyavailable);
+      case MediaStatus.AVAILABLE:
+        return intl.formatMessage(globalMessages.available);
+      default:
+        return undefined;
+    }
+  })();
+
+  const visibleStatusClassName = (() => {
+    switch (media?.status) {
+      case MediaStatus.PENDING:
+        return 'border-yellow-500/80 bg-yellow-500/20 text-yellow-100';
+      case MediaStatus.PROCESSING:
+        return 'border-indigo-500/80 bg-indigo-500/20 text-indigo-100';
+      case MediaStatus.PARTIALLY_AVAILABLE:
+      case MediaStatus.AVAILABLE:
+        return 'border-green-500/80 bg-green-500/20 text-green-100';
+      default:
+        return '';
+    }
+  })();
+
+  const visibleStatusPill =
+    has4kRequestAction && visibleStatusLabel ? (
+      <div
+        role="status"
+        aria-live="polite"
+        className={`ml-2 inline-flex min-h-[38px] items-center rounded-md border px-3 py-2 text-sm font-medium ${visibleStatusClassName}`}
+      >
+        <CheckIcon className="mr-2 h-5 w-5" />
+        <span>
+          {intl.formatMessage(messages.standardstatus, {
+            status: visibleStatusLabel,
+          })}
+        </span>
+      </div>
+    ) : null;
+
   const [buttonOne, ...others] = buttons;
 
   if (!buttonOne) {
@@ -391,6 +445,7 @@ const RequestButton = ({
         }}
         onCancel={() => setShowRequest4kModal(false)}
       />
+      {visibleStatusPill}
       <ButtonWithDropdown
         text={
           <>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -493,6 +493,7 @@
   "components.RequestButton.declinerequests": "Decline {requestCount, plural, one {Request} other {{requestCount} Requests}}",
   "components.RequestButton.requestmore": "Request More",
   "components.RequestButton.requestmore4k": "Request More in 4K",
+  "components.RequestButton.standardstatus": "Standard: {status}",
   "components.RequestButton.viewrequest": "View Request",
   "components.RequestButton.viewrequest4k": "View 4K Request",
   "components.RequestCard.approverequest": "Approve Request",


### PR DESCRIPTION
## Description

Makes the media status more visible on movie and series detail pages.

- Fixes #2993

## How Has This Been Tested?

- Ran eslint, prettier check, client typecheck, build, full lint, and `git diff --check`
- Manually checked a requested/partially available series detail page shows the new visible status pill
- Manually checked an unrequested movie detail page still shows the normal request button without the extra status pill

## Screenshots / Logs (if applicable)

<img width="472" height="65" alt="statuss" src="https://github.com/user-attachments/assets/02e5fd65-c422-405e-b056-53ef383c4a91" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request buttons now display a status pill indicating current media status
  * Status wording adapts when higher-quality request options (e.g., 4K) are available
  * Status indicator can appear even when no primary action button is shown

* **Internationalization**
  * Added localized label template for the status pill to improve translations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->