### PR TITLE
fix(webpush): resolve push subscription bugs for multi-device and shared browsers

### DIFF
--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -244,13 +244,13 @@ router.post<
         const transactionalRepo =
           transactionalEntityManager.getRepository(UserPushSubscription);
 
-        // Check for existing subscription by auth or endpoint within transaction
+        // Check for existing subscription by endpoint within transaction
         const existingSubscription = await transactionalRepo.findOne({
           relations: { user: true },
-          where: [
-            { auth: req.body.auth, user: { id: req.user?.id } },
-            { endpoint: req.body.endpoint, user: { id: req.user?.id } },
-          ],
+          where: {
+            endpoint: req.body.endpoint,
+            user: { id: req.user?.id },
+          },
         });
 
         if (existingSubscription) {
@@ -279,17 +279,15 @@ router.post<
           return;
         }
 
-        // Clean up old subscriptions from the same device (userAgent) for this user
-        // iOS can silently refresh endpoints, leaving stale subscriptions in the database
-        // Only clean up if we're creating a new subscription (not updating an existing one)
-        if (req.body.userAgent) {
+        // Clean up only true endpoint rotations. Same push-service subscription
+        // (matched by `auth`) but with a stale endpoint. Matching on `auth`
+        // avoids deleting sibling devices that only share a user agent.
+        if (req.body.auth) {
           const staleSubscriptions = await transactionalRepo.find({
             relations: { user: true },
             where: {
-              userAgent: req.body.userAgent,
               user: { id: req.user?.id },
-              // Only remove subscriptions with different endpoints (stale ones)
-              // Keep subscriptions that might be from different browsers/tabs
+              auth: req.body.auth,
               endpoint: Not(req.body.endpoint),
             },
           });

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -2,6 +2,7 @@ import CachedImage from '@app/components/Common/CachedImage';
 import MiniQuotaDisplay from '@app/components/Layout/UserDropdown/MiniQuotaDisplay';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
+import { unsubscribeToPushNotifications } from '@app/utils/pushSubscriptionHelpers';
 import { Menu, Transition } from '@headlessui/react';
 import {
   ArrowRightOnRectangleIcon,
@@ -39,6 +40,28 @@ const UserDropdown = () => {
   const { user, revalidate, hasPermission } = useUser();
 
   const logout = async () => {
+    try {
+      const unsubscribedEndpoint = await unsubscribeToPushNotifications(
+        user?.id
+      );
+
+      if (unsubscribedEndpoint) {
+        try {
+          await axios.delete(
+            `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
+              unsubscribedEndpoint
+            )}`
+          );
+        } catch {
+          // Ignore backend cleanup failures; logout should still continue.
+        }
+      }
+    } catch {
+      // dont block logout if push notification unsubscription fails
+    }
+
+    localStorage.removeItem('pushNotificationsEnabled');
+
     const response = await axios.post('/api/v1/auth/logout');
 
     if (response.data?.status === 'ok') {

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -2,6 +2,7 @@ import CachedImage from '@app/components/Common/CachedImage';
 import MiniQuotaDisplay from '@app/components/Layout/UserDropdown/MiniQuotaDisplay';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
+import { unsubscribeToPushNotifications } from '@app/utils/pushSubscriptionHelpers';
 import {
   Menu,
   MenuButton,
@@ -45,6 +46,28 @@ const UserDropdown = () => {
   const { user, revalidate, hasPermission } = useUser();
 
   const logout = async () => {
+    try {
+      const unsubscribedEndpoint = await unsubscribeToPushNotifications(
+        user?.id
+      );
+
+      if (unsubscribedEndpoint) {
+        try {
+          await axios.delete(
+            `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
+              unsubscribedEndpoint
+            )}`
+          );
+        } catch {
+          // Ignore backend cleanup failures; logout should still continue.
+        }
+      }
+    } catch {
+      // dont block logout if push notification unsubscription fails
+    }
+
+    localStorage.removeItem('pushNotificationsEnabled');
+
     const response = await axios.post('/api/v1/auth/logout');
 
     if (response.data?.status === 'ok') {

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -21,6 +21,12 @@ import Link from 'next/link';
 import { Fragment, forwardRef } from 'react';
 import { useIntl } from 'react-intl';
 
+const PUSH_CLEANUP_REQUEST_TIMEOUT_MS = 3000;
+// exceeds the request timeout so that fires first; the remainder covers the
+// unsubscribe step, whose serviceWorker.ready never settles without an active
+// registration
+const PUSH_CLEANUP_TOTAL_TIMEOUT_MS = PUSH_CLEANUP_REQUEST_TIMEOUT_MS + 2000;
+
 const messages = defineMessages('components.Layout.UserDropdown', {
   myprofile: 'Profile',
   settings: 'Settings',
@@ -46,27 +52,37 @@ const UserDropdown = () => {
   const { user, revalidate, hasPermission } = useUser();
 
   const logout = async () => {
-    try {
-      const unsubscribedEndpoint = await unsubscribeToPushNotifications(
-        user?.id
-      );
+    const cleanUpPushSubscription = async () => {
+      try {
+        const unsubscribedEndpoint = await unsubscribeToPushNotifications(
+          user?.id
+        );
 
-      if (unsubscribedEndpoint) {
-        try {
+        if (unsubscribedEndpoint) {
           await axios.delete(
             `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
               unsubscribedEndpoint
-            )}`
+            )}`,
+            { timeout: PUSH_CLEANUP_REQUEST_TIMEOUT_MS }
           );
-        } catch {
-          // Ignore backend cleanup failures; logout should still continue.
         }
+      } catch {
+        // continue logout regardless
       }
-    } catch {
-      // dont block logout if push notification unsubscription fails
-    }
+    };
 
-    localStorage.removeItem('pushNotificationsEnabled');
+    await Promise.race([
+      cleanUpPushSubscription(),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, PUSH_CLEANUP_TOTAL_TIMEOUT_MS);
+      }),
+    ]);
+
+    try {
+      localStorage.removeItem('pushNotificationsEnabled');
+    } catch {
+      // continue logout regardless
+    }
 
     const response = await axios.post('/api/v1/auth/logout');
 

--- a/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserNotificationSettings/UserNotificationsWebPush/index.tsx
@@ -12,8 +12,8 @@ import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import {
   getPushSubscription,
-  subscribeToPushNotifications,
   unsubscribeToPushNotifications,
+  verifyAndResubscribePushSubscription,
   verifyPushSubscription,
 } from '@app/utils/pushSubscriptionHelpers';
 import { ArrowDownOnSquareIcon } from '@heroicons/react/24/outline';
@@ -82,7 +82,7 @@ const UserWebPushSettings = () => {
   // Will only add to the database if subscribing for the first time
   const enablePushNotifications = async () => {
     try {
-      const isSubscribed = await subscribeToPushNotifications(
+      const isSubscribed = await verifyAndResubscribePushSubscription(
         user?.id,
         currentSettings
       );
@@ -111,17 +111,28 @@ const UserWebPushSettings = () => {
   // Deletes/disables corresponding push subscription from database
   const disablePushNotifications = async (endpoint?: string) => {
     try {
-      const unsubscribedEndpoint = await unsubscribeToPushNotifications(
+      // Only touch the browser subscription if it actually belongs to
+      // this user. Otherwise we'd silently kill a sibling user's working
+      // subscription if they happened to be using the same browser.
+      const ownsBrowserSubscription = await verifyPushSubscription(
         user?.id,
-        endpoint
+        currentSettings
       );
+
+      let unsubscribedEndpoint: string | null = null;
+      if (ownsBrowserSubscription) {
+        unsubscribedEndpoint = await unsubscribeToPushNotifications(
+          user?.id,
+          endpoint
+        );
+      }
 
       localStorage.setItem('pushNotificationsEnabled', 'false');
       setWebPushEnabled(false);
 
       // Only delete the current browser's subscription, not all devices
       const endpointToDelete = unsubscribedEndpoint || subEndpoint || endpoint;
-      if (endpointToDelete) {
+      if (endpointToDelete && ownsBrowserSubscription) {
         try {
           await axios.delete(
             `/api/v1/user/${user?.id}/pushSubscription/${encodeURIComponent(
@@ -171,26 +182,7 @@ const UserWebPushSettings = () => {
 
   useEffect(() => {
     const verifyWebPush = async () => {
-      const enabled = await verifyPushSubscription(user?.id, currentSettings);
-      let isEnabled = enabled;
-
-      if (!enabled && 'serviceWorker' in navigator) {
-        const { subscription } = await getPushSubscription();
-        if (subscription) {
-          isEnabled = true;
-        }
-      }
-
-      if (!isEnabled && dataDevices && dataDevices.length > 0) {
-        const currentUserAgent = navigator.userAgent;
-        const hasMatchingDevice = dataDevices.some(
-          (device) => device.userAgent === currentUserAgent
-        );
-
-        if (hasMatchingDevice) {
-          isEnabled = true;
-        }
-      }
+      const isEnabled = await verifyPushSubscription(user?.id, currentSettings);
 
       setWebPushEnabled(isEnabled);
       if (localStorage.getItem('pushNotificationsEnabled') === null) {
@@ -204,7 +196,7 @@ const UserWebPushSettings = () => {
     if (user?.id) {
       verifyWebPush();
     }
-  }, [user?.id, currentSettings, dataDevices]);
+  }, [user?.id, currentSettings]);
 
   useEffect(() => {
     const getSubscriptionEndpoint = async () => {

--- a/src/utils/pushSubscriptionHelpers.ts
+++ b/src/utils/pushSubscriptionHelpers.ts
@@ -69,7 +69,7 @@ export const verifyAndResubscribePushSubscription = async (
   userId: number | undefined,
   currentSettings: PublicSettingsResponse
 ): Promise<boolean> => {
-  if (!userId) {
+  if (!('serviceWorker' in navigator) || !userId) {
     return false;
   }
 
@@ -80,37 +80,37 @@ export const verifyAndResubscribePushSubscription = async (
     return true;
   }
 
-  if (subscription) {
+  if (!currentSettings.enablePushRegistration) {
     return false;
   }
 
-  if (currentSettings.enablePushRegistration) {
-    try {
-      const oldEndpoint = await unsubscribeToPushNotifications(userId);
+  try {
+    // If a browser-level subscription exists but doesn't belong to this
+    // user (or has stale VAPID keys), tear it down before resubscribing.
+    const oldEndpoint = subscription
+      ? await unsubscribeToPushNotifications(userId)
+      : null;
 
-      await subscribeToPushNotifications(userId, currentSettings);
+    await subscribeToPushNotifications(userId, currentSettings);
 
-      if (oldEndpoint) {
-        try {
-          await axios.delete(
-            `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(
-              oldEndpoint
-            )}`
-          );
-        } catch {
-          // Ignore errors when deleting old endpoint (it might not exist)
-        }
+    if (oldEndpoint) {
+      try {
+        await axios.delete(
+          `/api/v1/user/${userId}/pushSubscription/${encodeURIComponent(
+            oldEndpoint
+          )}`
+        );
+      } catch {
+        // Ignore errors when deleting old endpoint (it might not exist)
       }
-
-      return true;
-    } catch (error) {
-      throw new Error(`[SW] Resubscribe failed: ${error.message}`, {
-        cause: error,
-      });
     }
-  }
 
-  return false;
+    return true;
+  } catch (error) {
+    throw new Error(`[SW] Resubscribe failed: ${error.message}`, {
+      cause: error,
+    });
+  }
 };
 
 export const subscribeToPushNotifications = async (


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

This PR fixes a cluster of web push notification bugs affecting non-admin users, multi-device setups, and shared browsers. 

- Fixes #2660

Previously, cleanup matched only on `userAgent`, which meant two devices of the same model and OS/browser version sharing an identical user agent string were treated as the same device. Registering on the second device could delete the first device's subscription, breaking its notifications.

The cleanup now also requires a matching `auth` key, so only a true push-service endpoint rotation, same subscription identity with a new endpoint, is cleaned up. Duplicate detection remains endpoint-based so same-`auth` endpoint rotations can still replace the stale endpoint. Sibling devices that share a user agent but have distinct subscriptions are left intact. Any subscription that becomes genuinely invalid is still pruned by the delivery path, which removes subscriptions on a `410` or `404` response per [RFC 8030](https://www.rfc-editor.org/info/rfc8030/).

The second commit addresses cross-user contamination on shared browsers, where browser-level push subscriptions are per-origin and can otherwise persist across logout/login transitions.
Logout now unsubscribes the browser-level push subscription, deletes that endpoint from the current user's backend records, and clears the local enablement flag. This prevents a later user on the same browser from inheriting the previous user's push state.

The verification routine no longer treats the mere presence of any browser subscription as proof that the current user is subscribed. It verifies ownership against the current user's records. The resubscribe routine no longer bails out when a browser subscription exists but does not belong to the current user; it tears down the orphaned browser subscription and registers a fresh one. The disable action also verifies ownership before unsubscribing or deleting, so a user disabling push on a shared browser can no longer silently kill another user's working subscription.

## How Has This Been Tested?

- Verified one desktop browser, one iPhone on iOS 26, and one iPhone on iOS 18 can all be subscribed as `0xsysr3ll` and receive notifications independently.
- Verified disabling and re-enabling web push on each device does not remove or break sibling device subscriptions.
- Verified two subscriptions with the exact same `userAgent` but different push subscription keys can coexist in the database.
- Verified shared-browser logout unsubscribes the browser subscription and removes the backend row for the logged-in user.
- Verified logging in as a second user on the same browser does not inherit `0xsysr3ll`'s push state.
- Verified switching back to `0xsysr3ll` does not show a stale browser subscription while the iPhone subscriptions remain intact.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Push notifications are unsubscribed during logout, with local settings cleared.
  * Push registration now uses a verify-and-resubscribe flow.
  * Plex imports report how many existing users were refreshed.

* **Bug Fixes**
  * Prevents accidental deletion of other users’ subscriptions in shared-browser scenarios.
  * Improves stale-subscription cleanup and endpoint rotation handling.
  * Simplifies push-status verification for more consistent enable/disable behavior.
  * Ensures logout proceeds even if notification cleanup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->