### PR TITLE
feat: add a customizable message for local login

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   env: {
     commitTag: process.env.COMMIT_TAG || 'local',
+    loginMessage: process.env.LOGIN_MESSAGE,
   },
   images: {
     remotePatterns: [

--- a/src/components/Login/LocalLogin.tsx
+++ b/src/components/Login/LocalLogin.tsx
@@ -1,3 +1,4 @@
+import Alert from '@app/components/Common/Alert';
 import Button from '@app/components/Common/Button';
 import SensitiveInput from '@app/components/Common/SensitiveInput';
 import useSettings from '@app/hooks/useSettings';
@@ -88,6 +89,10 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
                     appName: settings.currentSettings.applicationTitle,
                   })}
                 </h2>
+
+                {process.env.loginMessage && (
+                  <Alert type="info">{process.env.loginMessage}</Alert>
+                )}
 
                 <div className="mb-4 mt-1">
                   <div className="form-input-field">


### PR DESCRIPTION
## Description

This PR adds the possibility to add a customizable message displayed on the local login form. This will be useful to display the username/password of the upcoming Seerr online demo.

Re #3017

## How Has This Been Tested?

```bash
LOGIN_MESSAGE='Hello World!' pnpm dev
```

## Screenshots / Logs (if applicable)

<img width="1672" height="1008" alt="image" src="https://github.com/user-attachments/assets/70508071-aadb-49c7-9c07-18676d3980e9" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can now configure an informational alert message to display on the login page. This feature enables effectively communicating time-sensitive updates, maintenance notices, service announcements, or other important information directly to users when they access the login screen, improving transparency and communication during critical operational moments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->