### PR TITLE
feat(request): add per-request Search Automatically toggle

### DIFF
--- a/docs/using-seerr/settings/services.md
+++ b/docs/using-seerr/settings/services.md
@@ -73,3 +73,5 @@ Enable this setting if you would like to scan your Radarr/Sonarr server for exis
 #### Enable Automatic Search (optional)
 
 Enable this setting to have Radarr/Sonarr to automatically search for media upon approval of a request.
+
+This serves as the default for all requests sent to this server. When submitting a request, users with access to advanced options can override this default on a per-request basis using the **Search Automatically** toggle in the request modal.

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -385,6 +385,7 @@ export class MediaRequest {
         rootFolder: rootFolder,
         tags: tags,
         isAutoRequest: options.isAutoRequest ?? false,
+        searchAutomatically: requestBody.searchAutomatically ?? null,
       });
 
       await requestRepository.save(request);
@@ -516,6 +517,7 @@ export class MediaRequest {
             })
         ),
         isAutoRequest: options.isAutoRequest ?? false,
+        searchAutomatically: requestBody.searchAutomatically ?? null,
       });
 
       await requestRepository.save(request);
@@ -621,6 +623,9 @@ export class MediaRequest {
 
   @Column({ default: false })
   public isAutoRequest: boolean;
+
+  @Column({ nullable: true, type: 'boolean' })
+  public searchAutomatically: boolean | null;
 
   constructor(init?: Partial<MediaRequest>) {
     Object.assign(this, init);

--- a/server/interfaces/api/requestInterfaces.ts
+++ b/server/interfaces/api/requestInterfaces.ts
@@ -26,4 +26,5 @@ export type MediaRequestBody = {
   languageProfileId?: number;
   userId?: number;
   tags?: number[];
+  searchAutomatically?: boolean;
 };

--- a/server/interfaces/api/serviceInterfaces.ts
+++ b/server/interfaces/api/serviceInterfaces.ts
@@ -14,6 +14,7 @@ export interface ServiceCommonServer {
   activeAnimeLanguageProfileId?: number;
   activeTags: number[];
   activeAnimeTags?: number[];
+  preventSearch: boolean;
 }
 
 export interface ServiceCommonServerWithDetails {

--- a/server/migration/postgres/1780982504352-AddSearchAutomaticallyColumn.ts
+++ b/server/migration/postgres/1780982504352-AddSearchAutomaticallyColumn.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSearchAutomaticallyColumn1780982504352 implements MigrationInterface {
+  name = 'AddSearchAutomaticallyColumn1780982504352';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media_request" ADD "searchAutomatically" boolean`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "media_request" DROP COLUMN "searchAutomatically"`
+    );
+  }
+}

--- a/server/migration/sqlite/1780982495597-AddSearchAutomaticallyColumn.ts
+++ b/server/migration/sqlite/1780982495597-AddSearchAutomaticallyColumn.ts
@@ -1,0 +1,119 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSearchAutomaticallyColumn1780982495597 implements MigrationInterface {
+  name = 'AddSearchAutomaticallyColumn1780982495597';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_push_subscription" RENAME TO "user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1"`);
+    await queryRunner.query(`DROP INDEX "IDX_6997bee94720f1ecb7f3113709"`);
+    await queryRunner.query(`DROP INDEX "IDX_a1aa713f41c99e9d10c48da75a"`);
+    await queryRunner.query(`DROP INDEX "IDX_4c696e8ed36ae34fe18abe59d2"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_media_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "status" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "type" varchar NOT NULL, "mediaId" integer, "requestedById" integer, "modifiedById" integer, "is4k" boolean NOT NULL DEFAULT (0), "serverId" integer, "profileId" integer, "rootFolder" varchar, "languageProfileId" integer, "tags" text, "isAutoRequest" boolean NOT NULL DEFAULT (0), "searchAutomatically" boolean, CONSTRAINT "FK_a1aa713f41c99e9d10c48da75a0" FOREIGN KEY ("mediaId") REFERENCES "media" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_6997bee94720f1ecb7f31137095" FOREIGN KEY ("requestedById") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f4fc4efa14c3ba2b29c4525fa15" FOREIGN KEY ("modifiedById") REFERENCES "user" ("id") ON DELETE SET NULL ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_media_request"("id", "status", "createdAt", "updatedAt", "type", "mediaId", "requestedById", "modifiedById", "is4k", "serverId", "profileId", "rootFolder", "languageProfileId", "tags", "isAutoRequest") SELECT "id", "status", "createdAt", "updatedAt", "type", "mediaId", "requestedById", "modifiedById", "is4k", "serverId", "profileId", "rootFolder", "languageProfileId", "tags", "isAutoRequest" FROM "media_request"`
+    );
+    await queryRunner.query(`DROP TABLE "media_request"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_media_request" RENAME TO "media_request"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1" ON "media_request" ("modifiedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6997bee94720f1ecb7f3113709" ON "media_request" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a1aa713f41c99e9d10c48da75a" ON "media_request" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4c696e8ed36ae34fe18abe59d2" ON "media_request" ("status") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_push_subscription" RENAME TO "user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_push_subscription" RENAME TO "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_user_push_subscription"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_4c696e8ed36ae34fe18abe59d2"`);
+    await queryRunner.query(`DROP INDEX "IDX_a1aa713f41c99e9d10c48da75a"`);
+    await queryRunner.query(`DROP INDEX "IDX_6997bee94720f1ecb7f3113709"`);
+    await queryRunner.query(`DROP INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1"`);
+    await queryRunner.query(
+      `ALTER TABLE "media_request" RENAME TO "temporary_media_request"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "media_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "status" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "type" varchar NOT NULL, "mediaId" integer, "requestedById" integer, "modifiedById" integer, "is4k" boolean NOT NULL DEFAULT (0), "serverId" integer, "profileId" integer, "rootFolder" varchar, "languageProfileId" integer, "tags" text, "isAutoRequest" boolean NOT NULL DEFAULT (0), CONSTRAINT "FK_a1aa713f41c99e9d10c48da75a0" FOREIGN KEY ("mediaId") REFERENCES "media" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_6997bee94720f1ecb7f31137095" FOREIGN KEY ("requestedById") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_f4fc4efa14c3ba2b29c4525fa15" FOREIGN KEY ("modifiedById") REFERENCES "user" ("id") ON DELETE SET NULL ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "media_request"("id", "status", "createdAt", "updatedAt", "type", "mediaId", "requestedById", "modifiedById", "is4k", "serverId", "profileId", "rootFolder", "languageProfileId", "tags", "isAutoRequest") SELECT "id", "status", "createdAt", "updatedAt", "type", "mediaId", "requestedById", "modifiedById", "is4k", "serverId", "profileId", "rootFolder", "languageProfileId", "tags", "isAutoRequest" FROM "temporary_media_request"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_media_request"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4c696e8ed36ae34fe18abe59d2" ON "media_request" ("status") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a1aa713f41c99e9d10c48da75a" ON "media_request" ("mediaId") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6997bee94720f1ecb7f3113709" ON "media_request" ("requestedById") `
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f4fc4efa14c3ba2b29c4525fa1" ON "media_request" ("modifiedById") `
+    );
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_push_subscription" RENAME TO "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_user_push_subscription"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+  }
+}

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -211,6 +211,27 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.profileId, 7);
     assert.strictEqual(saved.rootFolder, '/updated/movies');
   });
+
+  it('persists searchAutomatically to the database', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedRequest();
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.MOVIE,
+      serverId: mediaRequest.serverId,
+      profileId: mediaRequest.profileId,
+      rootFolder: mediaRequest.rootFolder,
+      searchAutomatically: false,
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.searchAutomatically, false);
+  });
 });
 
 describe('POST /request/:requestId/:status', () => {

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -511,6 +511,9 @@ requestRoutes.put<{ requestId: string }>(
         request.rootFolder = req.body.rootFolder;
         request.tags = req.body.tags;
         request.requestedBy = requestUser as User;
+        if (req.body.searchAutomatically !== undefined) {
+          request.searchAutomatically = req.body.searchAutomatically;
+        }
 
         await requestRepository.save(request);
       } else if (req.body.mediaType === MediaType.TV) {
@@ -521,6 +524,9 @@ requestRoutes.put<{ requestId: string }>(
         request.languageProfileId = req.body.languageProfileId;
         request.tags = req.body.tags;
         request.requestedBy = requestUser as User;
+        if (req.body.searchAutomatically !== undefined) {
+          request.searchAutomatically = req.body.searchAutomatically;
+        }
 
         const requestedSeasons = req.body.seasons as number[] | undefined;
 

--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -23,6 +23,7 @@ serviceRoutes.get('/radarr', async (req, res) => {
       activeDirectory: radarr.activeDirectory,
       activeProfileId: radarr.activeProfileId,
       activeTags: radarr.tags ?? [],
+      preventSearch: radarr.preventSearch,
     })
   );
 
@@ -63,6 +64,7 @@ serviceRoutes.get<{ radarrId: string }>(
         activeDirectory: radarrSettings.activeDirectory,
         activeProfileId: radarrSettings.activeProfileId,
         activeTags: radarrSettings.tags,
+        preventSearch: radarrSettings.preventSearch,
       },
       profiles: profiles.map((profile) => ({
         id: profile.id,
@@ -95,6 +97,7 @@ serviceRoutes.get('/sonarr', async (req, res) => {
       activeLanguageProfileId: sonarr.activeLanguageProfileId,
       activeAnimeLanguageProfileId: sonarr.activeAnimeLanguageProfileId,
       activeTags: [],
+      preventSearch: sonarr.preventSearch,
     })
   );
 
@@ -147,6 +150,7 @@ serviceRoutes.get<{ sonarrId: string }>(
             sonarrSettings.activeAnimeLanguageProfileId,
           activeTags: sonarrSettings.tags,
           activeAnimeTags: sonarrSettings.animeTags,
+          preventSearch: sonarrSettings.preventSearch,
         },
         profiles: profiles.map((profile) => ({
           id: profile.id,

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -370,7 +370,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           year: Number(movie.release_date.slice(0, 4)),
           monitored: true,
           tags,
-          searchNow: !radarrSettings.preventSearch,
+          searchNow:
+            entity.searchAutomatically ?? !radarrSettings.preventSearch,
         };
 
         // Run entity asynchronously so we don't wait for it on the UI side
@@ -712,7 +713,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           tags,
           monitored: true,
           monitorNewItems: sonarrSettings.monitorNewItems,
-          searchNow: !sonarrSettings.preventSearch,
+          searchNow:
+            entity.searchAutomatically ?? !sonarrSettings.preventSearch,
         };
 
         // Run entity asynchronously so we don't wait for it on the UI side

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -38,6 +38,7 @@ interface ModalProps {
   loading?: boolean;
   backdrop?: string;
   children?: React.ReactNode;
+  footerContent?: React.ReactNode;
   dialogClass?: string;
 }
 
@@ -66,6 +67,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
       loading = false,
       onTertiary,
       backdrop,
+      footerContent,
       dialogClass,
       okButtonProps,
       cancelButtonProps,
@@ -190,8 +192,16 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
               {children}
             </div>
           )}
-          {(onCancel || onOk || onSecondary || onTertiary) && (
-            <div className="relative mt-5 flex flex-row-reverse justify-center sm:mt-4 sm:justify-start">
+          {(onCancel || onOk || onSecondary || onTertiary || footerContent) && (
+            <div
+              className={`relative mt-5 flex items-center sm:mt-4 ${
+                footerContent
+                  ? 'justify-between'
+                  : 'flex-row-reverse justify-center sm:justify-start'
+              }`}
+            >
+              {footerContent && <div>{footerContent}</div>}
+              <div className={footerContent ? 'flex flex-row-reverse' : 'contents'}>
               {typeof onOk === 'function' && (
                 <Button
                   buttonType={okButtonType}
@@ -240,6 +250,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
                     : intl.formatMessage(globalMessages.cancel)}
                 </Button>
               )}
+              </div>
             </div>
           )}
         </Transition>

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -38,6 +38,7 @@ const messages = defineMessages('components.RequestModal.AdvancedRequester', {
   tags: 'Tags',
   selecttags: 'Select tags',
   notagoptions: 'No tags.',
+  searchautomatically: 'Search Automatically',
 });
 
 export type RequestOverrides = {
@@ -47,6 +48,7 @@ export type RequestOverrides = {
   tags?: number[];
   language?: number;
   user?: User;
+  searchAutomatically?: boolean;
 };
 
 interface AdvancedRequesterProps {
@@ -56,6 +58,8 @@ interface AdvancedRequesterProps {
   defaultOverrides?: RequestOverrides;
   requestUser?: User;
   onChange: (overrides: RequestOverrides) => void;
+  searchAutomatically?: boolean;
+  onSearchAutomaticallyChange?: (val: boolean) => void;
 }
 
 const AdvancedRequester = ({
@@ -65,6 +69,8 @@ const AdvancedRequester = ({
   defaultOverrides,
   requestUser,
   onChange,
+  searchAutomatically: searchAutomaticallyProp,
+  onSearchAutomaticallyChange,
 }: AdvancedRequesterProps) => {
   const intl = useIntl();
   const { user: currentUser, hasPermission: currentHasPermission } = useUser();
@@ -96,6 +102,20 @@ const AdvancedRequester = ({
   const [selectedTags, setSelectedTags] = useState<number[]>(
     defaultOverrides?.tags ?? []
   );
+
+  const [searchAutomaticallyInternal, setSearchAutomaticallyInternal] =
+    useState<boolean>(defaultOverrides?.searchAutomatically ?? true);
+  const searchAutomatically =
+    searchAutomaticallyProp !== undefined
+      ? searchAutomaticallyProp
+      : searchAutomaticallyInternal;
+  const setSearchAutomatically = (val: boolean) => {
+    if (onSearchAutomaticallyChange) {
+      onSearchAutomaticallyChange(val);
+    } else {
+      setSearchAutomaticallyInternal(val);
+    }
+  };
 
   const { data: serverData, isValidating } =
     useSWR<ServiceCommonServerWithDetails>(
@@ -233,6 +253,10 @@ const AdvancedRequester = ({
       ) {
         setSelectedTags(defaultTags);
       }
+
+      if (defaultOverrides?.searchAutomatically == null) {
+        setSearchAutomatically(!serverData.server.preventSearch);
+      }
     }
   }, [serverData]);
 
@@ -273,6 +297,7 @@ const AdvancedRequester = ({
         user: selectedUser ?? undefined,
         language: selectedLanguage !== -1 ? selectedLanguage : undefined,
         tags: selectedTags,
+        searchAutomatically,
       });
     }
   }, [
@@ -282,6 +307,7 @@ const AdvancedRequester = ({
     selectedUser,
     selectedLanguage,
     selectedTags,
+    searchAutomatically,
   ]);
 
   if (!data && !error) {
@@ -301,7 +327,8 @@ const AdvancedRequester = ({
             serverData.rootFolders.length < 2 &&
             (serverData.languageProfiles ?? []).length < 2 &&
             !serverData.tags?.length)))) &&
-    (!selectedUser || (filteredUserData ?? []).length < 2)
+    (!selectedUser || (filteredUserData ?? []).length < 2) &&
+    !currentHasPermission(Permission.REQUEST_ADVANCED)
   ) {
     return null;
   }
@@ -545,6 +572,25 @@ const AdvancedRequester = ({
                   intl.formatMessage(messages.notagoptions)
                 }
               />
+            </div>
+          )}
+        {!onSearchAutomaticallyChange &&
+          currentHasPermission(Permission.REQUEST_ADVANCED) &&
+          selectedServer !== null && (
+            <div className="mb-2 flex items-center gap-x-2">
+              <input
+                type="checkbox"
+                id="searchAutomatically"
+                checked={searchAutomatically}
+                onChange={(e) => setSearchAutomatically(e.target.checked)}
+                className="h-4 w-4 cursor-pointer rounded border-gray-600 bg-gray-700 text-indigo-600 focus:ring-indigo-500"
+              />
+              <label
+                htmlFor="searchAutomatically"
+                className="cursor-pointer text-sm text-white"
+              >
+                {intl.formatMessage(messages.searchautomatically)}
+              </label>
             </div>
           )}
         {currentHasPermission([

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -35,6 +35,7 @@ const messages = defineMessages('components.RequestModal', {
   requestApproved: 'Request for <strong>{title}</strong> approved!',
   requesterror: 'Something went wrong while submitting the request.',
   pendingapproval: 'Your request is pending approval.',
+  searchautomatically: 'Search Automatically',
 });
 
 interface RequestModalProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -57,6 +58,9 @@ const MovieRequestModal = ({
   const [isUpdating, setIsUpdating] = useState(false);
   const [requestOverrides, setRequestOverrides] =
     useState<RequestOverrides | null>(null);
+  const [searchAutomatically, setSearchAutomatically] = useState<boolean>(
+    editRequest?.searchAutomatically ?? true
+  );
   const { addToast } = useToasts();
   const { data, error } = useSWR<MovieDetails>(`/api/v1/movie/${tmdbId}`, {
     revalidateOnMount: true,
@@ -88,6 +92,7 @@ const MovieRequestModal = ({
           rootFolder: requestOverrides.folder,
           userId: requestOverrides.user?.id,
           tags: requestOverrides.tags,
+          searchAutomatically: requestOverrides.searchAutomatically,
         };
       }
       const response = await axios.post<MediaRequest>('/api/v1/request', {
@@ -183,6 +188,7 @@ const MovieRequestModal = ({
         rootFolder: requestOverrides?.folder,
         userId: requestOverrides?.user?.id,
         tags: requestOverrides?.tags,
+        searchAutomatically: requestOverrides?.searchAutomatically,
       });
 
       if (alsoApproveRequest) {
@@ -221,6 +227,26 @@ const MovieRequestModal = ({
       setIsUpdating(false);
     }
   };
+
+  const searchToggle = hasPermission(Permission.REQUEST_ADVANCED) &&
+    (requestOverrides?.server !== undefined ||
+      editRequest?.serverId != null) ? (
+    <div className="flex items-center gap-x-2">
+      <input
+        type="checkbox"
+        id="searchAutomatically"
+        checked={searchAutomatically}
+        onChange={(e) => setSearchAutomatically(e.target.checked)}
+        className="h-4 w-4 cursor-pointer rounded border-gray-600 bg-gray-700 text-indigo-600 focus:ring-indigo-500"
+      />
+      <label
+        htmlFor="searchAutomatically"
+        className="cursor-pointer text-sm leading-none text-white"
+      >
+        {intl.formatMessage(messages.searchautomatically)}
+      </label>
+    </div>
+  ) : undefined;
 
   if (editRequest) {
     const isOwner = editRequest.requestedBy.id === user?.id;
@@ -277,6 +303,7 @@ const MovieRequestModal = ({
         }
         secondaryButtonType="danger"
         cancelText={intl.formatMessage(globalMessages.close)}
+        footerContent={searchToggle}
         backdrop={`https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${data?.backdropPath}`}
       >
         {isOwner
@@ -295,10 +322,13 @@ const MovieRequestModal = ({
               profile: editRequest.profileId,
               server: editRequest.serverId,
               tags: editRequest.tags,
+              searchAutomatically: editRequest.searchAutomatically ?? undefined,
             }}
             onChange={(overrides) => {
               setRequestOverrides(overrides);
             }}
+            searchAutomatically={searchAutomatically}
+            onSearchAutomaticallyChange={setSearchAutomatically}
           />
         )}
       </Modal>
@@ -333,6 +363,7 @@ const MovieRequestModal = ({
             )
       }
       okButtonType={'primary'}
+      footerContent={searchToggle}
       backdrop={`https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${data?.backdropPath}`}
     >
       {hasAutoApprove && !quota?.movie.restricted && (
@@ -362,6 +393,8 @@ const MovieRequestModal = ({
           onChange={(overrides) => {
             setRequestOverrides(overrides);
           }}
+          searchAutomatically={searchAutomatically}
+          onSearchAutomaticallyChange={setSearchAutomatically}
         />
       )}
     </Modal>

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -50,6 +50,7 @@ const messages = defineMessages('components.RequestModal', {
   autoapproval: 'Automatic Approval',
   requesterror: 'Something went wrong while submitting the request.',
   pendingapproval: 'Your request is pending approval.',
+  searchautomatically: 'Search Automatically',
 });
 
 interface RequestModalProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -77,6 +78,9 @@ const TvRequestModal = ({
   const { data, error } = useSWR<TvDetails>(`/api/v1/tv/${tmdbId}`);
   const [requestOverrides, setRequestOverrides] =
     useState<RequestOverrides | null>(null);
+  const [searchAutomatically, setSearchAutomatically] = useState<boolean>(
+    editRequest?.searchAutomatically ?? true
+  );
   const [selectedSeasons, setSelectedSeasons] = useState<number[]>(
     editRequest ? editingSeasons : []
   );
@@ -120,6 +124,7 @@ const TvRequestModal = ({
           languageProfileId: requestOverrides?.language,
           userId: requestOverrides?.user?.id,
           tags: requestOverrides?.tags,
+          searchAutomatically: requestOverrides?.searchAutomatically,
           seasons: selectedSeasons.sort((a, b) => a - b),
         });
 
@@ -192,6 +197,7 @@ const TvRequestModal = ({
           languageProfileId: requestOverrides.language,
           userId: requestOverrides?.user?.id,
           tags: requestOverrides.tags,
+          searchAutomatically: requestOverrides.searchAutomatically,
         };
       }
       const response = await axios.post<MediaRequest>('/api/v1/request', {
@@ -375,6 +381,26 @@ const TvRequestModal = ({
 
   const isOwner = editRequest && editRequest.requestedBy.id === user?.id;
 
+  const searchToggle = hasPermission(Permission.REQUEST_ADVANCED) &&
+    (requestOverrides?.server !== undefined ||
+      editRequest?.serverId != null) ? (
+    <div className="flex items-center gap-x-2">
+      <input
+        type="checkbox"
+        id="searchAutomatically"
+        checked={searchAutomatically}
+        onChange={(e) => setSearchAutomatically(e.target.checked)}
+        className="h-4 w-4 cursor-pointer rounded border-gray-600 bg-gray-700 text-indigo-600 focus:ring-indigo-500"
+      />
+      <label
+        htmlFor="searchAutomatically"
+        className="cursor-pointer text-sm leading-none text-white"
+      >
+        {intl.formatMessage(messages.searchautomatically)}
+      </label>
+    </div>
+  ) : undefined;
+
   return data && !error && !data.externalIds.tvdbId && searchModal.show ? (
     <SearchByNameModal
       tvdbId={tvdbId}
@@ -460,6 +486,7 @@ const TvRequestModal = ({
             ? intl.formatMessage(globalMessages.back)
             : intl.formatMessage(globalMessages.cancel)
       }
+      footerContent={searchToggle}
       backdrop={`https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/${data?.backdropPath}`}
     >
       {editRequest
@@ -730,9 +757,13 @@ const TvRequestModal = ({
                   server: editRequest.serverId,
                   language: editRequest.languageProfileId,
                   tags: editRequest.tags,
+                  searchAutomatically:
+                    editRequest.searchAutomatically ?? undefined,
                 }
               : undefined
           }
+          searchAutomatically={searchAutomatically}
+          onSearchAutomaticallyChange={setSearchAutomatically}
         />
       )}
     </Modal>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -539,6 +539,7 @@
   "components.RequestModal.AdvancedRequester.qualityprofile": "Quality Profile",
   "components.RequestModal.AdvancedRequester.requestas": "Request As",
   "components.RequestModal.AdvancedRequester.rootfolder": "Root Folder",
+  "components.RequestModal.AdvancedRequester.searchautomatically": "Search Automatically",
   "components.RequestModal.AdvancedRequester.selecttags": "Select tags",
   "components.RequestModal.AdvancedRequester.tags": "Tags",
   "components.RequestModal.QuotaDisplay.allowedRequests": "You are allowed to request <strong>{limit}</strong> {type}{days, plural, =0 {} one { every day} other { every <strong>{days}</strong> days}}.",


### PR DESCRIPTION
**AI Disclosure**: I used Claude to help me write the code. I have reviewed the code. The PR description was written by me.

## Description

This adds the ability to toggle "automated search" per request for users with access to advanced options. The advanced search setting serves as the default and can be overridden at request time or at approval time.

This resolves one of two feature requests made in #1047 

## How Has This Been Tested?

Tests were updated and I tested it in a live environment with working Jellyfin/Radarr servers.

## Screenshots / Logs (if applicable)

<img width="1187" height="762" alt="image" src="https://github.com/user-attachments/assets/f3946f30-d505-4473-8f9d-8778231c3ee8" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
