### PR TITLE
fix(i18n): fallback to server locale for "Default" user lang in notifs

### DIFF
--- a/server/i18n/index.ts
+++ b/server/i18n/index.ts
@@ -1,4 +1,5 @@
 import { createIntl, createIntlCache } from '@formatjs/intl';
+import { getSettings } from '@server/lib/settings';
 import type { AvailableLocale } from '@server/types/languages';
 import { availableLocales } from '@server/types/languages';
 import fs from 'fs';
@@ -38,7 +39,10 @@ export function initI18n(): void {
 }
 
 export function getIntl(locale?: AvailableLocale): IntlInstance {
-  return intls.get(locale ?? 'en') || intls.get('en')!;
+  // "Default" stores a falsy locale, so fall back to the server language, then English
+  const serverLocale = getSettings().main.locale as AvailableLocale;
+  const resolved = locale || serverLocale || 'en';
+  return intls.get(resolved) || intls.get('en')!;
 }
 
 type MessageDescriptorMap<T extends Record<string, string>> = {


### PR DESCRIPTION
## Description

When a user's display language is set to "Default", their stored locale isan empty string, ignoring the server's configured application language.

Affects all per-user agents (email, Telegram, Pushbullet, Pushover,webpush, Discord with `useUserLocale: true`). Channel agents (Slack,
Gotify, ntfy, Discord with `useUserLocale: false`) pass an explicit localeand are unaffected, though they now also correctly fall back to the server
default if their configured locale is somehow empty.

- Fixes #3151

## How Has This Been Tested?
(no need)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default locale resolution to use server-configured settings instead of hardcoded fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->