### PR TITLE
fix(notifications): make the Discord IDs available even when the notification is disabled on Seerr

### DIFF
--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
@@ -24,7 +24,7 @@ const messages = defineMessages(
   'components.UserProfile.UserSettings.UserNotificationSettings',
   {
     discordNotificationsNotEnabled:
-      'The server owner has not enabled Discord notifications. These information will only be used if the server owner configure an external service.',
+      'The server owner has not enabled Discord notifications. This information will only be used if the server owner configures an external service.',
     discordsettingssaved: 'Discord notification settings saved successfully!',
     discordsettingsfailed: 'Discord notification settings failed to save.',
     discordId: 'User IDs',

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsDiscord.tsx
@@ -1,3 +1,4 @@
+import Alert from '@app/components/Common/Alert';
 import Button from '@app/components/Common/Button';
 import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import NotificationTypeSelector from '@app/components/NotificationTypeSelector';
@@ -22,6 +23,8 @@ import * as Yup from 'yup';
 const messages = defineMessages(
   'components.UserProfile.UserSettings.UserNotificationSettings',
   {
+    discordNotificationsNotEnabled:
+      'The server owner has not enabled Discord notifications. These information will only be used if the server owner configure an external service.',
     discordsettingssaved: 'Discord notification settings saved successfully!',
     discordsettingsfailed: 'Discord notification settings failed to save.',
     discordId: 'User IDs',
@@ -118,6 +121,14 @@ const UserNotificationsDiscord = () => {
       }) => {
         return (
           <Form className="section">
+            {!(data?.discordEnabledTypes ?? 0) && (
+              <Alert
+                type="warning"
+                title={intl.formatMessage(
+                  messages.discordNotificationsNotEnabled
+                )}
+              />
+            )}
             <div className="form-row">
               <label className="text-label">
                 {intl.formatMessage(messages.discordId)}

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/index.tsx
@@ -75,7 +75,6 @@ const UserNotificationSettings = ({
       ),
       route: '/settings/notifications/discord',
       regex: /\/settings\/notifications\/discord/,
-      hidden: !data?.discordEnabled,
     },
     {
       text: 'Pushbullet',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1524,7 +1524,7 @@
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdPlaceholder": "Discord User ID",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdRemove": "Remove",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdTip": "The <FindDiscordIdLink>multi-digit ID number</FindDiscordIdLink> associated with your user account. For multiple household accounts you can add more than one Discord user ID.",
-  "components.UserProfile.UserSettings.UserNotificationSettings.discordNotificationsNotEnabled": "The server owner has not enabled Discord notifications. These information will only be used if the server owner configure an external service.",
+  "components.UserProfile.UserSettings.UserNotificationSettings.discordNotificationsNotEnabled": "The server owner has not enabled Discord notifications. This information will only be used if the server owner configures an external service.",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordsettingsfailed": "Discord notification settings failed to save.",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordsettingssaved": "Discord notification settings saved successfully!",
   "components.UserProfile.UserSettings.UserNotificationSettings.email": "Email",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1524,6 +1524,7 @@
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdPlaceholder": "Discord User ID",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdRemove": "Remove",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordIdTip": "The <FindDiscordIdLink>multi-digit ID number</FindDiscordIdLink> associated with your user account. For multiple household accounts you can add more than one Discord user ID.",
+  "components.UserProfile.UserSettings.UserNotificationSettings.discordNotificationsNotEnabled": "The server owner has not enabled Discord notifications. These information will only be used if the server owner configure an external service.",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordsettingsfailed": "Discord notification settings failed to save.",
   "components.UserProfile.UserSettings.UserNotificationSettings.discordsettingssaved": "Discord notification settings saved successfully!",
   "components.UserProfile.UserSettings.UserNotificationSettings.email": "Email",


### PR DESCRIPTION
## Description

This PR makes the Discord IDs field visible and available inside the notification tab of the user settings.

Making this accessible even when the notification service is disabled on Seerr allows better integration with 3rd party services needing this info.

This PR also adds a warning when the Discord notification service is disabled on Seerr.

## How Has This Been Tested?

Go to the Discord tab of the user notification settings when Discord notifications are enabled/disabled.

## Screenshots / Logs (if applicable)

<img width="1960" height="736" alt="image" src="https://github.com/user-attachments/assets/608bfe1c-49e7-4a8a-a4f0-c13eea28af1a" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord notification settings tab is now always visible in the user settings menu.
  * Added an informational alert that displays when Discord notifications are not enabled by the server owner, clarifying administrator setup is required.
* **Localization**
  * Added English translation for the new informational message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->