### PR TITLE
fix: restore Webpack SVG loader config next to Turbopack

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,15 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/,
+      issuer: /\.(js|ts)x?$/,
+      use: ['@svgr/webpack'],
+    });
+
+    return config;
+  },
   experimental: {
     scrollRestoration: true,
     largePageDataBytes: 512 * 1000,


### PR DESCRIPTION
When building Next.js with Webpack (such as on architectures where Turbopack is unsupported, or using production builds), SVGs are imported as plain asset objects rather than React components. This causes a crash (React Error #130) when rendering SVGs. This PR restores the Webpack rules alongside the Turbopack configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SVG files can now be imported and used as components within the application, improving asset handling and flexibility in UI development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->