### PR TITLE
feat: add webhook/non-polling based Plex media processing

### DIFF
--- a/docs/using-seerr/plex/index.md
+++ b/docs/using-seerr/plex/index.md
@@ -11,6 +11,7 @@ Seerr provides integration features that connect with your Plex media server to 
 ## Available Features
 
 - [Watchlist Auto Request](./watchlist-auto-request) - Automatically request media from your Plex Watchlist
+- [Recently Added Processing](#recently-added-processing) - Process newly added Plex media from external tools
 - More features coming soon!
 
 ## Prerequisites
@@ -34,3 +35,33 @@ To use any Plex integration features, you must have logged into Seerr at least o
 :::note Server Configuration
 Plex server configuration is handled by your administrator. If you cannot log in with your Plex account, contact your administrator to verify the server setup.
 :::
+
+## Recently Added Processing
+
+Seerr can process a recently added Plex item from an external tool such as Tautulli. Configure the tool to send a `POST` request to:
+
+```text
+https://seerr.example.com/api/v1/plex/recently-added
+```
+
+Include your Seerr API key as an HTTP header:
+
+```text
+X-Api-Key: YOUR_SEERR_API_KEY
+```
+
+The webhook body must be JSON and include the Plex rating key:
+
+```json
+{
+  "ratingKey": "12345"
+}
+```
+
+For Tautulli recently added notifications, configure a webhook notification using this custom JSON body:
+
+```json
+{
+  "ratingKey": "{rating_key}"
+}
+```

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -2455,6 +2455,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PlexSettings'
+  /plex/recently-added:
+    post:
+      summary: Process recently added Plex media
+      description: Processes a recently added Plex media item by rating key. This endpoint can be called by external tools such as Tautulli.
+      tags:
+        - plex
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ratingKey:
+                  type: string
+              required:
+                - ratingKey
+      responses:
+        '200':
+          description: Plex media was processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ratingKey:
+                    type: string
+                  type:
+                    type: string
+                  title:
+                    type: string
+        '400':
+          description: Plex rating key is missing
+        '500':
+          description: Plex media could not be processed
   /settings/plex/library:
     get:
       summary: Get Plex libraries

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -50,8 +50,11 @@ interface PlexLibrariesResponse {
 export interface PlexMetadata {
   ratingKey: string;
   parentRatingKey?: string;
+  grandparentRatingKey?: string;
   guid: string;
-  type: 'movie' | 'show' | 'season';
+  parentGuid?: string;
+  grandparentGuid?: string;
+  type: 'movie' | 'show' | 'season' | 'episode';
   title: string;
   Guid: {
     id: string;

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -159,6 +159,34 @@ class PlexScanner
     }
   }
 
+  public async processRatingKey(ratingKey: string): Promise<PlexMetadata> {
+    const userRepository = getRepository(User);
+    const admin = await userRepository.findOne({
+      select: { id: true, plexToken: true },
+      where: { id: 1 },
+    });
+
+    if (!admin) {
+      throw new Error('No admin configured. Plex media processing skipped.');
+    }
+
+    const settings = getSettings();
+    this.plexClient = new PlexAPI({ plexToken: admin.plexToken });
+    this.libraries = settings.plex.libraries.filter(
+      (library) => library.enabled
+    );
+
+    const hasHama = await this.hasHamaAgent();
+    if (hasHama) {
+      await animeList.sync();
+    }
+
+    const metadata = await this.plexClient.getMetadata(ratingKey);
+    await this.processItem(metadata);
+
+    return metadata;
+  }
+
   private async paginateLibrary(
     library: Library,
     { start = 0, sessionId }: { start?: number; sessionId: string }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -37,6 +37,7 @@ import issueCommentRoutes from './issueComment';
 import mediaRoutes from './media';
 import movieRoutes from './movie';
 import personRoutes from './person';
+import plexRoutes from './plex';
 import requestRoutes from './request';
 import searchRoutes from './search';
 import serviceRoutes from './service';
@@ -148,6 +149,7 @@ router.get(
   }
 );
 router.use('/settings', isAuthenticated(Permission.ADMIN), settingsRoutes);
+router.use('/plex', isAuthenticated(Permission.ADMIN), plexRoutes);
 router.use('/search', isAuthenticated(), searchRoutes);
 router.use('/discover', isAuthenticated(), discoverRoutes);
 router.use('/request', isAuthenticated(), requestRoutes);

--- a/server/routes/plex.ts
+++ b/server/routes/plex.ts
@@ -1,0 +1,39 @@
+import { plexRecentScanner } from '@server/lib/scanners/plex';
+import logger from '@server/logger';
+import { Router } from 'express';
+
+const plexRoutes = Router();
+
+plexRoutes.post('/recently-added', async (req, res, next) => {
+  const ratingKey = req.body?.ratingKey;
+
+  if (!ratingKey || typeof ratingKey !== 'string') {
+    return next({
+      status: 400,
+      message: 'Plex ratingKey is required.',
+    });
+  }
+
+  try {
+    const metadata = await plexRecentScanner.processRatingKey(ratingKey);
+
+    return res.status(200).json({
+      ratingKey: metadata.ratingKey,
+      type: metadata.type,
+      title: metadata.title,
+    });
+  } catch (e) {
+    logger.error('Failed to process pushed Plex recently added media', {
+      label: 'Plex Scan',
+      ratingKey,
+      errorMessage: e.message,
+    });
+
+    return next({
+      status: 500,
+      message: 'Unable to process Plex media.',
+    });
+  }
+});
+
+export default plexRoutes;


### PR DESCRIPTION
## Description

I started tracking metrics on how long it takes from the moment a show or movie is requested to the moment the user is notified it's available on Plex. One of the slowest parts of the pipeline is polling lag from Seerr polling Plex for new releases. **This PR adds a new endpoint, allowing Plex/Tautulli/anyone to notify Seerr when new content is added via webhook.**

Right now I have it set up so Tautulli pushes to Seerr. Tautulli holds a WebSocket connection to Plex so it already gets instant notifications. It is set up to wait ~15 seconds after seeing one episode, to wait for other episodes to settle, then it will send the HTTP request to Seerr.

In the future we could consider Seerr maintaining a similar WebSocket connection to Plex, which would mean everyone gets the benefit and no one has to configure Tautulli for it. I chose to implement the webhook method in this PR, which also lays groundwork for the WebSocket method if we were to want that in the future.

**AI Disclosure**: I used OpenAI Codex for the code in this PR. I have reviewed the code manually, and I have tested manually. All writing, other than the diff, is my own. 

## How Has This Been Tested?

I have been running it on my home instance. It cuts down time-to-email from ~3 minutes to 16 seconds, pretty consistently. You can see in the screenshot below. (15 of the 16 seconds is due to an intentional import delay in Tautulli, so it does not live in Seerr.)

Since this is net new code we don't have to worry about it causing bugs in other existing stuff.

## Screenshots
I have a Grafana dashboard showing software-induced latency in my requested media pipeline. The **red bars** are what we're interested in, which answers the question: after something is available on Plex, how long until they receive the email notification that it's available? 

At the top of this screenshot you can see downloads from **before** I added the webhook push. They routinely have latency of 2-5 minutes, because of the 5 minute polling interval. 

Towards the bottom you can see downloads from **after** I added the webhook push. 
<img width="1384" height="691" alt="Screenshot 2026-06-16 at 23 13 36" src="https://github.com/user-attachments/assets/9b78e4df-89fe-4f9c-851f-e6f398ad8a39" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. **Updated OpenAPI yaml file.**
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract` **No translation keys were added.**
- [ ] Database migration (if required) **No database migration was required.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Plex "Recently Added Processing" feature allowing external webhook tools (e.g., Tautulli) to trigger processing of newly added media items via a dedicated endpoint with required metadata.

* **Documentation**
  * Added comprehensive documentation for Recently Added Processing, including webhook configuration instructions, required authentication headers, and example templates for external tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->