### PR TITLE
fix: availability sync demotion and orphan season rollup edge cases

### DIFF
--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -1167,4 +1167,286 @@ describe('AvailabilitySync', () => {
       );
     });
   });
+
+  describe('specials season handling', () => {
+    const tmdbSeasonsWithSpecials = [
+      {
+        id: 100,
+        air_date: '2024-01-01',
+        episode_count: 3,
+        name: 'Specials',
+        overview: '',
+        season_number: 0,
+      },
+      {
+        id: 101,
+        air_date: '2024-01-01',
+        episode_count: 10,
+        name: 'Season 1',
+        overview: '',
+        season_number: 1,
+      },
+    ];
+
+    it('should not demote an available show when only the specials season is missing (Jellyfin)', async () => {
+      configureJellyfin();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 13862;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.jellyfinMediaId = 'jellyfin-shogun-id';
+      media.externalServiceId = 300;
+      media.seasons = [
+        new Season({
+          seasonNumber: 0,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () => fakeTmdbShow(13862, tmdbSeasonsWithSpecials);
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jellyfin-shogun-id') {
+          return fakeJellyfinShow('jellyfin-shogun-id', '13862');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jellyfin-shogun-id') {
+          return [fakeJellyfinSeason(1, 'jellyfin-shogun-s1-id')];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jellyfin-shogun-s1-id') {
+          return fakeJellyfinEpisodes(10);
+        }
+        return [];
+      };
+
+      getSeriesByIdImpl = async (id: number) => {
+        if (id === 300) {
+          return {
+            tvdbId: 70814,
+            id: 300,
+            title: 'Shogun',
+            titleSlug: 'shogun',
+            monitored: true,
+            statistics: {
+              episodeFileCount: 10,
+              totalEpisodeCount: 10,
+              episodeCount: 10,
+              percentOfEpisodes: 100,
+              sizeOnDisk: 0,
+              seasonCount: 1,
+            },
+            seasons: fakeSonarrSeasons(1, { 1: 10 }),
+          } as unknown as SonarrSeries;
+        }
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 13862 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should stay AVAILABLE when only the specials season is missing'
+      );
+    });
+
+    it('should not demote an available show when only the specials season is missing (Plex)', async () => {
+      configurePlex();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 13863;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.ratingKey = 'plex-shogun-rk';
+      media.externalServiceId = 301;
+      media.seasons = [
+        new Season({
+          seasonNumber: 0,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () => fakeTmdbShow(13863, tmdbSeasonsWithSpecials);
+
+      getMetadataImpl = async (key: string) => {
+        if (key === 'plex-shogun-rk') {
+          return fakePlexShow('plex-shogun-rk');
+        }
+        throw new Error('404');
+      };
+
+      getChildrenMetadataImpl = async (key: string) => {
+        if (key === 'plex-shogun-rk') {
+          return [fakePlexSeason(1, 'plex-shogun-s1-rk')];
+        }
+        if (key === 'plex-shogun-s1-rk') {
+          return fakePlexEpisodes(10);
+        }
+        return [];
+      };
+
+      getSeriesByIdImpl = async (id: number) => {
+        if (id === 301) {
+          return {
+            tvdbId: 70814,
+            id: 301,
+            title: 'Shogun',
+            titleSlug: 'shogun',
+            monitored: true,
+            statistics: {
+              episodeFileCount: 10,
+              totalEpisodeCount: 10,
+              episodeCount: 10,
+              percentOfEpisodes: 100,
+              sizeOnDisk: 0,
+              seasonCount: 1,
+            },
+            seasons: fakeSonarrSeasons(1, { 1: 10 }),
+          } as unknown as SonarrSeries;
+        }
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 13863 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should stay AVAILABLE when only the specials season is missing'
+      );
+    });
+
+    it('should mark a removed specials season as DELETED without demoting the show (Jellyfin)', async () => {
+      configureJellyfin();
+      configureSonarr([{ syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 13864;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.jellyfinMediaId = 'jellyfin-specials-id';
+      media.externalServiceId = 302;
+      media.seasons = [
+        new Season({
+          seasonNumber: 0,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () => fakeTmdbShow(13864, tmdbSeasonsWithSpecials);
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jellyfin-specials-id') {
+          return fakeJellyfinShow('jellyfin-specials-id', '13864');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jellyfin-specials-id') {
+          return [fakeJellyfinSeason(1, 'jellyfin-specials-s1-id')];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jellyfin-specials-s1-id') {
+          return fakeJellyfinEpisodes(10);
+        }
+        return [];
+      };
+
+      getSeriesByIdImpl = async (id: number) => {
+        if (id === 302) {
+          return {
+            tvdbId: 70814,
+            id: 302,
+            title: 'Shogun',
+            titleSlug: 'shogun',
+            monitored: true,
+            statistics: {
+              episodeFileCount: 10,
+              totalEpisodeCount: 10,
+              episodeCount: 10,
+              percentOfEpisodes: 100,
+              sizeOnDisk: 0,
+              seasonCount: 1,
+            },
+            seasons: fakeSonarrSeasons(1, { 1: 10 }),
+          } as unknown as SonarrSeries;
+        }
+        throw new Error('404');
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 13864 },
+        relations: ['seasons'],
+      });
+
+      const specials = updated.seasons.find((s) => s.seasonNumber === 0);
+      assert.strictEqual(
+        specials?.status,
+        MediaStatus.DELETED,
+        'Removed specials season should be marked DELETED'
+      );
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should stay AVAILABLE when only specials were removed'
+      );
+    });
+  });
 });

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -379,6 +379,11 @@ class AvailabilitySync {
           if (tvShow) {
             // fill the finalSeasons and finalSeasons4k maps with false for missing seasons
             media.seasons.forEach((season) => {
+              // Specials don't count towards availability (baseScanner skips them too)
+              // TODO: doesn't respect enableSpecialEpisodes; needs a shared predicate with baseScanner.ts
+              if (season.seasonNumber === 0) {
+                return;
+              }
               if (
                 !finalSeasons.has(season.seasonNumber) &&
                 tvShow.seasons.find(
@@ -599,6 +604,8 @@ class AvailabilitySync {
     );
     // Retrieve the season keys to pass into our log
     const seasonKeys = [...seasonsPendingRemoval.keys()];
+    // Specials can still be marked DELETED below, but shouldn't demote the show
+    const nonSpecialSeasonKeys = seasonKeys.filter((key) => key !== 0);
 
     try {
       for (const mediaSeason of media.seasons) {
@@ -613,12 +620,15 @@ class AvailabilitySync {
         }
       }
 
-      if (media[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE) {
+      if (
+        nonSpecialSeasonKeys.length > 0 &&
+        media[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+      ) {
         media[is4k ? 'status4k' : 'status'] = MediaStatus.PARTIALLY_AVAILABLE;
         logger.debug(
           `Marking the ${
             is4k ? '4K' : 'non-4K'
-          } show [TMDB ID ${media.tmdbId}] as PARTIALLY_AVAILABLE because season(s) [${seasonKeys}] was not found in any ${
+          } show [TMDB ID ${media.tmdbId}] as PARTIALLY_AVAILABLE because season(s) [${nonSpecialSeasonKeys}] was not found in any ${
             media.mediaType === 'tv' ? 'Sonarr' : 'Radarr'
           } and ${
             mediaServerType === MediaServerType.PLEX

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -467,10 +467,25 @@ class BaseScanner<T> {
           (s) => s.seasonNumber !== 0
         );
 
-        const standardSeasonsForRollup = nonSpecialSeasons.filter(
-          (s) =>
-            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
-              ?.totalEpisodes ?? Infinity) > 0
+        // DB-only seasons block the rollup unless UNKNOWN (orphan placeholders
+        // can never be revisited by a scan and would pin the show forever).
+        const countsTowardsRollup = (
+          s: Season,
+          statusKey: 'status' | 'status4k'
+        ): boolean => {
+          const scannedSeason = seasons.find(
+            (season) => season.seasonNumber === s.seasonNumber
+          );
+
+          if (scannedSeason) {
+            return scannedSeason.totalEpisodes > 0;
+          }
+
+          return s[statusKey] !== MediaStatus.UNKNOWN;
+        };
+
+        const standardSeasonsForRollup = nonSpecialSeasons.filter((s) =>
+          countsTowardsRollup(s, 'status')
         );
         const isAllStandardSeasonsAvailable =
           standardSeasonsForRollup.length > 0 &&
@@ -478,10 +493,8 @@ class BaseScanner<T> {
             (s) => s.status === MediaStatus.AVAILABLE
           );
 
-        const seasons4kForRollup = nonSpecialSeasons.filter(
-          (s) =>
-            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
-              ?.totalEpisodes ?? Infinity) > 0
+        const seasons4kForRollup = nonSpecialSeasons.filter((s) =>
+          countsTowardsRollup(s, 'status4k')
         );
         const isAll4kSeasonsAvailable =
           seasons4kForRollup.length > 0 &&
@@ -530,25 +543,20 @@ class BaseScanner<T> {
           (s) => s.seasonNumber !== 0
         );
 
-        const standardSeasonsForRollup = nonSpecialNewSeasons.filter(
+        const newSeasonsForRollup = nonSpecialNewSeasons.filter(
           (s) =>
             (seasons.find((season) => season.seasonNumber === s.seasonNumber)
-              ?.totalEpisodes ?? Infinity) > 0
+              ?.totalEpisodes ?? 0) > 0
         );
         const isAllStandardSeasonsAvailable =
-          standardSeasonsForRollup.length > 0 &&
-          standardSeasonsForRollup.every(
-            (s) => s.status === MediaStatus.AVAILABLE
-          );
+          newSeasonsForRollup.length > 0 &&
+          newSeasonsForRollup.every((s) => s.status === MediaStatus.AVAILABLE);
 
-        const seasons4kForRollup = nonSpecialNewSeasons.filter(
-          (s) =>
-            (seasons.find((season) => season.seasonNumber === s.seasonNumber)
-              ?.totalEpisodes ?? Infinity) > 0
-        );
         const isAll4kSeasonsAvailable =
-          seasons4kForRollup.length > 0 &&
-          seasons4kForRollup.every((s) => s.status4k === MediaStatus.AVAILABLE);
+          newSeasonsForRollup.length > 0 &&
+          newSeasonsForRollup.every(
+            (s) => s.status4k === MediaStatus.AVAILABLE
+          );
 
         const newMedia = new Media({
           mediaType: MediaType.TV,

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -346,5 +346,160 @@ describe('Jellyfin Scanner', () => {
         'Show should be AVAILABLE when all non-empty TMDB seasons are fully scanned, ignoring empty placeholder seasons'
       );
     });
+
+    it('should mark show as available when an orphan UNKNOWN season exists in the DB but not in TMDB', async () => {
+      configureJellyfinWithLibrary();
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 5001;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PARTIALLY_AVAILABLE;
+      media.jellyfinMediaId = 'jf-orphan-show-id';
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        // Not present in the TMDB season list below
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.UNKNOWN,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () =>
+        fakeTmdbShow(5001, [
+          {
+            id: 1,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 1',
+            overview: '',
+            season_number: 1,
+          },
+        ]);
+
+      getLibraryContentsImpl = async (id: string) => {
+        if (id === 'test-library-id') {
+          return [fakeJellyfinSeriesItem('jf-orphan-show-id')];
+        }
+        return [];
+      };
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jf-orphan-show-id') {
+          return fakeJellyfinShowMetadata('jf-orphan-show-id', '5001');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jf-orphan-show-id') {
+          return [fakeJellyfinSeason(1, 'jf-orphan-s1-id')];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jf-orphan-s1-id') return fakeJellyfinEpisodes(10);
+        return [];
+      };
+
+      await jellyfinFullScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 5001 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.AVAILABLE,
+        'Show should be AVAILABLE when the only DB season missing from TMDB is an UNKNOWN orphan placeholder'
+      );
+    });
+
+    it('should keep show partially available when a season missing from TMDB was previously available', async () => {
+      configureJellyfinWithLibrary();
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 5002;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PARTIALLY_AVAILABLE;
+      media.jellyfinMediaId = 'jf-deleted-show-id';
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.DELETED,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      getTvShowImpl = async () =>
+        fakeTmdbShow(5002, [
+          {
+            id: 1,
+            air_date: '2024-01-01',
+            episode_count: 10,
+            name: 'Season 1',
+            overview: '',
+            season_number: 1,
+          },
+        ]);
+
+      getLibraryContentsImpl = async (id: string) => {
+        if (id === 'test-library-id') {
+          return [fakeJellyfinSeriesItem('jf-deleted-show-id')];
+        }
+        return [];
+      };
+
+      getItemDataImpl = async (id: string) => {
+        if (id === 'jf-deleted-show-id') {
+          return fakeJellyfinShowMetadata('jf-deleted-show-id', '5002');
+        }
+        return undefined;
+      };
+
+      getSeasonsImpl = async (seriesID: string) => {
+        if (seriesID === 'jf-deleted-show-id') {
+          return [fakeJellyfinSeason(1, 'jf-deleted-s1-id')];
+        }
+        return [];
+      };
+
+      getEpisodesImpl = async (_seriesID: string, seasonID: string) => {
+        if (seasonID === 'jf-deleted-s1-id') return fakeJellyfinEpisodes(10);
+        return [];
+      };
+
+      await jellyfinFullScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 5002 },
+        relations: ['seasons'],
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.PARTIALLY_AVAILABLE,
+        'Show should stay PARTIALLY_AVAILABLE when a DELETED season is missing from the metadata provider'
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description
This follows up on #3044, which made the scanner's availability rollup ignore season 0 (specials) when deciding if a show is fully available, since specials availability isn't a reliable signal and not every server/agent reports them consistently. However, that change only touched `baseScanner`, so `availabilitySync` was left checking season 0 like any other season.
A show could be scanned as AVAILABLE, then demoted to PARTIALLY_AVAILABLE by the next sync run because the specials season was missing from Sonarr/Plex/Jellyfin, then promoted back to AVAILABLE on the next scan, repeating indefinitely.

This PR makes availability sync consistent with the scanner: season 0 is excluded from the "is this show missing seasons" check, so it can no longer demote the show's overall status. A missing specials season can still be marked DELETED at the season level, it just won't drag the show down anymore.

Separately, this PR also fixes an unrelated bug in the scanner's rollup that #3044 introduced as a side effect. That PR changed the rollup to treat any season not present in the current scan as missing unless it had `totalEpisodes > 0`, with `?? Infinity` as the fallback for DB-only seasons. This meant that  a season that exists in the database but isn't returned by the metadata provider would always block the rollup. If such a row has status UNKNOWN (e.g. a placeholder created while TMDB briefly listed an upcoming season that was later removed), no future scan can ever revisit it, so the show gets pinned at PARTIALLY_AVAILABLE permanently. The rollup now only lets these DB-only seasons block availability if their status indicates they previously held content (AVAILABLE/PARTIALLY_AVAILABLE/DELETED) and UNKNOWN orphans are ignored, so the show can return to AVAILABLE.

**One thing worth flagging for later**: this still doesn't account for `enableSpecialEpisodes`. If that setting is on and someone specifically requests/monitors specials, a missing specials season still won't affect the show's overall status and this is the existing behavior in `baseScanner`, and this PR just makes availability sync consistent with it. Properly handling the setting would mean sharing one "does season 0 count" predicate between the scanner and availability sync, gated on `enableSpecialEpisodes`, rather than each having its own hardcoded skip. Left as a follow-up since it's a separate, more invasive change.

- Fixes #3129

## How Has This Been Tested?
- [X] Covered by the new unit tests added in this PR
- [x] Verified against my production instance with ~160 orphaned seasons affected by the rollup bug
- [x] Verified by the OP of #3129 against the specials-demotion fix (preview build available at `preview-sync-regression-fix`)

## Screenshots / Logs (if applicable)
Previously:
![Screenshot_20260611_034137_Chrome.jpg](https://github.com/user-attachments/assets/4ce5c9f6-de47-4f36-a080-a77f51785e94)

![Screenshot_20260611_034130_Chrome.jpg](https://github.com/user-attachments/assets/81446e6b-98fb-47b5-b399-d6b401ae00d6)

DB:
```
  id  | season_row_id | seasonNumber | status | status4k
------+---------------+--------------+--------+----------
 1965 |          2065 |            1 |      5 |        1
 1965 |          4182 |            2 |      1 |        1
(2 rows)
```

With this fix:
![Screenshot_20260611_061139_Chrome.jpg](https://github.com/user-attachments/assets/ec71b3a7-5b5c-4ef6-ae43-a4693a2b5b56)

![Screenshot_20260611_061130_Chrome.jpg](https://github.com/user-attachments/assets/3d7dce73-2fbd-4225-a777-9320fda137d6)


## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * TV shows with missing special seasons now maintain their "Available" status instead of being demoted to "Partially Available"
  * Refined season availability calculations for more accurate show status determination

* **Tests**
  * Added test coverage for special season handling in availability syncing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->