### PR TITLE
docs(settings): improve Metadata settings docs

### DIFF
--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -23,23 +23,19 @@ provider and updates the two status badges (`TheMovieDB`, `TheTVDB`). Each badge
 
 This section controls which provider is used for which media type.
 
-
 ### Series Metadata Provider
 
 Choose between **TheMovieDB** and **TheTVDB** as the source of metadata for TV
 series. TheMovieDB is the default and matches the source used for movies, which
 keeps IDs and artwork consistent across the UI.
 
-
 ### Anime Metadata Provider
 
 Choose between **TheMovieDB** and **TheTVDB** for anime entries.
 
-
 ## Saving and Testing
 
-The **Save** buttons persist changes to `config/settings.json`. The **Test**
-buttons make one request per provider:
+The **Test** buttons make one request per provider.
 
 *TMDB / TVDB are tested only when selected as the active provider for one of
 the media types.*

--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -1,0 +1,53 @@
+---
+title: Metadata Providers
+description: Configure the metadata providers Seerr uses for TV and anime.
+sidebar_position: 8
+---
+
+# Metadata Providers
+
+Seerr fetches descriptive metadata (titles, descriptions, posters, release dates,
+external IDs, etc.) from a number of third-party providers. The
+**Settings → Metadata Providers** page lets administrators pick which provider
+is used for each media type.
+
+A **Test** button at the top and bottom of the page exercises every configured
+provider and updates the three status badges (`TheMovieDB`, `TheTVDB`). Each badge shows one of:
+
+- **Operational** — the test request succeeded.
+- **Not tested** — no test has been run yet in this session.
+- **Failed** — the test request errored; a toast describes which provider(s)
+  failed so the issue can be resolved without scrolling back up.
+
+## Metadata Provider Selection
+
+This section controls which provider is used for which media type.
+
+
+### Series Metadata Provider
+
+Choose between **TheMovieDB** and **TheTVDB** as the source of metadata for TV
+series. TheMovieDB is the default and matches the source used for movies, which
+keeps IDs and artwork consistent across the UI. TheTVDB tends to have richer
+episode-level data for long-running shows.
+
+### Anime Metadata Provider
+
+Choose between **TheMovieDB** and **TheTVDB** for anime entries. Many users
+prefer **TheTVDB** here because its anime catalogue is typically more complete
+and uses release-aligned numbering.
+
+Selection changes are persisted with the **Save** button at the bottom of the
+page.
+
+
+## Saving and Testing
+
+The **Save** buttons persist changes to `config/settings.json`. The **Test**
+buttons make one request per provider:
+
+- TMDB / TVDB are tested only when selected as the active provider for one of
+  the media types.
+
+If any test fails, a toast is shown for that provider and its status badge is
+updated; the other providers' results are independent.

--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -28,17 +28,12 @@ This section controls which provider is used for which media type.
 
 Choose between **TheMovieDB** and **TheTVDB** as the source of metadata for TV
 series. TheMovieDB is the default and matches the source used for movies, which
-keeps IDs and artwork consistent across the UI. TheTVDB tends to have richer
-episode-level data for long-running shows.
+keeps IDs and artwork consistent across the UI.
+
 
 ### Anime Metadata Provider
 
-Choose between **TheMovieDB** and **TheTVDB** for anime entries. Many users
-prefer **TheTVDB** here because its anime catalogue is typically more complete
-and uses release-aligned numbering.
-
-Selection changes are persisted with the **Save** button at the bottom of the
-page.
+Choose between **TheMovieDB** and **TheTVDB** for anime entries.
 
 
 ## Saving and Testing
@@ -46,8 +41,8 @@ page.
 The **Save** buttons persist changes to `config/settings.json`. The **Test**
 buttons make one request per provider:
 
-- TMDB / TVDB are tested only when selected as the active provider for one of
-  the media types.
+*TMDB / TVDB are tested only when selected as the active provider for one of
+the media types.*
 
-If any test fails, a toast is shown for that provider and its status badge is
-updated; the other providers' results are independent.
+If any test fails, an error is shown for that provider and its status badge is
+updated.

--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata Providers
-description: Configure the metadata providers Seerr uses for TV and anime.
+description: Configure the metadata providers Seerr uses.
 sidebar_position: 8
 ---
 
@@ -23,7 +23,7 @@ provider and updates the two status badges (`TheMovieDB`, `TheTVDB`). Each badge
 
 This section controls which provider is used for which media type.
 
-### Series Metadata Provider
+### TV series Metadata Provider
 
 Choose between **TheMovieDB** and **TheTVDB** as the source of metadata for TV
 series. TheMovieDB is the default and matches the source used for movies, which

--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -33,7 +33,7 @@ keeps IDs and artwork consistent across the UI.
 
 Choose between **TheMovieDB** and **TheTVDB** for anime entries.
 
-## Saving and Testing
+## Metadata Provider Testing
 
 The **Test** buttons make one request per provider.
 

--- a/docs/using-seerr/settings/metadata.md
+++ b/docs/using-seerr/settings/metadata.md
@@ -12,7 +12,7 @@ external IDs, etc.) from a number of third-party providers. The
 is used for each media type.
 
 A **Test** button at the top and bottom of the page exercises every configured
-provider and updates the three status badges (`TheMovieDB`, `TheTVDB`). Each badge shows one of:
+provider and updates the two status badges (`TheMovieDB`, `TheTVDB`). Each badge shows one of:
 
 - **Operational** — the test request succeeded.
 - **Not tested** — no test has been run yet in this session.


### PR DESCRIPTION
## Description

Simple PR adding a page about metadata settings

Some AI has been used in initial generation, editing and proofreading done manually

## How Has This Been Tested?

It has been read

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required) -> not required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for Metadata Providers settings, detailing how to select TMDB or TVDB for Series and Anime and save changes.
  * Documented the Test action which queries configured providers and updates provider status badges (Operational / Not tested / Failed).
  * Clarified providers are tested only when selected for at least one media type; failures display an error and update the failing provider’s badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->