### PR TITLE
docs: update truenas migration section to include chown

### DIFF
--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -269,9 +269,13 @@ For detailed community-maintained TrueNAS SCALE walkthroughs, see the [Host Path
           ```bash
           rsync -av /mnt/.ix-apps/app_mounts/jellyseerr/ /mnt/storage/seerr/
           ```
-    4. Install Seerr and use the same Host Path storage that was created before (`/mnt/storage/seerr/config` in our example)
-    5. Start Seerr app
-    6. Delete Jellyseerr/Overseerr app
+    4. Change ownership of the folder from `root` to the `apps` user and group:
+      ```bash
+      chown -R 568:568 /mnt/storage/seerr/
+      ```
+    5. Install Seerr and use the same Host Path storage that was created before (`/mnt/storage/seerr/config` in our example)
+    6. Start Seerr app
+    7. Delete Jellyseerr/Overseerr app
   </TabItem>
 </Tabs>
 

--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -267,15 +267,11 @@ For detailed community-maintained TrueNAS SCALE walkthroughs, see the [Host Path
     3. Copy ixVolume Data
           Open System Settings → Shell, or SSH into your TrueNAS server as root and run :
           ```bash
-          rsync -av /mnt/.ix-apps/app_mounts/jellyseerr/ /mnt/storage/seerr/
+          rsync -av --chown=568:568 /mnt/.ix-apps/app_mounts/jellyseerr/ /mnt/storage/seerr/
           ```
-    4. Change ownership of the folder from `root` to the `apps` user and group:
-      ```bash
-      chown -R 568:568 /mnt/storage/seerr/
-      ```
-    5. Install Seerr and use the same Host Path storage that was created before (`/mnt/storage/seerr/config` in our example)
-    6. Start Seerr app
-    7. Delete Jellyseerr/Overseerr app
+    4. Install Seerr and use the same Host Path storage that was created before (`/mnt/storage/seerr/config` in our example)
+    5. Start Seerr app
+    6. Delete Jellyseerr/Overseerr app
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Added step to explain necessary ownership change of the Seerr folder after starting Seerr for the first time when migrating TrueNAS.
Without this, the first start of Seerr will just result in a lot of "EACCES: permission denied" 

## How Has This Been Tested?

Did not test changes. Its a simple doc change, i did not set up a dev environment for this.
I clicked the Edit On Github button in the docs, edited it, opened this PR.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the TrueNAS SCALE “ixVolume” migration guide to ensure migrated files are assigned the correct directory ownership during the `rsync` copy step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->