### PR TITLE
feat: Add parental controls and global content exclusions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:22.22.2-alpine3.23@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS base
+
+LABEL org.opencontainers.image.source="https://github.com/magicalpotato0001/seerr"
+
 ARG SOURCE_DATE_EPOCH
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "preinstall": "npx only-allow pnpm",
     "postinstall": "next telemetry disable",
     "dev": "nodemon -e ts,json,yml --watch server --watch seerr-api.yml --exec 'ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts'",
+    "wdev": "nodemon -e ts,json,yml --watch server --watch seerr-api.yml --exec \"pnpm exec ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts\"",
     "build:server": "tsc --project server/tsconfig.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && copyfiles -u 2 \"server/i18n/locale/*.json\" dist/i18n && tsc-alias -p server/tsconfig.json",
     "build:next": "next build",
     "build": "pnpm build:next && pnpm build:server",
@@ -220,6 +221,6 @@
     "enabled": false
   },
   "volta": {
-    "node": "22.19.0"
+    "node": "22.22.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -218,5 +218,8 @@
   },
   "scarfSettings": {
     "enabled": false
+  },
+  "volta": {
+    "node": "22.19.0"
   }
 }

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -152,6 +152,7 @@ class JellyfinAPI extends ExternalAPI {
       jellyfinHost,
       {},
       {
+        timeout: settings.network.apiRequestTimeout,
         headers: {
           Authorization: authHeaderVal,
           'Content-Type': 'application/json',

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -10,6 +10,10 @@ import { getRepository } from '@server/datasource';
 import OverrideRule from '@server/entity/OverrideRule';
 import type { MediaRequestBody } from '@server/interfaces/api/requestInterfaces';
 import notificationManager, { Notification } from '@server/lib/notifications';
+import {
+  ParentalControlRestrictedError,
+  isMediaAllowedByParentalControls,
+} from '@server/lib/parentalControls';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
@@ -123,6 +127,19 @@ export class MediaRequest {
       requestBody.mediaType === MediaType.MOVIE
         ? await tmdb.getMovie({ movieId: requestBody.mediaId })
         : await tmdb.getTvShow({ tvId: requestBody.mediaId });
+
+    if (
+      !(await isMediaAllowedByParentalControls({
+        user: requestUser,
+        mediaType: requestBody.mediaType,
+        media: tmdbMedia,
+        tmdb,
+      }))
+    ) {
+      throw new ParentalControlRestrictedError(
+        'This media is restricted by parental controls.'
+      );
+    }
 
     let media = await mediaRepository.findOne({
       where: {

--- a/server/entity/UserSettings.ts
+++ b/server/entity/UserSettings.ts
@@ -85,6 +85,21 @@ export class UserSettings {
   @Column({ nullable: true })
   public watchlistSyncTv?: boolean;
 
+  @Column({ default: false })
+  public parentalControlsEnabled?: boolean;
+
+  @Column({ nullable: true })
+  public maxMovieCertification?: string;
+
+  @Column({ nullable: true })
+  public maxTvCertification?: string;
+
+  @Column({ default: 'US' })
+  public parentalControlsRegion?: string;
+
+  @Column({ default: false })
+  public blockUnrated?: boolean;
+
   @Column({
     type: 'text',
     nullable: true,

--- a/server/interfaces/api/userSettingsInterfaces.ts
+++ b/server/interfaces/api/userSettingsInterfaces.ts
@@ -17,6 +17,11 @@ export interface UserSettingsGeneralResponse {
   globalTvQuotaDays?: number;
   watchlistSyncMovies?: boolean;
   watchlistSyncTv?: boolean;
+  parentalControlsEnabled?: boolean;
+  parentalControlsRegion?: string;
+  maxMovieCertification?: string;
+  maxTvCertification?: string;
+  blockUnrated?: boolean;
 }
 
 export type NotificationAgentTypes = Record<NotificationAgentKey, number>;

--- a/server/lib/parentalControls.ts
+++ b/server/lib/parentalControls.ts
@@ -1,0 +1,552 @@
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbMovieDetails,
+  TmdbMovieResult,
+  TmdbSearchMovieResponse,
+  TmdbSearchMultiResponse,
+  TmdbSearchTvResponse,
+  TmdbTvDetails,
+  TmdbTvResult,
+} from '@server/api/themoviedb/interfaces';
+import { MediaType } from '@server/constants/media';
+import type { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+
+type CertificationMediaType = MediaType.MOVIE | MediaType.TV;
+
+type FilterableMediaResult =
+  | TmdbMovieResult
+  | TmdbTvResult
+  | TmdbSearchMultiResponse['results'][number];
+
+type CertificationFilter = {
+  certificationCountry?: string;
+  certificationGte?: string;
+  certificationLte?: string;
+};
+
+type KeywordFilter = {
+  excludeKeywords?: string;
+};
+
+export class ParentalControlRestrictedError extends Error {}
+
+const isParentalControlsEnabled = (user?: User): boolean =>
+  !!user?.settings?.parentalControlsEnabled;
+
+const isUnratedCertification = (certification?: string): boolean => {
+  const normalized = certification?.trim().toLowerCase();
+
+  return (
+    !normalized ||
+    normalized === 'nr' ||
+    normalized === 'not rated' ||
+    normalized === 'unrated'
+  );
+};
+
+const getMinimumRatedCertification = async (
+  tmdb: TheMovieDb,
+  mediaType: CertificationMediaType,
+  region: string
+): Promise<string | undefined> => {
+  const data =
+    mediaType === MediaType.MOVIE
+      ? await tmdb.getMovieCertifications()
+      : await tmdb.getTvCertifications();
+
+  return data.certifications[region]
+    ?.filter((cert) => !isUnratedCertification(cert.certification))
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))[0]?.certification;
+};
+
+export const getParentalCertificationFilter = async (
+  user: User | undefined,
+  mediaType: CertificationMediaType,
+  tmdb = new TheMovieDb()
+): Promise<CertificationFilter> => {
+  if (!isParentalControlsEnabled(user)) {
+    return {};
+  }
+
+  const certificationLte =
+    mediaType === MediaType.MOVIE
+      ? user?.settings?.maxMovieCertification
+      : user?.settings?.maxTvCertification;
+  const certificationCountry =
+    certificationLte || user?.settings?.blockUnrated
+      ? (user?.settings?.parentalControlsRegion ?? 'US')
+      : undefined;
+
+  return {
+    certificationCountry,
+    certificationGte:
+      certificationCountry && user?.settings?.blockUnrated
+        ? await getMinimumRatedCertification(
+            tmdb,
+            mediaType,
+            certificationCountry
+          )
+        : undefined,
+    certificationLte,
+  };
+};
+
+const getMovieCertification = (
+  movie: TmdbMovieDetails,
+  region: string
+): string | undefined => {
+  const release = movie.release_dates.results.find(
+    (result) => result.iso_3166_1 === region
+  );
+
+  return release?.release_dates.find((date) => date.certification)
+    ?.certification;
+};
+
+const getTvCertification = (
+  show: TmdbTvDetails,
+  region: string
+): string | undefined =>
+  show.content_ratings.results.find((result) => result.iso_3166_1 === region)
+    ?.rating;
+
+const getCertificationOrder = async (
+  tmdb: TheMovieDb,
+  mediaType: CertificationMediaType,
+  region: string,
+  certification: string
+): Promise<number | undefined> => {
+  const data =
+    mediaType === MediaType.MOVIE
+      ? await tmdb.getMovieCertifications()
+      : await tmdb.getTvCertifications();
+
+  return data.certifications[region]?.find(
+    (cert) => cert.certification === certification
+  )?.order;
+};
+
+export const isMediaAllowedByParentalControls = async ({
+  user,
+  mediaType,
+  media,
+  tmdb = new TheMovieDb(),
+}: {
+  user?: User;
+  mediaType: CertificationMediaType;
+  media: TmdbMovieDetails | TmdbTvDetails;
+  tmdb?: TheMovieDb;
+}): Promise<boolean> => {
+  if (!isParentalControlsEnabled(user)) {
+    return true;
+  }
+
+  const region = user?.settings?.parentalControlsRegion ?? 'US';
+  const maxCertification =
+    mediaType === MediaType.MOVIE
+      ? user?.settings?.maxMovieCertification
+      : user?.settings?.maxTvCertification;
+
+  if (mediaType === MediaType.MOVIE && (media as TmdbMovieDetails).adult) {
+    return false;
+  }
+
+  const certification =
+    mediaType === MediaType.MOVIE
+      ? getMovieCertification(media as TmdbMovieDetails, region)
+      : getTvCertification(media as TmdbTvDetails, region);
+
+  if (isUnratedCertification(certification)) {
+    return !user?.settings?.blockUnrated;
+  }
+
+  if (!maxCertification) {
+    return true;
+  }
+
+  const ratedCertification = certification as string;
+
+  const [certificationOrder, maxCertificationOrder] = await Promise.all([
+    getCertificationOrder(tmdb, mediaType, region, ratedCertification),
+    getCertificationOrder(tmdb, mediaType, region, maxCertification),
+  ]);
+
+  if (certificationOrder === undefined || maxCertificationOrder === undefined) {
+    return true;
+  }
+
+  return certificationOrder <= maxCertificationOrder;
+};
+
+const getResultMediaType = (
+  result: FilterableMediaResult,
+  fallbackMediaType?: CertificationMediaType
+): CertificationMediaType | undefined => {
+  if ('media_type' in result) {
+    if (result.media_type === MediaType.MOVIE) {
+      return MediaType.MOVIE;
+    }
+
+    if (result.media_type === MediaType.TV) {
+      return MediaType.TV;
+    }
+  }
+
+  return fallbackMediaType;
+};
+
+export const filterResultsByParentalControls = async <
+  T extends FilterableMediaResult,
+>({
+  user,
+  results,
+  tmdb = new TheMovieDb(),
+  mediaType,
+  language,
+}: {
+  user?: User;
+  results: T[];
+  tmdb?: TheMovieDb;
+  mediaType?: CertificationMediaType;
+  language?: string;
+}): Promise<T[]> => {
+  if (!isParentalControlsEnabled(user)) {
+    return results;
+  }
+
+  const allowedResults: (T | null)[] = await Promise.all(
+    results.map(async (result) => {
+      const resultMediaType = getResultMediaType(result, mediaType);
+
+      if (!resultMediaType) {
+        return result;
+      }
+
+      const details =
+        resultMediaType === MediaType.MOVIE
+          ? await tmdb.getMovie({ movieId: result.id, language })
+          : await tmdb.getTvShow({ tvId: result.id, language });
+
+      return (await isMediaAllowedByParentalControls({
+        user,
+        mediaType: resultMediaType,
+        media: details,
+        tmdb,
+      }))
+        ? (result as T)
+        : null;
+    })
+  );
+
+  return allowedResults.filter((result): result is T => !!result);
+};
+
+export const filterMovieResponseByParentalControls = async (
+  response: TmdbSearchMovieResponse,
+  user?: User,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchMovieResponse> => ({
+  ...response,
+  results: await filterResultsByParentalControls({
+    user,
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.MOVIE,
+    language,
+  }),
+});
+
+export const filterTvResponseByParentalControls = async (
+  response: TmdbSearchTvResponse,
+  user?: User,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchTvResponse> => ({
+  ...response,
+  results: await filterResultsByParentalControls({
+    user,
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.TV,
+    language,
+  }),
+});
+
+const getGlobalExcludedCertifications = (
+  mediaType: CertificationMediaType
+): string[] => {
+  const settings = getSettings();
+  const exclusions =
+    mediaType === MediaType.MOVIE
+      ? settings.main.excludedMovieCertifications
+      : settings.main.excludedTvCertifications;
+
+  return exclusions
+    ? exclusions
+        .split('|')
+        .map((certification) => certification.trim())
+        .filter(Boolean)
+    : [];
+};
+
+const isGloballyExcludedCertification = (
+  certification: string | undefined,
+  exclusions: string[]
+): boolean => {
+  if (isUnratedCertification(certification)) {
+    return exclusions.some(isUnratedCertification);
+  }
+
+  return exclusions.includes(certification as string);
+};
+
+export const getGlobalCertificationExclusionFilter = async (
+  mediaType: CertificationMediaType,
+  tmdb = new TheMovieDb()
+): Promise<CertificationFilter> => {
+  const settings = getSettings();
+  const exclusions = getGlobalExcludedCertifications(mediaType);
+  const certificationCountry =
+    settings.main.excludedCertificationRegion || 'US';
+
+  return {
+    certificationCountry: exclusions.length ? certificationCountry : undefined,
+    certificationGte: exclusions.some(isUnratedCertification)
+      ? await getMinimumRatedCertification(
+          tmdb,
+          mediaType,
+          certificationCountry
+        )
+      : undefined,
+  };
+};
+
+export const isMediaAllowedByGlobalRatingExclusions = ({
+  mediaType,
+  media,
+}: {
+  mediaType: CertificationMediaType;
+  media: TmdbMovieDetails | TmdbTvDetails;
+}): boolean => {
+  const settings = getSettings();
+  const region = settings.main.excludedCertificationRegion || 'US';
+  const exclusions = getGlobalExcludedCertifications(mediaType);
+
+  if (!exclusions.length) {
+    return true;
+  }
+
+  const certification =
+    mediaType === MediaType.MOVIE
+      ? getMovieCertification(media as TmdbMovieDetails, region)
+      : getTvCertification(media as TmdbTvDetails, region);
+
+  return !isGloballyExcludedCertification(certification, exclusions);
+};
+
+export const filterResultsByGlobalRatingExclusions = async <
+  T extends FilterableMediaResult,
+>({
+  results,
+  tmdb = new TheMovieDb(),
+  mediaType,
+  language,
+}: {
+  results: T[];
+  tmdb?: TheMovieDb;
+  mediaType?: CertificationMediaType;
+  language?: string;
+}): Promise<T[]> => {
+  const settings = getSettings();
+
+  if (
+    !settings.main.excludedMovieCertifications &&
+    !settings.main.excludedTvCertifications
+  ) {
+    return results;
+  }
+
+  const allowedResults: (T | null)[] = await Promise.all(
+    results.map(async (result) => {
+      const resultMediaType = getResultMediaType(result, mediaType);
+
+      if (!resultMediaType) {
+        return result;
+      }
+
+      const details =
+        resultMediaType === MediaType.MOVIE
+          ? await tmdb.getMovie({ movieId: result.id, language })
+          : await tmdb.getTvShow({ tvId: result.id, language });
+
+      return isMediaAllowedByGlobalRatingExclusions({
+        mediaType: resultMediaType,
+        media: details,
+      })
+        ? (result as T)
+        : null;
+    })
+  );
+
+  return allowedResults.filter((result): result is T => !!result);
+};
+
+export const filterMovieResponseByGlobalRatingExclusions = async (
+  response: TmdbSearchMovieResponse,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchMovieResponse> => ({
+  ...response,
+  results: await filterResultsByGlobalRatingExclusions({
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.MOVIE,
+    language,
+  }),
+});
+
+export const filterTvResponseByGlobalRatingExclusions = async (
+  response: TmdbSearchTvResponse,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchTvResponse> => ({
+  ...response,
+  results: await filterResultsByGlobalRatingExclusions({
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.TV,
+    language,
+  }),
+});
+
+const getGlobalExcludedKeywordIds = (
+  mediaType: CertificationMediaType
+): number[] => {
+  const settings = getSettings();
+  const tags =
+    mediaType === MediaType.MOVIE
+      ? settings.main.excludedMovieTags
+      : settings.main.excludedTvTags;
+
+  return tags
+    ? tags
+        .split(',')
+        .map((tag) => Number(tag))
+        .filter((tag) => !Number.isNaN(tag))
+    : [];
+};
+
+export const getGlobalKeywordExclusionFilter = (
+  mediaType: CertificationMediaType,
+  existingExcludeKeywords?: string
+): KeywordFilter => {
+  const excludedKeywordIds = getGlobalExcludedKeywordIds(mediaType);
+  const keywords = [
+    ...(existingExcludeKeywords
+      ? existingExcludeKeywords.split(',').map((keyword) => Number(keyword))
+      : []),
+    ...excludedKeywordIds,
+  ].filter((keyword) => !Number.isNaN(keyword));
+
+  return {
+    excludeKeywords: keywords.length
+      ? [...new Set(keywords)].join(',')
+      : undefined,
+  };
+};
+
+export const isMediaAllowedByGlobalTagExclusions = ({
+  mediaType,
+  media,
+}: {
+  mediaType: CertificationMediaType;
+  media: TmdbMovieDetails | TmdbTvDetails;
+}): boolean => {
+  const excludedKeywordIds = getGlobalExcludedKeywordIds(mediaType);
+
+  if (!excludedKeywordIds.length) {
+    return true;
+  }
+
+  const keywords =
+    mediaType === MediaType.MOVIE
+      ? (media as TmdbMovieDetails).keywords.keywords
+      : (media as TmdbTvDetails).keywords.results;
+
+  return !keywords.some((keyword) => excludedKeywordIds.includes(keyword.id));
+};
+
+export const filterResultsByGlobalTagExclusions = async <
+  T extends FilterableMediaResult,
+>({
+  results,
+  tmdb = new TheMovieDb(),
+  mediaType,
+  language,
+}: {
+  results: T[];
+  tmdb?: TheMovieDb;
+  mediaType?: CertificationMediaType;
+  language?: string;
+}): Promise<T[]> => {
+  if (
+    !getGlobalExcludedKeywordIds(MediaType.MOVIE).length &&
+    !getGlobalExcludedKeywordIds(MediaType.TV).length
+  ) {
+    return results;
+  }
+
+  const allowedResults: (T | null)[] = await Promise.all(
+    results.map(async (result) => {
+      const resultMediaType = getResultMediaType(result, mediaType);
+
+      if (!resultMediaType) {
+        return result;
+      }
+
+      const details =
+        resultMediaType === MediaType.MOVIE
+          ? await tmdb.getMovie({ movieId: result.id, language })
+          : await tmdb.getTvShow({ tvId: result.id, language });
+
+      return isMediaAllowedByGlobalTagExclusions({
+        mediaType: resultMediaType,
+        media: details,
+      })
+        ? (result as T)
+        : null;
+    })
+  );
+
+  return allowedResults.filter((result): result is T => !!result);
+};
+
+export const filterMovieResponseByGlobalTagExclusions = async (
+  response: TmdbSearchMovieResponse,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchMovieResponse> => ({
+  ...response,
+  results: await filterResultsByGlobalTagExclusions({
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.MOVIE,
+    language,
+  }),
+});
+
+export const filterTvResponseByGlobalTagExclusions = async (
+  response: TmdbSearchTvResponse,
+  tmdb = new TheMovieDb(),
+  language?: string
+): Promise<TmdbSearchTvResponse> => ({
+  ...response,
+  results: await filterResultsByGlobalTagExclusions({
+    results: response.results,
+    tmdb,
+    mediaType: MediaType.TV,
+    language,
+  }),
+});

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -147,6 +147,11 @@ export interface MainSettings {
   discoverRegion: string;
   streamingRegion: string;
   originalLanguage: string;
+  excludedMovieCertifications: string;
+  excludedTvCertifications: string;
+  excludedCertificationRegion: string;
+  excludedMovieTags: string;
+  excludedTvTags: string;
   blocklistRegion: string;
   blocklistLanguage: string;
   blocklistedTags: string;
@@ -419,6 +424,11 @@ class Settings {
         discoverRegion: '',
         streamingRegion: '',
         originalLanguage: '',
+        excludedMovieCertifications: 'NR',
+        excludedTvCertifications: 'NR',
+        excludedCertificationRegion: 'US',
+        excludedMovieTags: '',
+        excludedTvTags: '',
         blocklistRegion: '',
         blocklistLanguage: '',
         blocklistedTags: '',

--- a/server/migration/postgres/1780776000000-AddParentalControlsToUserSettings.ts
+++ b/server/migration/postgres/1780776000000-AddParentalControlsToUserSettings.ts
@@ -1,0 +1,41 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddParentalControlsToUserSettings1780776000000 implements MigrationInterface {
+  name = 'AddParentalControlsToUserSettings1780776000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "parentalControlsEnabled" boolean NOT NULL DEFAULT false`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "maxMovieCertification" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "maxTvCertification" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "parentalControlsRegion" character varying NOT NULL DEFAULT 'US'`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "blockUnrated" boolean NOT NULL DEFAULT false`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "blockUnrated"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "parentalControlsRegion"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "maxTvCertification"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "maxMovieCertification"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" DROP COLUMN "parentalControlsEnabled"`
+    );
+  }
+}

--- a/server/migration/sqlite/1780776000000-AddParentalControlsToUserSettings.ts
+++ b/server/migration/sqlite/1780776000000-AddParentalControlsToUserSettings.ts
@@ -1,0 +1,36 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddParentalControlsToUserSettings1780776000000 implements MigrationInterface {
+  name = 'AddParentalControlsToUserSettings1780776000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "parentalControlsEnabled" boolean NOT NULL DEFAULT (0)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "maxMovieCertification" varchar`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "maxTvCertification" varchar`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "parentalControlsRegion" varchar NOT NULL DEFAULT ('US')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_settings" ADD "blockUnrated" boolean NOT NULL DEFAULT (0)`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_settings" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "locale" varchar NOT NULL DEFAULT (''), "discoverRegion" varchar, "streamingRegion" varchar, "originalLanguage" varchar, "pgpKey" varchar, "discordIds" text, "pushbulletAccessToken" varchar, "pushoverApplicationToken" varchar, "pushoverUserKey" varchar, "pushoverSound" varchar, "telegramChatId" varchar, "telegramSendSilently" boolean, "watchlistSyncMovies" boolean, "watchlistSyncTv" boolean, "notificationTypes" text, "userId" integer, "telegramMessageThreadId" varchar, CONSTRAINT "REL_986a2b6d3c05eb4091bb8066f7" UNIQUE ("userId"), CONSTRAINT "FK_986a2b6d3c05eb4091bb8066f78" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_settings"("id", "locale", "discoverRegion", "streamingRegion", "originalLanguage", "pgpKey", "discordIds", "pushbulletAccessToken", "pushoverApplicationToken", "pushoverUserKey", "pushoverSound", "telegramChatId", "telegramSendSilently", "watchlistSyncMovies", "watchlistSyncTv", "notificationTypes", "userId", "telegramMessageThreadId") SELECT "id", "locale", "discoverRegion", "streamingRegion", "originalLanguage", "pgpKey", "discordIds", "pushbulletAccessToken", "pushoverApplicationToken", "pushoverUserKey", "pushoverSound", "telegramChatId", "telegramSendSilently", "watchlistSyncMovies", "watchlistSyncTv", "notificationTypes", "userId", "telegramMessageThreadId" FROM "user_settings"`
+    );
+    await queryRunner.query(`DROP TABLE "user_settings"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_settings" RENAME TO "user_settings"`
+    );
+  }
+}

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -11,6 +11,23 @@ import type {
   GenreSliderItem,
   WatchlistResponse,
 } from '@server/interfaces/api/discoverInterfaces';
+import {
+  filterMovieResponseByGlobalRatingExclusions,
+  filterMovieResponseByGlobalTagExclusions,
+  filterMovieResponseByParentalControls,
+  filterResultsByGlobalRatingExclusions,
+  filterResultsByGlobalTagExclusions,
+  filterResultsByParentalControls,
+  filterTvResponseByGlobalRatingExclusions,
+  filterTvResponseByGlobalTagExclusions,
+  filterTvResponseByParentalControls,
+  getGlobalCertificationExclusionFilter,
+  getGlobalKeywordExclusionFilter,
+  getParentalCertificationFilter,
+  isMediaAllowedByGlobalRatingExclusions,
+  isMediaAllowedByGlobalTagExclusions,
+  isMediaAllowedByParentalControls,
+} from '@server/lib/parentalControls';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { mapProductionCompany } from '@server/models/Movie';
@@ -102,10 +119,11 @@ discoverRoutes.get('/movies', async (req, res, next) => {
     const keywords = query.keywords;
     const excludeKeywords = query.excludeKeywords;
 
-    const data = await tmdb.getDiscoverMovies({
+    const language = req.locale ?? query.language;
+    let data = await tmdb.getDiscoverMovies({
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
-      language: req.locale ?? query.language,
+      language,
       originalLanguage: query.language,
       genre: query.genre,
       studio: query.studio,
@@ -116,7 +134,7 @@ discoverRoutes.get('/movies', async (req, res, next) => {
         ? new Date(query.primaryReleaseDateGte).toISOString().split('T')[0]
         : undefined,
       keywords,
-      excludeKeywords,
+      ...getGlobalKeywordExclusionFilter(MediaType.MOVIE, excludeKeywords),
       withRuntimeGte: query.withRuntimeGte,
       withRuntimeLte: query.withRuntimeLte,
       voteAverageGte: query.voteAverageGte,
@@ -129,7 +147,25 @@ discoverRoutes.get('/movies', async (req, res, next) => {
       certificationGte: query.certificationGte,
       certificationLte: query.certificationLte,
       certificationCountry: query.certificationCountry,
+      ...(await getParentalCertificationFilter(
+        req.user,
+        MediaType.MOVIE,
+        tmdb
+      )),
+      ...(await getGlobalCertificationExclusionFilter(MediaType.MOVIE, tmdb)),
     });
+    data = await filterMovieResponseByParentalControls(
+      data,
+      req.user,
+      tmdb,
+      language
+    );
+    data = await filterMovieResponseByGlobalRatingExclusions(
+      data,
+      tmdb,
+      language
+    );
+    data = await filterMovieResponseByGlobalTagExclusions(data, tmdb, language);
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -189,19 +225,43 @@ discoverRoutes.get<{ language: string }>(
     try {
       const languages = await tmdb.getLanguages();
 
-      const language = languages.find(
+      const languageDetails = languages.find(
         (lang) => lang.iso_639_1 === req.params.language
       );
 
-      if (!language) {
+      if (!languageDetails) {
         return next({ status: 404, message: 'Language not found.' });
       }
 
-      const data = await tmdb.getDiscoverMovies({
+      const requestLanguage = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language: requestLanguage,
         originalLanguage: req.params.language,
+        ...getGlobalKeywordExclusionFilter(MediaType.MOVIE),
+        ...(await getParentalCertificationFilter(
+          req.user,
+          MediaType.MOVIE,
+          tmdb
+        )),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.MOVIE, tmdb)),
       });
+      data = await filterMovieResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        requestLanguage
+      );
+      data = await filterMovieResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        requestLanguage
+      );
+      data = await filterMovieResponseByGlobalTagExclusions(
+        data,
+        tmdb,
+        requestLanguage
+      );
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -215,7 +275,7 @@ discoverRoutes.get<{ language: string }>(
         page: data.page,
         totalPages: data.total_pages,
         totalResults: data.total_results,
-        language,
+        language: languageDetails,
         results: data.results.map((result) =>
           mapMovieResult(
             result,
@@ -258,11 +318,35 @@ discoverRoutes.get<{ genreId: string }>(
         return next({ status: 404, message: 'Genre not found.' });
       }
 
-      const data = await tmdb.getDiscoverMovies({
+      const language = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language,
         genre: req.params.genreId as string,
+        ...getGlobalKeywordExclusionFilter(MediaType.MOVIE),
+        ...(await getParentalCertificationFilter(
+          req.user,
+          MediaType.MOVIE,
+          tmdb
+        )),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.MOVIE, tmdb)),
       });
+      data = await filterMovieResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalTagExclusions(
+        data,
+        tmdb,
+        language
+      );
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -309,11 +393,35 @@ discoverRoutes.get<{ studioId: string }>(
     try {
       const studio = await tmdb.getStudio(Number(req.params.studioId));
 
-      const data = await tmdb.getDiscoverMovies({
+      const language = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverMovies({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language,
         studio: req.params.studioId as string,
+        ...getGlobalKeywordExclusionFilter(MediaType.MOVIE),
+        ...(await getParentalCertificationFilter(
+          req.user,
+          MediaType.MOVIE,
+          tmdb
+        )),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.MOVIE, tmdb)),
       });
+      data = await filterMovieResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalTagExclusions(
+        data,
+        tmdb,
+        language
+      );
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -362,11 +470,31 @@ discoverRoutes.get('/movies/upcoming', async (req, res, next) => {
     .split('T')[0];
 
   try {
-    const data = await tmdb.getDiscoverMovies({
+    const language = (req.query.language as string) ?? req.locale;
+    let data = await tmdb.getDiscoverMovies({
       page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
+      language,
       primaryReleaseDateGte: date,
+      ...getGlobalKeywordExclusionFilter(MediaType.MOVIE),
+      ...(await getParentalCertificationFilter(
+        req.user,
+        MediaType.MOVIE,
+        tmdb
+      )),
+      ...(await getGlobalCertificationExclusionFilter(MediaType.MOVIE, tmdb)),
     });
+    data = await filterMovieResponseByParentalControls(
+      data,
+      req.user,
+      tmdb,
+      language
+    );
+    data = await filterMovieResponseByGlobalRatingExclusions(
+      data,
+      tmdb,
+      language
+    );
+    data = await filterMovieResponseByGlobalTagExclusions(data, tmdb, language);
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -409,10 +537,11 @@ discoverRoutes.get('/tv', async (req, res, next) => {
     const query = ApiQuerySchema.parse(req.query);
     const keywords = query.keywords;
     const excludeKeywords = query.excludeKeywords;
-    const data = await tmdb.getDiscoverTv({
+    const language = req.locale ?? query.language;
+    let data = await tmdb.getDiscoverTv({
       page: Number(query.page),
       sortBy: query.sortBy as SortOptions,
-      language: req.locale ?? query.language,
+      language,
       genre: query.genre,
       network: query.network ? Number(query.network) : undefined,
       firstAirDateLte: query.firstAirDateLte
@@ -423,7 +552,7 @@ discoverRoutes.get('/tv', async (req, res, next) => {
         : undefined,
       originalLanguage: query.language,
       keywords,
-      excludeKeywords,
+      ...getGlobalKeywordExclusionFilter(MediaType.TV, excludeKeywords),
       withRuntimeGte: query.withRuntimeGte,
       withRuntimeLte: query.withRuntimeLte,
       voteAverageGte: query.voteAverageGte,
@@ -437,7 +566,17 @@ discoverRoutes.get('/tv', async (req, res, next) => {
       certificationGte: query.certificationGte,
       certificationLte: query.certificationLte,
       certificationCountry: query.certificationCountry,
+      ...(await getParentalCertificationFilter(req.user, MediaType.TV, tmdb)),
+      ...(await getGlobalCertificationExclusionFilter(MediaType.TV, tmdb)),
     });
+    data = await filterTvResponseByParentalControls(
+      data,
+      req.user,
+      tmdb,
+      language
+    );
+    data = await filterTvResponseByGlobalRatingExclusions(data, tmdb, language);
+    data = await filterTvResponseByGlobalTagExclusions(data, tmdb, language);
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -496,19 +635,39 @@ discoverRoutes.get<{ language: string }>(
     try {
       const languages = await tmdb.getLanguages();
 
-      const language = languages.find(
+      const languageDetails = languages.find(
         (lang) => lang.iso_639_1 === req.params.language
       );
 
-      if (!language) {
+      if (!languageDetails) {
         return next({ status: 404, message: 'Language not found.' });
       }
 
-      const data = await tmdb.getDiscoverTv({
+      const requestLanguage = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language: requestLanguage,
         originalLanguage: req.params.language,
+        ...getGlobalKeywordExclusionFilter(MediaType.TV),
+        ...(await getParentalCertificationFilter(req.user, MediaType.TV, tmdb)),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.TV, tmdb)),
       });
+      data = await filterTvResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        requestLanguage
+      );
+      data = await filterTvResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        requestLanguage
+      );
+      data = await filterTvResponseByGlobalTagExclusions(
+        data,
+        tmdb,
+        requestLanguage
+      );
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -522,7 +681,7 @@ discoverRoutes.get<{ language: string }>(
         page: data.page,
         totalPages: data.total_pages,
         totalResults: data.total_results,
-        language,
+        language: languageDetails,
         results: data.results.map((result) =>
           mapTvResult(
             result,
@@ -565,11 +724,27 @@ discoverRoutes.get<{ genreId: string }>(
         return next({ status: 404, message: 'Genre not found.' });
       }
 
-      const data = await tmdb.getDiscoverTv({
+      const language = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language,
         genre: req.params.genreId,
+        ...getGlobalKeywordExclusionFilter(MediaType.TV),
+        ...(await getParentalCertificationFilter(req.user, MediaType.TV, tmdb)),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.TV, tmdb)),
       });
+      data = await filterTvResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        language
+      );
+      data = await filterTvResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        language
+      );
+      data = await filterTvResponseByGlobalTagExclusions(data, tmdb, language);
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -616,11 +791,27 @@ discoverRoutes.get<{ networkId: string }>(
     try {
       const network = await tmdb.getNetwork(Number(req.params.networkId));
 
-      const data = await tmdb.getDiscoverTv({
+      const language = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getDiscoverTv({
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language,
         network: Number(req.params.networkId),
+        ...getGlobalKeywordExclusionFilter(MediaType.TV),
+        ...(await getParentalCertificationFilter(req.user, MediaType.TV, tmdb)),
+        ...(await getGlobalCertificationExclusionFilter(MediaType.TV, tmdb)),
       });
+      data = await filterTvResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        language
+      );
+      data = await filterTvResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        language
+      );
+      data = await filterTvResponseByGlobalTagExclusions(data, tmdb, language);
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -669,11 +860,23 @@ discoverRoutes.get('/tv/upcoming', async (req, res, next) => {
     .split('T')[0];
 
   try {
-    const data = await tmdb.getDiscoverTv({
+    const language = (req.query.language as string) ?? req.locale;
+    let data = await tmdb.getDiscoverTv({
       page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
+      language,
       firstAirDateGte: date,
+      ...getGlobalKeywordExclusionFilter(MediaType.TV),
+      ...(await getParentalCertificationFilter(req.user, MediaType.TV, tmdb)),
+      ...(await getGlobalCertificationExclusionFilter(MediaType.TV, tmdb)),
     });
+    data = await filterTvResponseByParentalControls(
+      data,
+      req.user,
+      tmdb,
+      language
+    );
+    data = await filterTvResponseByGlobalRatingExclusions(data, tmdb, language);
+    data = await filterTvResponseByGlobalTagExclusions(data, tmdb, language);
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -747,10 +950,29 @@ discoverRoutes.get('/trending', async (req, res, next) => {
     } as const;
 
     const { data, mapper, type } = await trendingFetchers[mediaType]();
+    let filteredResults = await filterResultsByParentalControls({
+      user: req.user,
+      results: data.results,
+      tmdb,
+      mediaType: type ?? undefined,
+      language,
+    });
+    filteredResults = await filterResultsByGlobalRatingExclusions({
+      results: filteredResults,
+      tmdb,
+      mediaType: type ?? undefined,
+      language,
+    });
+    filteredResults = await filterResultsByGlobalTagExclusions({
+      results: filteredResults,
+      tmdb,
+      mediaType: type ?? undefined,
+      language,
+    });
 
     const media = await Media.getRelatedMedia(
       req.user,
-      data.results.map((result) => ({
+      filteredResults.map((result) => ({
         tmdbId: result.id,
         mediaType: isMovie(result) ? MediaType.MOVIE : MediaType.TV,
       }))
@@ -760,7 +982,7 @@ discoverRoutes.get('/trending', async (req, res, next) => {
       page: data.page,
       totalPages: data.total_pages,
       totalResults: data.total_results,
-      results: data.results.map((result) => {
+      results: filteredResults.map((result) => {
         // - If "type" is set (case: "movie" or "tv"), the mediaType must also match.
         // - If "type" is not set (case: "all"), only filter by tmdbId.
         const selectedMedia = media.find(
@@ -789,11 +1011,28 @@ discoverRoutes.get<{ keywordId: string }>(
     const tmdb = new TheMovieDb();
 
     try {
-      const data = await tmdb.getMoviesByKeyword({
+      const language = (req.query.language as string) ?? req.locale;
+      let data = await tmdb.getMoviesByKeyword({
         keywordId: Number(req.params.keywordId),
         page: Number(req.query.page),
-        language: (req.query.language as string) ?? req.locale,
+        language,
       });
+      data = await filterMovieResponseByParentalControls(
+        data,
+        req.user,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalRatingExclusions(
+        data,
+        tmdb,
+        language
+      );
+      data = await filterMovieResponseByGlobalTagExclusions(
+        data,
+        tmdb,
+        language
+      );
 
       const media = await Media.getRelatedMedia(
         req.user,
@@ -845,9 +1084,35 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
 
       await Promise.all(
         genres.map(async (genre) => {
-          const genreData = await tmdb.getDiscoverMovies({
+          let genreData = await tmdb.getDiscoverMovies({
             genre: genre.id.toString(),
+            ...getGlobalKeywordExclusionFilter(MediaType.MOVIE),
+            ...(await getParentalCertificationFilter(
+              req.user,
+              MediaType.MOVIE,
+              tmdb
+            )),
+            ...(await getGlobalCertificationExclusionFilter(
+              MediaType.MOVIE,
+              tmdb
+            )),
           });
+          genreData = await filterMovieResponseByParentalControls(
+            genreData,
+            req.user,
+            tmdb,
+            req.query.language as string
+          );
+          genreData = await filterMovieResponseByGlobalRatingExclusions(
+            genreData,
+            tmdb,
+            req.query.language as string
+          );
+          genreData = await filterMovieResponseByGlobalTagExclusions(
+            genreData,
+            tmdb,
+            req.query.language as string
+          );
 
           mappedGenres.push({
             id: genre.id,
@@ -889,9 +1154,35 @@ discoverRoutes.get<{ language: string }, GenreSliderItem[]>(
 
       await Promise.all(
         genres.map(async (genre) => {
-          const genreData = await tmdb.getDiscoverTv({
+          let genreData = await tmdb.getDiscoverTv({
             genre: genre.id.toString(),
+            ...getGlobalKeywordExclusionFilter(MediaType.TV),
+            ...(await getParentalCertificationFilter(
+              req.user,
+              MediaType.TV,
+              tmdb
+            )),
+            ...(await getGlobalCertificationExclusionFilter(
+              MediaType.TV,
+              tmdb
+            )),
           });
+          genreData = await filterTvResponseByParentalControls(
+            genreData,
+            req.user,
+            tmdb,
+            req.query.language as string
+          );
+          genreData = await filterTvResponseByGlobalRatingExclusions(
+            genreData,
+            tmdb,
+            req.query.language as string
+          );
+          genreData = await filterTvResponseByGlobalTagExclusions(
+            genreData,
+            tmdb,
+            req.query.language as string
+          );
 
           mappedGenres.push({
             id: genre.id,
@@ -967,15 +1258,61 @@ discoverRoutes.get<Record<string, unknown>, WatchlistResponse>(
 
     const watchlist = await plexTV.getWatchlist({ offset });
 
+    const watchlistTmdb = new TheMovieDb();
+    const filteredWatchlist = (
+      await Promise.all(
+        watchlist.items
+          .filter((item) => item.tmdbId)
+          .map(async (item) => {
+            const mediaType =
+              item.type === 'show' ? MediaType.TV : MediaType.MOVIE;
+            const details =
+              mediaType === MediaType.MOVIE
+                ? await watchlistTmdb.getMovie({ movieId: item.tmdbId })
+                : await watchlistTmdb.getTvShow({ tvId: item.tmdbId });
+
+            const allowedByParentalControls =
+              await isMediaAllowedByParentalControls({
+                user: req.user,
+                mediaType,
+                media: details,
+                tmdb: watchlistTmdb,
+              });
+            const allowedByGlobalExclusions =
+              isMediaAllowedByGlobalRatingExclusions({
+                mediaType,
+                media: details,
+              });
+            const allowedByGlobalTagExclusions =
+              isMediaAllowedByGlobalTagExclusions({
+                mediaType,
+                media: details,
+              });
+
+            return allowedByParentalControls &&
+              allowedByGlobalExclusions &&
+              allowedByGlobalTagExclusions
+              ? {
+                  id: item.tmdbId,
+                  ratingKey: item.ratingKey,
+                  title: item.title,
+                  mediaType,
+                  tmdbId: item.tmdbId,
+                }
+              : null;
+          })
+      )
+    ).filter((item): item is NonNullable<typeof item> => !!item);
+
     return res.json({
       page,
       totalPages: Math.ceil(watchlist.totalSize / itemsPerPage),
       totalResults: watchlist.totalSize,
-      results: watchlist.items.map((item) => ({
+      results: filteredWatchlist.map((item) => ({
         id: item.tmdbId,
         ratingKey: item.ratingKey,
         title: item.title,
-        mediaType: item.type === 'show' ? 'tv' : 'movie',
+        mediaType: item.mediaType,
         tmdbId: item.tmdbId,
       })),
     });

--- a/server/routes/movie.ts
+++ b/server/routes/movie.ts
@@ -6,6 +6,14 @@ import { MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { Watchlist } from '@server/entity/Watchlist';
+import {
+  filterMovieResponseByGlobalRatingExclusions,
+  filterMovieResponseByGlobalTagExclusions,
+  filterMovieResponseByParentalControls,
+  isMediaAllowedByGlobalRatingExclusions,
+  isMediaAllowedByGlobalTagExclusions,
+  isMediaAllowedByParentalControls,
+} from '@server/lib/parentalControls';
 import logger from '@server/logger';
 import { mapMovieDetails } from '@server/models/Movie';
 import { mapMovieResult } from '@server/models/Search';
@@ -21,6 +29,44 @@ movieRoutes.get('/:id', async (req, res, next) => {
       movieId: Number(req.params.id),
       language: (req.query.language as string) ?? req.locale,
     });
+
+    if (
+      !(await isMediaAllowedByParentalControls({
+        user: req.user,
+        mediaType: MediaType.MOVIE,
+        media: tmdbMovie,
+        tmdb,
+      }))
+    ) {
+      return next({
+        status: 403,
+        message: 'This movie is restricted by parental controls.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalRatingExclusions({
+        mediaType: MediaType.MOVIE,
+        media: tmdbMovie,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This movie is hidden by rating settings.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalTagExclusions({
+        mediaType: MediaType.MOVIE,
+        media: tmdbMovie,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This movie is hidden by tag settings.',
+      });
+    }
 
     const media = await Media.getMedia(tmdbMovie.id, MediaType.MOVIE);
 
@@ -60,11 +106,27 @@ movieRoutes.get('/:id/recommendations', async (req, res, next) => {
   const tmdb = new TheMovieDb();
 
   try {
-    const results = await tmdb.getMovieRecommendations({
-      movieId: Number(req.params.id),
-      page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
-    });
+    const language = (req.query.language as string) ?? req.locale;
+    let results = await filterMovieResponseByParentalControls(
+      await tmdb.getMovieRecommendations({
+        movieId: Number(req.params.id),
+        page: Number(req.query.page),
+        language,
+      }),
+      req.user,
+      tmdb,
+      language
+    );
+    results = await filterMovieResponseByGlobalRatingExclusions(
+      results,
+      tmdb,
+      language
+    );
+    results = await filterMovieResponseByGlobalTagExclusions(
+      results,
+      tmdb,
+      language
+    );
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -105,11 +167,27 @@ movieRoutes.get('/:id/similar', async (req, res, next) => {
   const tmdb = new TheMovieDb();
 
   try {
-    const results = await tmdb.getMovieSimilar({
-      movieId: Number(req.params.id),
-      page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
-    });
+    const language = (req.query.language as string) ?? req.locale;
+    let results = await filterMovieResponseByParentalControls(
+      await tmdb.getMovieSimilar({
+        movieId: Number(req.params.id),
+        page: Number(req.query.page),
+        language,
+      }),
+      req.user,
+      tmdb,
+      language
+    );
+    results = await filterMovieResponseByGlobalRatingExclusions(
+      results,
+      tmdb,
+      language
+    );
+    results = await filterMovieResponseByGlobalTagExclusions(
+      results,
+      tmdb,
+      language
+    );
 
     const media = await Media.getRelatedMedia(
       req.user,

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -21,6 +21,7 @@ import type {
   MediaRequestBody,
   RequestResultsResponse,
 } from '@server/interfaces/api/requestInterfaces';
+import { ParentalControlRestrictedError } from '@server/lib/parentalControls';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
@@ -321,6 +322,7 @@ requestRoutes.post<never, MediaRequest, MediaRequestBody>(
       switch (error.constructor) {
         case RequestPermissionError:
         case QuotaRestrictedError:
+        case ParentalControlRestrictedError:
           return next({ status: 403, message: error.message });
         case DuplicateMediaRequestError:
           return next({ status: 409, message: error.message });

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -1,6 +1,7 @@
 import TheMovieDb from '@server/api/themoviedb';
 import type { TmdbSearchMultiResponse } from '@server/api/themoviedb/interfaces';
 import Media from '@server/entity/Media';
+import { filterResultsByParentalControls } from '@server/lib/parentalControls';
 import { findSearchProvider } from '@server/lib/search';
 import logger from '@server/logger';
 import { mapSearchResults } from '@server/models/Search';
@@ -33,9 +34,15 @@ searchRoutes.get('/', async (req, res, next) => {
       });
     }
 
+    const filteredResults = await filterResultsByParentalControls({
+      user: req.user,
+      results: results.results,
+      language: (req.query.language as string) ?? req.locale,
+    });
+
     const media = await Media.getRelatedMedia(
       req.user,
-      results.results.map((result) => ({
+      filteredResults.map((result) => ({
         tmdbId: result.id,
         mediaType: result.media_type,
       }))
@@ -45,7 +52,7 @@ searchRoutes.get('/', async (req, res, next) => {
       page: results.page,
       totalPages: results.total_pages,
       totalResults: results.total_results,
-      results: mapSearchResults(results.results, media),
+      results: mapSearchResults(filteredResults, media),
     });
   } catch (e) {
     logger.debug('Something went wrong retrieving search results', {

--- a/server/routes/tv.ts
+++ b/server/routes/tv.ts
@@ -7,6 +7,14 @@ import { MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { Watchlist } from '@server/entity/Watchlist';
+import {
+  filterTvResponseByGlobalRatingExclusions,
+  filterTvResponseByGlobalTagExclusions,
+  filterTvResponseByParentalControls,
+  isMediaAllowedByGlobalRatingExclusions,
+  isMediaAllowedByGlobalTagExclusions,
+  isMediaAllowedByParentalControls,
+} from '@server/lib/parentalControls';
 import logger from '@server/logger';
 import { mapTvResult } from '@server/models/Search';
 import { mapSeasonWithEpisodes, mapTvDetails } from '@server/models/Tv';
@@ -30,6 +38,45 @@ tvRoutes.get('/:id', async (req, res, next) => {
       tvId: Number(req.params.id),
       language: (req.query.language as string) ?? req.locale,
     });
+
+    if (
+      !(await isMediaAllowedByParentalControls({
+        user: req.user,
+        mediaType: MediaType.TV,
+        media: tv,
+        tmdb,
+      }))
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is restricted by parental controls.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalRatingExclusions({
+        mediaType: MediaType.TV,
+        media: tv,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is hidden by rating settings.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalTagExclusions({
+        mediaType: MediaType.TV,
+        media: tv,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is hidden by tag settings.',
+      });
+    }
+
     const media = await Media.getMedia(tv.id, MediaType.TV);
 
     const onUserWatchlist = await getRepository(Watchlist).exist({
@@ -78,6 +125,44 @@ tvRoutes.get('/:id/season/:seasonNumber', async (req, res, next) => {
       ? await getMetadataProvider('anime')
       : await getMetadataProvider('tv');
 
+    if (
+      !(await isMediaAllowedByParentalControls({
+        user: req.user,
+        mediaType: MediaType.TV,
+        media: tmdbTv,
+        tmdb,
+      }))
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is restricted by parental controls.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalRatingExclusions({
+        mediaType: MediaType.TV,
+        media: tmdbTv,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is hidden by rating settings.',
+      });
+    }
+
+    if (
+      !isMediaAllowedByGlobalTagExclusions({
+        mediaType: MediaType.TV,
+        media: tmdbTv,
+      })
+    ) {
+      return next({
+        status: 403,
+        message: 'This series is hidden by tag settings.',
+      });
+    }
+
     const season = await metadataProvider.getTvSeason({
       tvId: Number(req.params.id),
       seasonNumber: Number(req.params.seasonNumber),
@@ -103,11 +188,27 @@ tvRoutes.get('/:id/recommendations', async (req, res, next) => {
   const tmdb = new TheMovieDb();
 
   try {
-    const results = await tmdb.getTvRecommendations({
-      tvId: Number(req.params.id),
-      page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
-    });
+    const language = (req.query.language as string) ?? req.locale;
+    let results = await filterTvResponseByParentalControls(
+      await tmdb.getTvRecommendations({
+        tvId: Number(req.params.id),
+        page: Number(req.query.page),
+        language,
+      }),
+      req.user,
+      tmdb,
+      language
+    );
+    results = await filterTvResponseByGlobalRatingExclusions(
+      results,
+      tmdb,
+      language
+    );
+    results = await filterTvResponseByGlobalTagExclusions(
+      results,
+      tmdb,
+      language
+    );
 
     const media = await Media.getRelatedMedia(
       req.user,
@@ -147,11 +248,27 @@ tvRoutes.get('/:id/similar', async (req, res, next) => {
   const tmdb = new TheMovieDb();
 
   try {
-    const results = await tmdb.getTvSimilar({
-      tvId: Number(req.params.id),
-      page: Number(req.query.page),
-      language: (req.query.language as string) ?? req.locale,
-    });
+    const language = (req.query.language as string) ?? req.locale;
+    let results = await filterTvResponseByParentalControls(
+      await tmdb.getTvSimilar({
+        tvId: Number(req.params.id),
+        page: Number(req.query.page),
+        language,
+      }),
+      req.user,
+      tmdb,
+      language
+    );
+    results = await filterTvResponseByGlobalRatingExclusions(
+      results,
+      tmdb,
+      language
+    );
+    results = await filterTvResponseByGlobalTagExclusions(
+      results,
+      tmdb,
+      language
+    );
 
     const media = await Media.getRelatedMedia(
       req.user,

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -62,6 +62,11 @@ userSettingsRoutes.get<{ id: string }, UserSettingsGeneralResponse>(
         globalTvQuotaLimit: defaultQuotas.tv.quotaLimit,
         watchlistSyncMovies: user.settings?.watchlistSyncMovies,
         watchlistSyncTv: user.settings?.watchlistSyncTv,
+        parentalControlsEnabled: user.settings?.parentalControlsEnabled,
+        parentalControlsRegion: user.settings?.parentalControlsRegion,
+        maxMovieCertification: user.settings?.maxMovieCertification,
+        maxTvCertification: user.settings?.maxTvCertification,
+        blockUnrated: user.settings?.blockUnrated,
       });
     } catch (e) {
       next({ status: 500, message: e.message });
@@ -127,6 +132,11 @@ userSettingsRoutes.post<
         originalLanguage: req.body.originalLanguage,
         watchlistSyncMovies: req.body.watchlistSyncMovies,
         watchlistSyncTv: req.body.watchlistSyncTv,
+        parentalControlsEnabled: req.body.parentalControlsEnabled,
+        parentalControlsRegion: req.body.parentalControlsRegion,
+        maxMovieCertification: req.body.maxMovieCertification,
+        maxTvCertification: req.body.maxTvCertification,
+        blockUnrated: req.body.blockUnrated,
       });
     } else {
       user.settings.locale = req.body.locale;
@@ -135,6 +145,11 @@ userSettingsRoutes.post<
       user.settings.originalLanguage = req.body.originalLanguage;
       user.settings.watchlistSyncMovies = req.body.watchlistSyncMovies;
       user.settings.watchlistSyncTv = req.body.watchlistSyncTv;
+      user.settings.parentalControlsEnabled = req.body.parentalControlsEnabled;
+      user.settings.parentalControlsRegion = req.body.parentalControlsRegion;
+      user.settings.maxMovieCertification = req.body.maxMovieCertification;
+      user.settings.maxTvCertification = req.body.maxTvCertification;
+      user.settings.blockUnrated = req.body.blockUnrated;
     }
 
     const savedUser = await userRepository.save(user);
@@ -147,6 +162,11 @@ userSettingsRoutes.post<
       originalLanguage: savedUser.settings?.originalLanguage,
       watchlistSyncMovies: savedUser.settings?.watchlistSyncMovies,
       watchlistSyncTv: savedUser.settings?.watchlistSyncTv,
+      parentalControlsEnabled: savedUser.settings?.parentalControlsEnabled,
+      parentalControlsRegion: savedUser.settings?.parentalControlsRegion,
+      maxMovieCertification: savedUser.settings?.maxMovieCertification,
+      maxTvCertification: savedUser.settings?.maxTvCertification,
+      blockUnrated: savedUser.settings?.blockUnrated,
       email: savedUser.email,
     });
   } catch (e) {

--- a/src/components/BlocklistedTagsSelector/index.tsx
+++ b/src/components/BlocklistedTagsSelector/index.tsx
@@ -52,10 +52,12 @@ type SingleVal = {
 
 type BlocklistedTagsSelectorProps = {
   defaultValue?: string;
+  fieldName?: string;
 };
 
 const BlocklistedTagsSelector = ({
   defaultValue,
+  fieldName = 'blocklistedTags',
 }: BlocklistedTagsSelectorProps) => {
   const { setFieldValue } = useFormikContext();
   const [value, setValue] = useState<string | undefined>(defaultValue);
@@ -68,9 +70,9 @@ const BlocklistedTagsSelector = ({
       const strVal = value?.map((v) => v.value).join(',');
       setSelectorValue(value);
       setValue(strVal);
-      setFieldValue('blocklistedTags', strVal);
+      setFieldValue(fieldName, strVal);
     },
-    [setSelectorValue, setValue, setFieldValue]
+    [setSelectorValue, setValue, setFieldValue, fieldName]
   );
 
   const copyDisabled = value === null || value?.length === 0;

--- a/src/components/BlocklistedTagsSelector/index.tsx
+++ b/src/components/BlocklistedTagsSelector/index.tsx
@@ -21,7 +21,12 @@ import {
   useState,
 } from 'react';
 import { useIntl } from 'react-intl';
-import type { ClearIndicatorProps, GroupBase, MultiValue } from 'react-select';
+import type {
+  ClearIndicatorProps,
+  GroupBase,
+  MultiValue,
+  StylesConfig,
+} from 'react-select';
 import { components } from 'react-select';
 import AsyncSelect from 'react-select/async';
 
@@ -48,6 +53,25 @@ const messages = defineMessages('components.Settings', {
 type SingleVal = {
   label: string;
   value: number;
+};
+
+const selectMenuStyles: StylesConfig<SingleVal, true> = {
+  menu: (base) => ({
+    ...base,
+    backgroundColor: '#374151',
+    color: '#d1d5db',
+    zIndex: 9999,
+  }),
+  menuPortal: (base) => ({
+    ...base,
+    zIndex: 9999,
+  }),
+  option: (base, state) => ({
+    ...base,
+    backgroundColor: state.isFocused ? '#4b5563' : '#374151',
+    color: state.isFocused ? '#ffffff' : '#d1d5db',
+    cursor: 'pointer',
+  }),
 };
 
 type BlocklistedTagsSelectorProps = {
@@ -120,6 +144,13 @@ const ControlledKeywordSelector = ({
   value,
 }: BaseSelectorMultiProps) => {
   const intl = useIntl();
+  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(
+    null
+  );
+
+  useEffect(() => {
+    setMenuPortalTarget(document.body);
+  }, []);
 
   useEffect(() => {
     const loadDefaultKeywords = async (): Promise<void> => {
@@ -179,6 +210,9 @@ const ControlledKeywordSelector = ({
       placeholder={intl.formatMessage(messages.searchKeywords)}
       onChange={onChange}
       components={components}
+      menuPosition="fixed"
+      menuPortalTarget={menuPortalTarget ?? undefined}
+      styles={selectMenuStyles}
     />
   );
 };

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import LanguageSelector from '@app/components/LanguageSelector';
 import RegionSelector from '@app/components/RegionSelector';
+import USCertificationSelector from '@app/components/Selector/USCertificationSelector';
 import CopyButton from '@app/components/Settings/CopyButton';
 import SettingsBadge from '@app/components/Settings/SettingsBadge';
 import { availableLanguages } from '@app/context/LanguageContext';
@@ -38,6 +39,18 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   discoverRegionTip: 'Filter content by regional availability',
   originallanguage: 'Discover Language',
   originallanguageTip: 'Filter content by original language',
+  excludedMovieCertifications: 'Excluded Movie Ratings',
+  excludedMovieCertificationsTip:
+    'Hide movies with these ratings from discover and movie pages. Search results are not affected.',
+  excludedTvCertifications: 'Excluded Series Ratings',
+  excludedTvCertificationsTip:
+    'Hide series with these ratings from discover and series pages. Search results are not affected.',
+  excludedMovieTags: 'Excluded Movie Tags',
+  excludedMovieTagsTip:
+    'Hide movies with these TMDB keywords from discover and movie pages. Search results are not affected.',
+  excludedTvTags: 'Excluded Series Tags',
+  excludedTvTagsTip:
+    'Hide series with these TMDB keywords from discover and series pages. Search results are not affected.',
   blocklistRegion: 'Blocklist Region',
   blocklistRegionTip:
     'Region used for blocklist content scanning (independent of discover settings)',
@@ -174,6 +187,13 @@ const SettingsMain = () => {
             locale: data?.locale ?? 'en',
             discoverRegion: data?.discoverRegion,
             originalLanguage: data?.originalLanguage,
+            excludedMovieCertifications:
+              data?.excludedMovieCertifications ?? 'NR',
+            excludedTvCertifications: data?.excludedTvCertifications ?? 'NR',
+            excludedCertificationRegion:
+              data?.excludedCertificationRegion ?? 'US',
+            excludedMovieTags: data?.excludedMovieTags,
+            excludedTvTags: data?.excludedTvTags,
             streamingRegion: data?.streamingRegion || 'US',
             blocklistRegion: data?.blocklistRegion || '',
             blocklistLanguage: data?.blocklistLanguage || '',
@@ -197,6 +217,11 @@ const SettingsMain = () => {
                 discoverRegion: values.discoverRegion,
                 streamingRegion: values.streamingRegion,
                 originalLanguage: values.originalLanguage,
+                excludedMovieCertifications: values.excludedMovieCertifications,
+                excludedTvCertifications: values.excludedTvCertifications,
+                excludedCertificationRegion: values.excludedCertificationRegion,
+                excludedMovieTags: values.excludedMovieTags,
+                excludedTvTags: values.excludedTvTags,
                 blocklistRegion: values.blocklistRegion,
                 blocklistLanguage: values.blocklistLanguage,
                 blocklistedTags: values.blocklistedTags,
@@ -409,6 +434,94 @@ const SettingsMain = () => {
                         onChange={setFieldValue}
                         regionType="streaming"
                         disableAll
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label
+                    htmlFor="excludedMovieCertifications"
+                    className="text-label"
+                  >
+                    <span>
+                      {intl.formatMessage(messages.excludedMovieCertifications)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(
+                        messages.excludedMovieCertificationsTip
+                      )}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <USCertificationSelector
+                      type="movie"
+                      certification={values.excludedMovieCertifications}
+                      onChange={(params) => {
+                        setFieldValue(
+                          'excludedMovieCertifications',
+                          params.certification
+                        );
+                        setFieldValue('excludedCertificationRegion', 'US');
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label
+                    htmlFor="excludedTvCertifications"
+                    className="text-label"
+                  >
+                    <span>
+                      {intl.formatMessage(messages.excludedTvCertifications)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.excludedTvCertificationsTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <USCertificationSelector
+                      type="tv"
+                      certification={values.excludedTvCertifications}
+                      onChange={(params) => {
+                        setFieldValue(
+                          'excludedTvCertifications',
+                          params.certification
+                        );
+                        setFieldValue('excludedCertificationRegion', 'US');
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="excludedMovieTags" className="text-label">
+                    <span>
+                      {intl.formatMessage(messages.excludedMovieTags)}
+                    </span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.excludedMovieTagsTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field relative z-10">
+                      <BlocklistedTagsSelector
+                        fieldName="excludedMovieTags"
+                        defaultValue={values.excludedMovieTags}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="excludedTvTags" className="text-label">
+                    <span>{intl.formatMessage(messages.excludedTvTags)}</span>
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.excludedTvTagsTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <div className="form-input-field relative z-10">
+                      <BlocklistedTagsSelector
+                        fieldName="excludedTvTags"
+                        defaultValue={values.excludedTvTags}
                       />
                     </div>
                   </div>

--- a/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserGeneralSettings/index.tsx
@@ -5,6 +5,7 @@ import PageTitle from '@app/components/Common/PageTitle';
 import LanguageSelector from '@app/components/LanguageSelector';
 import QuotaSelector from '@app/components/QuotaSelector';
 import RegionSelector from '@app/components/RegionSelector';
+import CertificationSelector from '@app/components/Selector/CertificationSelector';
 import { availableLanguages } from '@app/context/LanguageContext';
 import useLocale from '@app/hooks/useLocale';
 import useSettings from '@app/hooks/useSettings';
@@ -69,6 +70,11 @@ const messages = defineMessages(
     plexwatchlistsyncseries: 'Auto-Request Series',
     plexwatchlistsyncseriestip:
       'Automatically request series on your <PlexWatchlistSupportLink>Plex Watchlist</PlexWatchlistSupportLink>',
+    parentalControlsEnabled: 'Enable Parental Controls',
+    parentalControlsTip: 'Restrict requests by content rating.',
+    maxMovieCertification: 'Maximum Movie Rating',
+    maxTvCertification: 'Maximum Series Rating',
+    blockUnrated: 'Block Unrated Titles',
   }
 );
 
@@ -161,6 +167,11 @@ const UserGeneralSettings = () => {
           tvQuotaDays: data?.tvQuotaDays,
           watchlistSyncMovies: data?.watchlistSyncMovies,
           watchlistSyncTv: data?.watchlistSyncTv,
+          parentalControlsEnabled: data?.parentalControlsEnabled,
+          parentalControlsRegion: data?.parentalControlsRegion ?? 'US',
+          maxMovieCertification: data?.maxMovieCertification,
+          maxTvCertification: data?.maxTvCertification,
+          blockUnrated: data?.blockUnrated,
         }}
         validationSchema={UserGeneralSettingsSchema}
         enableReinitialize
@@ -182,6 +193,11 @@ const UserGeneralSettings = () => {
               tvQuotaDays: tvQuotaEnabled ? values.tvQuotaDays : null,
               watchlistSyncMovies: values.watchlistSyncMovies,
               watchlistSyncTv: values.watchlistSyncTv,
+              parentalControlsEnabled: values.parentalControlsEnabled,
+              parentalControlsRegion: values.parentalControlsRegion,
+              maxMovieCertification: values.maxMovieCertification,
+              maxTvCertification: values.maxTvCertification,
+              blockUnrated: values.blockUnrated,
             });
 
             if (currentUser?.id === user?.id && setLocale) {
@@ -418,6 +434,107 @@ const UserGeneralSettings = () => {
                   </div>
                 </div>
               </div>
+              {currentHasPermission(Permission.MANAGE_USERS) && (
+                <>
+                  <div className="form-row">
+                    <label
+                      htmlFor="parentalControlsEnabled"
+                      className="checkbox-label"
+                    >
+                      <span>
+                        {intl.formatMessage(messages.parentalControlsEnabled)}
+                      </span>
+                      <span className="label-tip">
+                        {intl.formatMessage(messages.parentalControlsTip)}
+                      </span>
+                    </label>
+                    <div className="form-input-area">
+                      <Field
+                        type="checkbox"
+                        id="parentalControlsEnabled"
+                        name="parentalControlsEnabled"
+                        onChange={() => {
+                          setFieldValue(
+                            'parentalControlsEnabled',
+                            !values.parentalControlsEnabled
+                          );
+                        }}
+                      />
+                    </div>
+                  </div>
+                  {values.parentalControlsEnabled && (
+                    <>
+                      <div className="form-row">
+                        <label className="text-label">
+                          {intl.formatMessage(messages.maxMovieCertification)}
+                        </label>
+                        <div className="form-input-area">
+                          <CertificationSelector
+                            type="movie"
+                            certificationCountry={values.parentalControlsRegion}
+                            certification={values.maxMovieCertification}
+                            onChange={(params) => {
+                              setFieldValue(
+                                'parentalControlsRegion',
+                                params.certificationCountry ?? 'US'
+                              );
+                              setFieldValue(
+                                'maxMovieCertification',
+                                params.certification
+                              );
+                            }}
+                          />
+                        </div>
+                      </div>
+                      <div className="form-row">
+                        <label className="text-label">
+                          {intl.formatMessage(messages.maxTvCertification)}
+                        </label>
+                        <div className="form-input-area">
+                          <CertificationSelector
+                            type="tv"
+                            certificationCountry={values.parentalControlsRegion}
+                            certification={values.maxTvCertification}
+                            onChange={(params) => {
+                              setFieldValue(
+                                'parentalControlsRegion',
+                                params.certificationCountry ?? 'US'
+                              );
+                              setFieldValue(
+                                'maxTvCertification',
+                                params.certification
+                              );
+                            }}
+                          />
+                        </div>
+                      </div>
+                      <div className="form-row">
+                        <label
+                          htmlFor="blockUnrated"
+                          className="checkbox-label"
+                        >
+                          <span>
+                            {intl.formatMessage(messages.blockUnrated)}
+                          </span>
+                        </label>
+                        <div className="form-input-area">
+                          <Field
+                            type="checkbox"
+                            id="blockUnrated"
+                            name="blockUnrated"
+                            onChange={() => {
+                              setFieldValue(
+                                'blockUnrated',
+                                !values.blockUnrated
+                              );
+                            }}
+                          />
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </>
+              )}
               {currentHasPermission(Permission.MANAGE_USERS) &&
                 !hasPermission(Permission.MANAGE_USERS) && (
                   <>

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -145,7 +145,7 @@ const useDiscover = <
   const isEmpty = !isLoadingInitialData && titles?.length === 0;
   const isReachingEnd =
     isEmpty ||
-    (!!data && (data[data?.length - 1]?.results.length ?? 0) < 20) ||
+    (!!data && data.length >= (data[data.length - 1]?.totalPages ?? 0)) ||
     (!!data && (data[data?.length - 1]?.totalResults ?? 0) <= size * 20) ||
     (!!data && (data[data?.length - 1]?.totalResults ?? 0) < 41);
 


### PR DESCRIPTION
## Title

Add parental controls and global content exclusions

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Adds per-user parental controls and app-wide content exclusion settings.

This change adds parental control settings to user profiles, allowing admins to set maximum movie/series ratings and optionally block unrated content. 

It also adds global Seerr settings for excluding specific ratings and TMDB keyword tags from discover/movie/series browsing independently from the blocklist. This allows admins to allow ratings like `R` while still hiding titles with specific tags. Manual search remains unaffected by the global exclusions.



## AI Assistance Disclosure

This pull request was developed with assistance from AI tooling(codex). The changes were reviewed and tested locally before submission. I have experience as a react/nextjs developer, I was planning on making it mostly myself but decided to try out codex since this feature was very needed for me.

## How Has This Been Tested?

Tested locally on Windows with Node/pnpm project dependencies installed.

Ran:

- `pnpm typecheck:server`
- `pnpm typecheck:client`
- `pnpm build`
- Prettier checks on touched files



## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` (not sure about this)
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parental controls: enable/disable, region-specific certification limits, and option to block unrated content.
  * Global exclusions: filter content by certification and by tag/keyword.
  * Parental/global filters applied across search, discovery, trending, recommendations, similar, watchlist, movie and TV detail endpoints.

* **UI**
  * Settings and user profile screens updated to configure parental controls and global exclusions.

* **Chores**
  * Node pinned to 22.22.3; improved discovery pagination; added image metadata label for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->