### PR TITLE
feat(servarr): add removal and tag/season cleanup methods (1/5 removal requests)

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -270,6 +270,17 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
   public removeMovie = async (movieId: number): Promise<void> => {
     try {
       const { id, title } = await this.getMovieByTmdbId(movieId);
+      if (!id) {
+        // Movie is not in the Radarr library (e.g. already removed). Treat the
+        // desired end-state as reached so retries remain idempotent.
+        logger.info(
+          '[Radarr] Movie not present in library; nothing to remove',
+          {
+            tmdbId: movieId,
+          }
+        );
+        return;
+      }
       await this.axios.delete(`/movie/${id}`, {
         params: {
           deleteFiles: true,
@@ -281,6 +292,26 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
       throw new Error(`[Radarr] Failed to remove movie: ${e.message}`, {
         cause: e,
       });
+    }
+  };
+
+  public removeTagFromMovie = async (
+    tmdbId: number,
+    tagId: number
+  ): Promise<void> => {
+    try {
+      const movie = await this.getMovieByTmdbId(tmdbId);
+      const updatedTags = movie.tags.filter((t) => t !== tagId);
+      await this.axios.put(`/movie`, {
+        ...movie,
+        tags: updatedTags,
+      });
+      logger.info(`[Radarr] Removed tag ${tagId} from movie ${movie.title}`);
+    } catch (e) {
+      throw new Error(
+        `[Radarr] Failed to remove tag from movie: ${e.message}`,
+        { cause: e }
+      );
     }
   };
 

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -413,6 +413,15 @@ class SonarrAPI extends ServarrBase<{
   public removeSeries = async (serieId: number): Promise<void> => {
     try {
       const { id, title } = await this.getSeriesByTvdbId(serieId);
+      if (!id) {
+        // Series is not in the Sonarr library (e.g. already removed). Treat the
+        // desired end-state as reached so retries remain idempotent.
+        logger.info(
+          '[Sonarr] Series not present in library; nothing to remove',
+          { tvdbId: serieId }
+        );
+        return;
+      }
       await this.axios.delete(`/series/${id}`, {
         params: {
           deleteFiles: true,
@@ -422,6 +431,84 @@ class SonarrAPI extends ServarrBase<{
       logger.info(`[Sonarr] Removed series ${title}`);
     } catch (e) {
       throw new Error(`[Sonarr] Failed to remove series: ${e.message}`, {
+        cause: e,
+      });
+    }
+  };
+
+  public removeTagFromSeries = async (
+    tvdbId: number,
+    tagId: number
+  ): Promise<void> => {
+    try {
+      const series = await this.getSeriesByTvdbId(tvdbId);
+      if (!series.id) {
+        throw new Error('Series not found in Sonarr');
+      }
+      const updatedTags = series.tags.filter((t) => t !== tagId);
+      await this.axios.put(`/series/${series.id}`, {
+        ...series,
+        tags: updatedTags,
+      });
+      logger.info(`[Sonarr] Removed tag ${tagId} from series ${series.title}`);
+    } catch (e) {
+      throw new Error(
+        `[Sonarr] Failed to remove tag from series: ${e.message}`,
+        { cause: e }
+      );
+    }
+  };
+
+  public removeSeasonFiles = async (
+    tvdbId: number,
+    seasonNumbers: number[]
+  ): Promise<void> => {
+    try {
+      const series = await this.getSeriesByTvdbId(tvdbId);
+      if (!series.id) {
+        // Series is not in the Sonarr library (e.g. already removed). Treat the
+        // desired end-state as reached so retries remain idempotent.
+        logger.info(
+          '[Sonarr] Series not present in library; nothing to remove',
+          { tvdbId }
+        );
+        return;
+      }
+
+      const episodes = await this.getEpisodes(series.id);
+      const targetEpisodes = episodes.filter((ep) =>
+        seasonNumbers.includes(ep.seasonNumber)
+      );
+      const episodeFileIds = targetEpisodes
+        .filter((ep) => ep.hasFile && ep.episodeFileId > 0)
+        .map((ep) => ep.episodeFileId);
+
+      // Unmonitor the affected episodes before deleting files
+      const episodeIds = targetEpisodes.map((ep) => ep.id);
+      if (episodeIds.length > 0) {
+        await this.axios.put('/episode/monitor', {
+          episodeIds,
+          monitored: false,
+        });
+      }
+
+      // Delete episode files
+      for (const fileId of [...new Set(episodeFileIds)]) {
+        await this.axios.delete(`/episodefile/${fileId}`);
+      }
+
+      // Unmonitor the seasons
+      series.seasons = series.seasons.map((s) => ({
+        ...s,
+        monitored: seasonNumbers.includes(s.seasonNumber) ? false : s.monitored,
+      }));
+      await this.axios.put(`/series/${series.id}`, series);
+
+      logger.info(
+        `[Sonarr] Removed files for seasons ${seasonNumbers.join(', ')} of ${series.title}`
+      );
+    } catch (e) {
+      throw new Error(`[Sonarr] Failed to remove season files: ${e.message}`, {
         cause: e,
       });
     }


### PR DESCRIPTION
## Description

This is the first of a stacked series that splits the media removal request feature (originally #2828) into independently reviewable PRs, following the same approach as the Lidarr split (#3109).

This PR adds the **Servarr connectivity layer** only: new removal/cleanup helpers on the Radarr and Sonarr API clients. It is functionally stand-alone — it can be merged on its own with no behavioural change to the app, and is consumed by the later PRs in the series.

- **Radarr**: `removeMovie` is now idempotent (no-op when the movie is no longer in the library, so retries are safe); adds `removeTagFromMovie`.
- **Sonarr**: `removeSeries` is now idempotent; adds `removeTagFromSeries` and `removeSeasonFiles` (unmonitors the selected seasons/episodes and deletes their episode files).

### Stacked series (each opened against `develop` as the previous merges)
1. **servarr removal API** ← _this PR_
2. data model + permissions (entity, migrations, permission bits)
3. removal request API routes + tests + OpenAPI
4. removal request UI building blocks (RemovalRequestBlock, SeasonRemovalModal, detail-page entry)
5. wire-up into ManageSlideOver + RequestList

Tracking: #2828

## How Has This Been Tested?

- `pnpm typecheck` (server + client)
- `pnpm lint`
- Existing Radarr/Sonarr behaviour unchanged; new methods exercised as part of the removal stack (PR3 route tests).

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` — n/a (no UI strings)
- [ ] Database migration (if required) — n/a

## AI Assistance Notice

The mechanical splitting of the original branch into this stacked series, and drafting of this description, were done with assistance from Claude (Opus 4.8). All code is unchanged from the reviewed-by-author original feature branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to remove tags from movies
  * Added ability to remove tags from series
  * Added ability to remove season files from series

* **Bug Fixes**
  * Movie and series removal operations are now idempotent, gracefully handling cases where items are already removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->