### PR TITLE
feat(discover): add detail previous and next navigation

### DIFF
--- a/src/components/Common/ListView/index.tsx
+++ b/src/components/Common/ListView/index.tsx
@@ -4,6 +4,7 @@ import TmdbTitleCard from '@app/components/TitleCard/TmdbTitleCard';
 import { Permission, useUser } from '@app/hooks/useUser';
 import useVerticalScroll from '@app/hooks/useVerticalScroll';
 import globalMessages from '@app/i18n/globalMessages';
+import { storeDiscoverNavigationContext } from '@app/utils/discoverNavigation';
 import { MediaStatus } from '@server/constants/media';
 import type { WatchlistItem } from '@server/interfaces/api/discoverInterfaces';
 import type {
@@ -42,6 +43,31 @@ const ListView = ({
     { type: 'or' }
   );
 
+  const visibleItems = items?.filter((title) => {
+    if (!blocklistVisibility)
+      return (
+        (title as TvResult | MovieResult).mediaInfo?.status !==
+        MediaStatus.BLOCKLISTED
+      );
+    return title;
+  });
+
+  const navigationItems =
+    visibleItems
+      ?.filter((title): title is MovieResult | TvResult =>
+        ['movie', 'tv'].includes(title.mediaType)
+      )
+      .map((title) => ({
+        id: title.id,
+        mediaType: title.mediaType,
+      })) ?? [];
+
+  const plexNavigationItems =
+    plexItems?.map((title) => ({
+      id: title.tmdbId,
+      mediaType: title.mediaType,
+    })) ?? [];
+
   return (
     <>
       {isEmpty && (
@@ -60,93 +86,98 @@ const ListView = ({
                 isAddedToWatchlist={true}
                 canExpand
                 mutateParent={mutateParent}
+                onOpen={() =>
+                  storeDiscoverNavigationContext(plexNavigationItems, {
+                    id: title.tmdbId,
+                    mediaType: title.mediaType,
+                  })
+                }
               />
             </li>
           );
         })}
-        {items
-          ?.filter((title) => {
-            if (!blocklistVisibility)
-              return (
-                (title as TvResult | MovieResult).mediaInfo?.status !==
-                MediaStatus.BLOCKLISTED
+        {visibleItems?.map((title, index) => {
+          let titleCard: React.ReactNode;
+
+          switch (title.mediaType) {
+            case 'movie':
+              titleCard = (
+                <TitleCard
+                  key={title.id}
+                  id={title.id}
+                  isAddedToWatchlist={title.mediaInfo?.watchlists?.length ?? 0}
+                  image={title.posterPath}
+                  status={title.mediaInfo?.status}
+                  summary={title.overview}
+                  title={title.title}
+                  userScore={title.voteAverage}
+                  year={title.releaseDate}
+                  mediaType={title.mediaType}
+                  inProgress={
+                    (title.mediaInfo?.downloadStatus ?? []).length > 0
+                  }
+                  canExpand
+                  onOpen={() =>
+                    storeDiscoverNavigationContext(navigationItems, {
+                      id: title.id,
+                      mediaType: title.mediaType,
+                    })
+                  }
+                />
               );
-            return title;
-          })
-          .map((title, index) => {
-            let titleCard: React.ReactNode;
+              break;
+            case 'tv':
+              titleCard = (
+                <TitleCard
+                  key={title.id}
+                  id={title.id}
+                  isAddedToWatchlist={title.mediaInfo?.watchlists?.length ?? 0}
+                  image={title.posterPath}
+                  status={title.mediaInfo?.status}
+                  summary={title.overview}
+                  title={title.name}
+                  userScore={title.voteAverage}
+                  year={title.firstAirDate}
+                  mediaType={title.mediaType}
+                  inProgress={
+                    (title.mediaInfo?.downloadStatus ?? []).length > 0
+                  }
+                  canExpand
+                  onOpen={() =>
+                    storeDiscoverNavigationContext(navigationItems, {
+                      id: title.id,
+                      mediaType: title.mediaType,
+                    })
+                  }
+                />
+              );
+              break;
+            case 'collection':
+              titleCard = (
+                <TitleCard
+                  id={title.id}
+                  image={title.posterPath}
+                  summary={title.overview}
+                  title={title.title}
+                  mediaType={title.mediaType}
+                  canExpand
+                />
+              );
+              break;
+            case 'person':
+              titleCard = (
+                <PersonCard
+                  personId={title.id}
+                  name={title.name}
+                  profilePath={title.profilePath}
+                  canExpand
+                />
+              );
+              break;
+          }
 
-            switch (title.mediaType) {
-              case 'movie':
-                titleCard = (
-                  <TitleCard
-                    key={title.id}
-                    id={title.id}
-                    isAddedToWatchlist={
-                      title.mediaInfo?.watchlists?.length ?? 0
-                    }
-                    image={title.posterPath}
-                    status={title.mediaInfo?.status}
-                    summary={title.overview}
-                    title={title.title}
-                    userScore={title.voteAverage}
-                    year={title.releaseDate}
-                    mediaType={title.mediaType}
-                    inProgress={
-                      (title.mediaInfo?.downloadStatus ?? []).length > 0
-                    }
-                    canExpand
-                  />
-                );
-                break;
-              case 'tv':
-                titleCard = (
-                  <TitleCard
-                    key={title.id}
-                    id={title.id}
-                    isAddedToWatchlist={
-                      title.mediaInfo?.watchlists?.length ?? 0
-                    }
-                    image={title.posterPath}
-                    status={title.mediaInfo?.status}
-                    summary={title.overview}
-                    title={title.name}
-                    userScore={title.voteAverage}
-                    year={title.firstAirDate}
-                    mediaType={title.mediaType}
-                    inProgress={
-                      (title.mediaInfo?.downloadStatus ?? []).length > 0
-                    }
-                    canExpand
-                  />
-                );
-                break;
-              case 'collection':
-                titleCard = (
-                  <TitleCard
-                    id={title.id}
-                    image={title.posterPath}
-                    summary={title.overview}
-                    title={title.title}
-                    mediaType={title.mediaType}
-                    canExpand
-                  />
-                );
-                break;
-              case 'person':
-                titleCard = (
-                  <PersonCard
-                    personId={title.id}
-                    name={title.name}
-                    profilePath={title.profilePath}
-                    canExpand
-                  />
-                );
-                break;
-            }
-
-            return <li key={`${title.id}-${index}`}>{titleCard}</li>;
-          })}
+          return <li key={`${title.id}-${index}`}>{titleCard}</li>;
+        })}
         {isLoading &&
           !isReachingEnd &&
           [...Array(20)].map((_item, i) => (

--- a/src/components/Discover/DiscoverNavigationButtons/index.tsx
+++ b/src/components/Discover/DiscoverNavigationButtons/index.tsx
@@ -1,0 +1,74 @@
+import Button from '@app/components/Common/Button';
+import Tooltip from '@app/components/Common/Tooltip';
+import globalMessages from '@app/i18n/globalMessages';
+import {
+  getDiscoverNavigationPath,
+  getDiscoverNavigationState,
+  markDiscoverNavigationPending,
+  type DiscoverNavigationItem,
+  type DiscoverNavigationState,
+} from '@app/utils/discoverNavigation';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+
+interface DiscoverNavigationButtonsProps {
+  currentItem: DiscoverNavigationItem;
+}
+
+const DiscoverNavigationButtons = ({
+  currentItem,
+}: DiscoverNavigationButtonsProps) => {
+  const router = useRouter();
+  const intl = useIntl();
+  const [navigationState, setNavigationState] =
+    useState<DiscoverNavigationState | null>(null);
+
+  useEffect(() => {
+    setNavigationState(getDiscoverNavigationState(currentItem));
+  }, [currentItem]);
+
+  if (!navigationState?.previous && !navigationState?.next) {
+    return null;
+  }
+
+  const navigateToItem = (item: DiscoverNavigationItem) => {
+    markDiscoverNavigationPending(item);
+    router.push(getDiscoverNavigationPath(item));
+  };
+
+  const previousItem = navigationState.previous;
+  const nextItem = navigationState.next;
+
+  return (
+    <>
+      {previousItem ? (
+        <Tooltip content={intl.formatMessage(globalMessages.previous)}>
+          <Button
+            buttonType="ghost"
+            className="z-40 mr-2"
+            buttonSize="md"
+            onClick={() => navigateToItem(previousItem)}
+          >
+            <ChevronLeftIcon />
+          </Button>
+        </Tooltip>
+      ) : null}
+      {nextItem ? (
+        <Tooltip content={intl.formatMessage(globalMessages.next)}>
+          <Button
+            buttonType="ghost"
+            className="z-40 mr-2"
+            buttonSize="md"
+            onClick={() => navigateToItem(nextItem)}
+          >
+            <ChevronRightIcon />
+          </Button>
+        </Tooltip>
+      ) : null}
+    </>
+  );
+};
+
+export default DiscoverNavigationButtons;

--- a/src/components/MovieDetails/index.tsx
+++ b/src/components/MovieDetails/index.tsx
@@ -14,6 +14,7 @@ import type { PlayButtonLink } from '@app/components/Common/PlayButton';
 import PlayButton from '@app/components/Common/PlayButton';
 import Tag from '@app/components/Common/Tag';
 import Tooltip from '@app/components/Common/Tooltip';
+import DiscoverNavigationButtons from '@app/components/Discover/DiscoverNavigationButtons';
 import ExternalLinkBlock from '@app/components/ExternalLinkBlock';
 import IssueModal from '@app/components/IssueModal';
 import ManageSlideOver from '@app/components/ManageSlideOver';
@@ -562,6 +563,9 @@ const MovieDetails = ({ movie }: MovieDetailsProps) => {
           </span>
         </div>
         <div className="media-actions">
+          <DiscoverNavigationButtons
+            currentItem={{ id: data.id, mediaType: 'movie' }}
+          />
           {showHideButton &&
             data?.mediaInfo?.status !== MediaStatus.PROCESSING &&
             data?.mediaInfo?.status !== MediaStatus.AVAILABLE &&

--- a/src/components/TitleCard/TmdbTitleCard.tsx
+++ b/src/components/TitleCard/TmdbTitleCard.tsx
@@ -13,6 +13,7 @@ export interface TmdbTitleCardProps {
   canExpand?: boolean;
   isAddedToWatchlist?: boolean;
   mutateParent?: () => void;
+  onOpen?: () => void;
 }
 
 const isMovie = (movie: MovieDetails | TvDetails): movie is MovieDetails => {
@@ -27,6 +28,7 @@ const TmdbTitleCard = ({
   canExpand,
   isAddedToWatchlist = false,
   mutateParent,
+  onOpen,
 }: TmdbTitleCardProps) => {
   const { hasPermission } = useUser();
 
@@ -74,6 +76,7 @@ const TmdbTitleCard = ({
       mediaType={'movie'}
       canExpand={canExpand}
       mutateParent={mutateParent}
+      onOpen={onOpen}
     />
   ) : (
     <TitleCard
@@ -91,6 +94,7 @@ const TmdbTitleCard = ({
       mediaType={'tv'}
       canExpand={canExpand}
       mutateParent={mutateParent}
+      onOpen={onOpen}
     />
   );
 };

--- a/src/components/TitleCard/index.tsx
+++ b/src/components/TitleCard/index.tsx
@@ -43,6 +43,7 @@ interface TitleCardProps {
   inProgress?: boolean;
   isAddedToWatchlist?: number | boolean;
   mutateParent?: () => void;
+  onOpen?: () => void;
 }
 
 const messages = defineMessages('components.TitleCard', {
@@ -67,6 +68,7 @@ const TitleCard = ({
   inProgress = false,
   canExpand = false,
   mutateParent,
+  onOpen,
 }: TitleCardProps) => {
   const isTouch = useIsTouch();
   const intl = useIntl();
@@ -502,6 +504,7 @@ const TitleCard = ({
                       ? `/collection/${id}`
                       : `/tv/${id}`
                 }
+                onClick={onOpen}
                 className="absolute inset-0 h-full w-full cursor-pointer overflow-hidden text-left"
                 style={{
                   background:

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -15,6 +15,7 @@ import PlayButton from '@app/components/Common/PlayButton';
 import StatusBadgeMini from '@app/components/Common/StatusBadgeMini';
 import Tag from '@app/components/Common/Tag';
 import Tooltip from '@app/components/Common/Tooltip';
+import DiscoverNavigationButtons from '@app/components/Discover/DiscoverNavigationButtons';
 import ExternalLinkBlock from '@app/components/ExternalLinkBlock';
 import IssueModal from '@app/components/IssueModal';
 import ManageSlideOver from '@app/components/ManageSlideOver';
@@ -604,6 +605,9 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
           </span>
         </div>
         <div className="media-actions">
+          <DiscoverNavigationButtons
+            currentItem={{ id: data.id, mediaType: 'tv' }}
+          />
           {showHideButton &&
             data?.mediaInfo?.status !== MediaStatus.PROCESSING &&
             data?.mediaInfo?.status !== MediaStatus.AVAILABLE &&

--- a/src/utils/discoverNavigation.ts
+++ b/src/utils/discoverNavigation.ts
@@ -26,6 +26,33 @@ const PENDING_TTL_MS = 5 * 60 * 1000;
 
 const isBrowser = (): boolean => typeof window !== 'undefined';
 
+const getSessionStorage = (): Storage | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+const removeDiscoverNavigationStorage = (): void => {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.removeItem(CONTEXT_KEY);
+    storage.removeItem(PENDING_KEY);
+  } catch {
+    // Ignore storage cleanup failures. Navigation state is optional.
+  }
+};
+
 export const getDiscoverNavigationPath = (
   item: DiscoverNavigationItem
 ): string => `/${item.mediaType}/${item.id}`;
@@ -34,7 +61,9 @@ export const storeDiscoverNavigationContext = (
   items: DiscoverNavigationItem[],
   currentItem: DiscoverNavigationItem
 ): void => {
-  if (!isBrowser()) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
     return;
   }
 
@@ -51,14 +80,22 @@ export const storeDiscoverNavigationContext = (
     items: uniqueItems,
   };
 
-  window.sessionStorage.setItem(CONTEXT_KEY, JSON.stringify(context));
+  try {
+    storage.setItem(CONTEXT_KEY, JSON.stringify(context));
+  } catch {
+    removeDiscoverNavigationStorage();
+    return;
+  }
+
   markDiscoverNavigationPending(currentItem);
 };
 
 export const markDiscoverNavigationPending = (
   item: DiscoverNavigationItem
 ): void => {
-  if (!isBrowser()) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
     return;
   }
 
@@ -67,19 +104,25 @@ export const markDiscoverNavigationPending = (
     expiresAt: Date.now() + PENDING_TTL_MS,
   };
 
-  window.sessionStorage.setItem(PENDING_KEY, JSON.stringify(pending));
+  try {
+    storage.setItem(PENDING_KEY, JSON.stringify(pending));
+  } catch {
+    removeDiscoverNavigationStorage();
+  }
 };
 
 export const getDiscoverNavigationState = (
   currentItem: DiscoverNavigationItem
 ): DiscoverNavigationState | null => {
-  if (!isBrowser()) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
     return null;
   }
 
   try {
     const pending = JSON.parse(
-      window.sessionStorage.getItem(PENDING_KEY) ?? 'null'
+      storage.getItem(PENDING_KEY) ?? 'null'
     ) as DiscoverNavigationPending | null;
 
     if (
@@ -91,7 +134,7 @@ export const getDiscoverNavigationState = (
     }
 
     const context = JSON.parse(
-      window.sessionStorage.getItem(CONTEXT_KEY) ?? 'null'
+      storage.getItem(CONTEXT_KEY) ?? 'null'
     ) as DiscoverNavigationContext | null;
 
     if (!context?.items.length) {
@@ -112,8 +155,7 @@ export const getDiscoverNavigationState = (
       next: context.items[currentIndex + 1],
     };
   } catch {
-    window.sessionStorage.removeItem(CONTEXT_KEY);
-    window.sessionStorage.removeItem(PENDING_KEY);
+    removeDiscoverNavigationStorage();
     return null;
   }
 };

--- a/src/utils/discoverNavigation.ts
+++ b/src/utils/discoverNavigation.ts
@@ -1,0 +1,119 @@
+export type DiscoverNavigationMediaType = 'movie' | 'tv';
+
+export interface DiscoverNavigationItem {
+  id: number;
+  mediaType: DiscoverNavigationMediaType;
+}
+
+interface DiscoverNavigationContext {
+  sourceUrl: string;
+  items: DiscoverNavigationItem[];
+}
+
+interface DiscoverNavigationPending {
+  path: string;
+  expiresAt: number;
+}
+
+export interface DiscoverNavigationState {
+  previous?: DiscoverNavigationItem;
+  next?: DiscoverNavigationItem;
+}
+
+const CONTEXT_KEY = 'seerr.discoverNavigation.context';
+const PENDING_KEY = 'seerr.discoverNavigation.pending';
+const PENDING_TTL_MS = 5 * 60 * 1000;
+
+const isBrowser = (): boolean => typeof window !== 'undefined';
+
+export const getDiscoverNavigationPath = (
+  item: DiscoverNavigationItem
+): string => `/${item.mediaType}/${item.id}`;
+
+export const storeDiscoverNavigationContext = (
+  items: DiscoverNavigationItem[],
+  currentItem: DiscoverNavigationItem
+): void => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const uniqueItems = items.filter(
+    (item, index, allItems) =>
+      allItems.findIndex(
+        (candidate) =>
+          candidate.id === item.id && candidate.mediaType === item.mediaType
+      ) === index
+  );
+
+  const context: DiscoverNavigationContext = {
+    sourceUrl: `${window.location.pathname}${window.location.search}`,
+    items: uniqueItems,
+  };
+
+  window.sessionStorage.setItem(CONTEXT_KEY, JSON.stringify(context));
+  markDiscoverNavigationPending(currentItem);
+};
+
+export const markDiscoverNavigationPending = (
+  item: DiscoverNavigationItem
+): void => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  const pending: DiscoverNavigationPending = {
+    path: getDiscoverNavigationPath(item),
+    expiresAt: Date.now() + PENDING_TTL_MS,
+  };
+
+  window.sessionStorage.setItem(PENDING_KEY, JSON.stringify(pending));
+};
+
+export const getDiscoverNavigationState = (
+  currentItem: DiscoverNavigationItem
+): DiscoverNavigationState | null => {
+  if (!isBrowser()) {
+    return null;
+  }
+
+  try {
+    const pending = JSON.parse(
+      window.sessionStorage.getItem(PENDING_KEY) ?? 'null'
+    ) as DiscoverNavigationPending | null;
+
+    if (
+      !pending ||
+      pending.expiresAt < Date.now() ||
+      pending.path !== getDiscoverNavigationPath(currentItem)
+    ) {
+      return null;
+    }
+
+    const context = JSON.parse(
+      window.sessionStorage.getItem(CONTEXT_KEY) ?? 'null'
+    ) as DiscoverNavigationContext | null;
+
+    if (!context?.items.length) {
+      return null;
+    }
+
+    const currentIndex = context.items.findIndex(
+      (item) =>
+        item.id === currentItem.id && item.mediaType === currentItem.mediaType
+    );
+
+    if (currentIndex === -1) {
+      return null;
+    }
+
+    return {
+      previous: context.items[currentIndex - 1],
+      next: context.items[currentIndex + 1],
+    };
+  } catch {
+    window.sessionStorage.removeItem(CONTEXT_KEY);
+    window.sessionStorage.removeItem(PENDING_KEY);
+    return null;
+  }
+};


### PR DESCRIPTION
## Description

Adds previous and next navigation on movie and series detail pages when opened from a Discover list.

The controls use the currently loaded Discover result order, so users can browse detail pages without going back to the grid each time.

I used Codex for help and validation.

- Fixes #3015

## How Has This Been Tested?

- Ran eslint, prettier check, client typecheck, build, and `git diff --check`
- Manually checked direct movie detail URLs do not show previous/next controls
- Manually checked Discover Movies previous/next navigation follows the visible grid order
- Manually checked filtered Discover Movies previous/next navigation follows the filtered order
- Manually checked Discover Series previous/next navigation works
- Manually checked first and last loaded items only show the available navigation direction

## Screenshots / Logs (if applicable)

<img width="573" height="93" alt="discover-navigation" src="https://github.com/user-attachments/assets/0c65e9c2-5a33-44a5-99c6-e15ea82da759" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Previous" and "Next" navigation buttons on movie and TV detail pages to move through discovery results.
  * Persistent discovery navigation context so browsing order is preserved across the session for seamless back/forward navigation.

* **Bug Fixes**
  * List views now consistently hide blocklisted items when blocklist visibility is not granted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->