### PR TITLE
fix(scanners): decline orphaned requests when media is removed from servarr

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -1,7 +1,12 @@
 import TheMovieDb from '@server/api/themoviedb';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
+import MediaRequest from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
@@ -635,6 +640,43 @@ class BaseScanner<T> {
         this.log(`Saved ${title}`);
       }
     });
+  }
+
+  /**
+   * Declines APPROVED requests bound to media that has been orphaned before completion.
+   * DECLINED clears the duplicate-request guard so the user can re-request it.
+   * Callers must load the requests relation on the media.
+   */
+  protected async declineOrphanedRequests(
+    media: Media,
+    is4k: boolean
+  ): Promise<void> {
+    if (media.requests === undefined) {
+      throw new Error(
+        `declineOrphanedRequests called for media ${media.id} without the 'requests' relation loaded`
+      );
+    }
+
+    const requestRepository = getRepository(MediaRequest);
+
+    const orphanedRequests = (media.requests ?? []).filter(
+      (request) =>
+        request.is4k === is4k && request.status === MediaRequestStatus.APPROVED
+    );
+
+    for (const request of orphanedRequests) {
+      request.status = MediaRequestStatus.DECLINED;
+      // Ensure that the media relation is set so the AfterUpdate
+      // notification hook can resolve it
+      request.media = media;
+      await requestRepository.save(request);
+      this.log(
+        `Declined orphaned ${
+          media.mediaType === MediaType.MOVIE ? 'movie' : 'series'
+        } request ${request.id} for ${media.tmdbId} not found in any Sonarr/Radarr server.`,
+        'info'
+      );
+    }
   }
 
   /**

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -28,6 +28,8 @@ class RadarrScanner
   private scanned4kTmdbIds: Set<number> = new Set();
   private didScanStandard = false;
   private didScan4k = false;
+  private serverReturnedEmpty = false;
+  private server4kReturnedEmpty = false;
 
   constructor() {
     super('Radarr Scan', { bundleSize: 50 });
@@ -50,6 +52,8 @@ class RadarrScanner
     this.scanned4kTmdbIds.clear();
     this.didScanStandard = false;
     this.didScan4k = false;
+    this.serverReturnedEmpty = false;
+    this.server4kReturnedEmpty = false;
 
     try {
       this.servers = uniqWith(settings.radarr, (radarrA, radarrB) => {
@@ -82,6 +86,18 @@ class RadarrScanner
             this.didScanStandard = true;
           }
 
+          if (this.items.length === 0) {
+            if (server4k) {
+              this.server4kReturnedEmpty = true;
+            } else {
+              this.serverReturnedEmpty = true;
+            }
+            this.log(
+              `Radarr server ${server.name} returned no movies. Orphan cleanup for this profile type will be skipped.`,
+              'warn'
+            );
+          }
+
           await this.loop(this.processRadarrMovie.bind(this), { sessionId });
         } else {
           this.log(`Sync not enabled. Skipping Radarr server: ${server.name}`);
@@ -103,6 +119,13 @@ class RadarrScanner
         this.didScanStandard = false;
       }
       if (!all4kScanned) {
+        this.didScan4k = false;
+      }
+
+      if (this.serverReturnedEmpty) {
+        this.didScanStandard = false;
+      }
+      if (this.server4kReturnedEmpty) {
         this.didScan4k = false;
       }
 
@@ -147,12 +170,14 @@ class RadarrScanner
     if (this.didScanStandard) {
       const processingMovies = await mediaRepository.find({
         where: { mediaType: MediaType.MOVIE, status: MediaStatus.PROCESSING },
+        relations: { requests: true },
       });
 
       for (const media of processingMovies) {
         if (!this.scannedTmdbIds.has(media.tmdbId)) {
           media.status = MediaStatus.UNKNOWN;
           await mediaRepository.save(media);
+          await this.declineOrphanedRequests(media, false);
           this.log(
             `Movie ${media.tmdbId} not found in any Radarr server. Status reset to UNKNOWN.`,
             'info'
@@ -172,12 +197,14 @@ class RadarrScanner
           mediaType: MediaType.MOVIE,
           status4k: MediaStatus.PROCESSING,
         },
+        relations: { requests: true },
       });
 
       for (const media of processing4kMovies) {
         if (!this.scanned4kTmdbIds.has(media.tmdbId)) {
           media.status4k = MediaStatus.UNKNOWN;
           await mediaRepository.save(media);
+          await this.declineOrphanedRequests(media, true);
           this.log(
             `Movie ${media.tmdbId} not found in any 4K Radarr server. 4K status reset to UNKNOWN.`,
             'info'

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -1,14 +1,20 @@
-import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
-
 import type { RadarrMovie } from '@server/api/servarr/radarr';
 import RadarrAPI from '@server/api/servarr/radarr';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
+import MediaRequest from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { radarrScanner } from '@server/lib/scanners/radarr';
 import type { RadarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
 
 let getMoviesImpl: () => Promise<RadarrMovie[]> = async () => [];
 Object.defineProperty(RadarrAPI.prototype, 'getMovies', {
@@ -19,7 +25,7 @@ Object.defineProperty(RadarrAPI.prototype, 'getMovies', {
   configurable: true,
 });
 
-import { radarrScanner } from '@server/lib/scanners/radarr';
+mock.method(MediaRequest, 'sendNotification', async () => undefined);
 
 setupTestDb();
 
@@ -235,8 +241,7 @@ describe('Radarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureRadarr([{ syncEnabled: true }]);
-      // Radarr returns empty meaning movie was deleted
-      getMoviesImpl = async () => [];
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
       await radarrScanner.run();
 
@@ -336,7 +341,7 @@ describe('Radarr Scanner', () => {
         if (callCount === 1) {
           return [fakeRadarrMovie({ tmdbId: 902, id: 10 })];
         }
-        return [];
+        return [fakeRadarrMovie({ tmdbId: 903, id: 11 })];
       };
 
       await radarrScanner.run();
@@ -365,7 +370,7 @@ describe('Radarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureRadarr([{ syncEnabled: true, is4k: true }]);
-      getMoviesImpl = async () => [];
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
       await radarrScanner.run();
 
@@ -394,6 +399,244 @@ describe('Radarr Scanner', () => {
         where: { tmdbId: 961 },
       });
       assert.strictEqual(updated.status4k, MediaStatus.AVAILABLE);
+    });
+  });
+
+  describe('orphaned request handling', () => {
+    it('declines the approved request and resets media to UNKNOWN when the movie is orphaned', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 1003596,
+          mediaType: MediaType.MOVIE,
+          status: MediaStatus.PROCESSING,
+        })
+      );
+
+      const settings = getSettings();
+      settings.radarr = [];
+      settings.sonarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.MOVIE,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
+
+      await radarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1003596 },
+      });
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.UNKNOWN);
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.DECLINED);
+    });
+
+    it('does not decline the request when the movie still exists in Radarr', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 700,
+          mediaType: MediaType.MOVIE,
+          status: MediaStatus.PROCESSING,
+        })
+      );
+
+      const settings = getSettings();
+      settings.radarr = [];
+      settings.sonarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.MOVIE,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
+      ];
+
+      await radarrScanner.run();
+
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.APPROVED);
+    });
+
+    it('skips cleanup and leaves the request approved when Radarr returns an empty list', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 1234,
+          mediaType: MediaType.MOVIE,
+          status: MediaStatus.PROCESSING,
+        })
+      );
+
+      const settings = getSettings();
+      settings.radarr = [];
+      settings.sonarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.MOVIE,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [];
+
+      await radarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1234 },
+      });
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.PROCESSING);
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.APPROVED);
+    });
+
+    it('declineOrphanedRequests throws when the requests relation is not loaded', async () => {
+      const media = new Media();
+      media.id = 1;
+      media.tmdbId = 123;
+      media.mediaType = MediaType.MOVIE;
+
+      await assert.rejects(
+        () =>
+          (
+            radarrScanner as unknown as {
+              declineOrphanedRequests: (
+                m: Media,
+                is4k: boolean
+              ) => Promise<void>;
+            }
+          ).declineOrphanedRequests(media, false),
+        /without the 'requests' relation loaded/
+      );
+    });
+
+    it('declines only the 4k request when the 4k dimension is orphaned but standard still exists', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 1003598,
+          mediaType: MediaType.MOVIE,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.PROCESSING,
+        })
+      );
+
+      const settings = getSettings();
+      settings.radarr = [];
+      settings.sonarr = [];
+      const standardRequest = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.MOVIE,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+      const fourKRequest = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.MOVIE,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: true,
+        })
+      );
+
+      configureRadarr([
+        { syncEnabled: true, id: 0, hostname: 'server-standard' },
+        { syncEnabled: true, id: 1, hostname: 'server-4k', is4k: true },
+      ]);
+
+      let callCount = 0;
+      getMoviesImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          // standard server still has the movie
+          return [
+            fakeRadarrMovie({
+              tmdbId: 1003598,
+              id: 42,
+              monitored: true,
+              hasFile: false,
+            }),
+          ];
+        }
+        // 4k server: populated but the movie is absent, so 4k dimension orphaned
+        return [fakeRadarrMovie({ tmdbId: 2, id: 88 })];
+      };
+
+      await radarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1003598 },
+      });
+      const updatedStandard = await requestRepository.findOneOrFail({
+        where: { id: standardRequest.id },
+      });
+      const updated4k = await requestRepository.findOneOrFail({
+        where: { id: fourKRequest.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.PROCESSING);
+      assert.strictEqual(updatedMedia.status4k, MediaStatus.UNKNOWN);
+      assert.strictEqual(updatedStandard.status, MediaRequestStatus.APPROVED);
+      assert.strictEqual(updated4k.status, MediaRequestStatus.DECLINED);
     });
   });
 });

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -36,6 +36,8 @@ class SonarrScanner
   private scanned4kTvdbIds: Set<number> = new Set();
   private didScanStandard = false;
   private didScan4k = false;
+  private serverReturnedEmpty = false;
+  private server4kReturnedEmpty = false;
 
   constructor() {
     super('Sonarr Scan', { bundleSize: 50 });
@@ -58,6 +60,8 @@ class SonarrScanner
     this.scanned4kTvdbIds.clear();
     this.didScanStandard = false;
     this.didScan4k = false;
+    this.serverReturnedEmpty = false;
+    this.server4kReturnedEmpty = false;
 
     try {
       this.servers = uniqWith(settings.sonarr, (sonarrA, sonarrB) => {
@@ -90,6 +94,18 @@ class SonarrScanner
             this.didScanStandard = true;
           }
 
+          if (this.items.length === 0) {
+            if (server4k) {
+              this.server4kReturnedEmpty = true;
+            } else {
+              this.serverReturnedEmpty = true;
+            }
+            this.log(
+              `Sonarr server ${server.name} returned no series. Orphan cleanup for this profile type will be skipped.`,
+              'warn'
+            );
+          }
+
           await this.loop(this.processSonarrSeries.bind(this), { sessionId });
         } else {
           this.log(`Sync not enabled. Skipping Sonarr server: ${server.name}`);
@@ -111,6 +127,13 @@ class SonarrScanner
         this.didScanStandard = false;
       }
       if (!all4kScanned) {
+        this.didScan4k = false;
+      }
+
+      if (this.serverReturnedEmpty) {
+        this.didScanStandard = false;
+      }
+      if (this.server4kReturnedEmpty) {
         this.didScan4k = false;
       }
 
@@ -218,7 +241,7 @@ class SonarrScanner
     if (this.didScanStandard) {
       const processingShows = await mediaRepository.find({
         where: { mediaType: MediaType.TV, status: MediaStatus.PROCESSING },
-        relations: ['seasons'],
+        relations: { seasons: true, requests: true },
       });
 
       for (const media of processingShows) {
@@ -230,6 +253,7 @@ class SonarrScanner
             }
           }
           await mediaRepository.save(media);
+          await this.declineOrphanedRequests(media, false);
           this.log(
             `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any Sonarr server. Status reset to UNKNOWN.`,
             'info'
@@ -246,7 +270,7 @@ class SonarrScanner
     if (this.didScan4k) {
       const processing4kShows = await mediaRepository.find({
         where: { mediaType: MediaType.TV, status4k: MediaStatus.PROCESSING },
-        relations: ['seasons'],
+        relations: { seasons: true, requests: true },
       });
 
       for (const media of processing4kShows) {
@@ -258,6 +282,7 @@ class SonarrScanner
             }
           }
           await mediaRepository.save(media);
+          await this.declineOrphanedRequests(media, true);
           this.log(
             `Show ${media.tmdbId} (tvdb: ${media.tvdbId}) not found in any 4K Sonarr server. 4K status reset to UNKNOWN.`,
             'info'

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -5,15 +5,22 @@ import type {
   TmdbTvDetails,
   TmdbTvSeasonResult,
 } from '@server/api/themoviedb/interfaces';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
+import MediaRequest from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
+import { User } from '@server/entity/User';
+import { sonarrScanner } from '@server/lib/scanners/sonarr';
 import type { SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
 import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
+import { beforeEach, describe, it, mock } from 'node:test';
 
 let getSeriesImpl: () => Promise<SonarrSeries[]> = async () => [];
 Object.defineProperty(SonarrAPI.prototype, 'getSeries', {
@@ -96,7 +103,7 @@ Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
   configurable: true,
 });
 
-import { sonarrScanner } from '@server/lib/scanners/sonarr';
+mock.method(MediaRequest, 'sendNotification', async () => undefined);
 
 setupTestDb();
 
@@ -214,7 +221,7 @@ describe('Sonarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureSonarr([{ syncEnabled: true }]);
-      getSeriesImpl = async () => [];
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
       await sonarrScanner.run();
 
@@ -328,7 +335,7 @@ describe('Sonarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureSonarr([{ syncEnabled: true }]);
-      getSeriesImpl = async () => [];
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
       await sonarrScanner.run();
 
@@ -400,14 +407,7 @@ describe('Sonarr Scanner', () => {
         { syncEnabled: true, id: 1, hostname: 'server-b' },
       ]);
 
-      let callCount = 0;
-      getSeriesImpl = async () => {
-        callCount++;
-        if (callCount === 2) {
-          return [fakeSonarrSeries({ tvdbId: 511 })];
-        }
-        return [];
-      };
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 511 })];
 
       getShowByTvdbIdImpl = async () => fakeTmdbShow(2);
       getTvShowImpl = async () => fakeTmdbShow(2);
@@ -438,7 +438,7 @@ describe('Sonarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureSonarr([{ syncEnabled: true }]);
-      getSeriesImpl = async () => [];
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
       await sonarrScanner.run();
 
@@ -469,7 +469,7 @@ describe('Sonarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureSonarr([{ syncEnabled: true, is4k: true }]);
-      getSeriesImpl = async () => [];
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
       await sonarrScanner.run();
 
@@ -505,7 +505,7 @@ describe('Sonarr Scanner', () => {
       await mediaRepository.save(media);
 
       configureSonarr([{ syncEnabled: true, is4k: true }]);
-      getSeriesImpl = async () => [];
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
       await sonarrScanner.run();
 
@@ -517,6 +517,309 @@ describe('Sonarr Scanner', () => {
       const s2 = updated.seasons.find((s) => s.seasonNumber === 2);
       assert.strictEqual(s1?.status4k, MediaStatus.AVAILABLE);
       assert.strictEqual(s2?.status4k, MediaStatus.UNKNOWN);
+    });
+  });
+
+  describe('orphaned request handling', () => {
+    it('declines the approved request and resets the show to UNKNOWN when orphaned', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 2000,
+          tvdbId: 555,
+          mediaType: MediaType.TV,
+          status: MediaStatus.PROCESSING,
+          seasons: [
+            new Season({
+              seasonNumber: 1,
+              status: MediaStatus.PROCESSING,
+              status4k: MediaStatus.UNKNOWN,
+            }),
+          ],
+        })
+      );
+
+      const settings = getSettings();
+      settings.sonarr = [];
+      settings.radarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
+
+      await sonarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 2000 },
+      });
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.UNKNOWN);
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.DECLINED);
+    });
+
+    it('does not decline the request when the show still exists in Sonarr', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 2001,
+          tvdbId: 600,
+          mediaType: MediaType.TV,
+          status: MediaStatus.PROCESSING,
+          seasons: [
+            new Season({
+              seasonNumber: 1,
+              status: MediaStatus.PROCESSING,
+              status4k: MediaStatus.UNKNOWN,
+            }),
+          ],
+        })
+      );
+
+      const settings = getSettings();
+      settings.sonarr = [];
+      settings.radarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [
+        fakeSonarrSeries({
+          tvdbId: 600,
+          seasons: [
+            {
+              seasonNumber: 1,
+              monitored: true,
+              statistics: {
+                episodeFileCount: 0,
+                totalEpisodeCount: 10,
+                episodeCount: 10,
+                percentOfEpisodes: 0,
+                sizeOnDisk: 0,
+                previousAiring: undefined,
+              },
+            },
+          ],
+        }),
+      ];
+      getShowByTvdbIdImpl = async () => fakeTmdbShow(2001);
+      getTvShowImpl = async () => fakeTmdbShow(2001);
+
+      await sonarrScanner.run();
+
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.APPROVED);
+    });
+
+    it('skips cleanup and leaves the request approved when Sonarr returns an empty list', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 2005,
+          tvdbId: 605,
+          mediaType: MediaType.TV,
+          status: MediaStatus.PROCESSING,
+          seasons: [
+            new Season({
+              seasonNumber: 1,
+              status: MediaStatus.PROCESSING,
+              status4k: MediaStatus.UNKNOWN,
+            }),
+          ],
+        })
+      );
+
+      const settings = getSettings();
+      settings.sonarr = [];
+      settings.radarr = [];
+      const request = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [];
+
+      await sonarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 2005 },
+      });
+      const updatedRequest = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.PROCESSING);
+      assert.strictEqual(updatedRequest.status, MediaRequestStatus.APPROVED);
+    });
+
+    it('declineOrphanedRequests throws when the requests relation is not loaded', async () => {
+      const media = new Media();
+      media.id = 1;
+      media.tmdbId = 123;
+      media.mediaType = MediaType.TV;
+
+      await assert.rejects(
+        () =>
+          (
+            sonarrScanner as unknown as {
+              declineOrphanedRequests: (
+                m: Media,
+                is4k: boolean
+              ) => Promise<void>;
+            }
+          ).declineOrphanedRequests(media, false),
+        /without the 'requests' relation loaded/
+      );
+    });
+
+    it('declines only the 4k request when the 4k dimension is orphaned but standard still exists', async () => {
+      const mediaRepository = getRepository(Media);
+      const requestRepository = getRepository(MediaRequest);
+      const userRepository = getRepository(User);
+
+      const requestedBy = await userRepository.findOneOrFail({
+        where: { id: 1 },
+      });
+
+      const media = await mediaRepository.save(
+        new Media({
+          tmdbId: 2002,
+          tvdbId: 666,
+          mediaType: MediaType.TV,
+          status: MediaStatus.PROCESSING,
+          status4k: MediaStatus.PROCESSING,
+          seasons: [
+            new Season({
+              seasonNumber: 1,
+              status: MediaStatus.PROCESSING,
+              status4k: MediaStatus.PROCESSING,
+            }),
+          ],
+        })
+      );
+
+      const settings = getSettings();
+      settings.sonarr = [];
+      settings.radarr = [];
+      const standardRequest = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: false,
+        })
+      );
+      const fourKRequest = await requestRepository.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.APPROVED,
+          media,
+          requestedBy,
+          is4k: true,
+        })
+      );
+
+      configureSonarr([
+        { syncEnabled: true, id: 0, hostname: 'server-standard' },
+        { syncEnabled: true, id: 1, hostname: 'server-4k', is4k: true },
+      ]);
+
+      let callCount = 0;
+      getSeriesImpl = async () => {
+        callCount++;
+        if (callCount === 1) {
+          // standard server still has the show (processing, no files)
+          return [
+            fakeSonarrSeries({
+              tvdbId: 666,
+              seasons: [
+                {
+                  seasonNumber: 1,
+                  monitored: true,
+                  statistics: {
+                    episodeFileCount: 0,
+                    totalEpisodeCount: 10,
+                    episodeCount: 10,
+                    percentOfEpisodes: 0,
+                    sizeOnDisk: 0,
+                    previousAiring: undefined,
+                  },
+                },
+              ],
+            }),
+          ];
+        }
+        // 4k server: populated but the show is absent, so 4k dimension orphaned
+        return [fakeSonarrSeries({ tvdbId: 997 })];
+      };
+
+      getShowByTvdbIdImpl = async ({ tvdbId }) =>
+        tvdbId === 666 ? fakeTmdbShow(2002) : fakeTmdbShow(997);
+      getTvShowImpl = async ({ tvId }) => fakeTmdbShow(tvId);
+
+      await sonarrScanner.run();
+
+      const updatedMedia = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 2002 },
+      });
+      const updatedStandard = await requestRepository.findOneOrFail({
+        where: { id: standardRequest.id },
+      });
+      const updated4k = await requestRepository.findOneOrFail({
+        where: { id: fourKRequest.id },
+      });
+
+      assert.strictEqual(updatedMedia.status, MediaStatus.PROCESSING);
+      assert.strictEqual(updatedMedia.status4k, MediaStatus.UNKNOWN);
+      assert.strictEqual(updatedStandard.status, MediaRequestStatus.APPROVED);
+      assert.strictEqual(updated4k.status, MediaRequestStatus.DECLINED);
     });
   });
 });


### PR DESCRIPTION
## Description

This fixes a stuck state where a movie/show shows a Request button but blocks the request as a duplicate.

When an approved request is sent to Radarr/Sonarr and the entry later disappears before completion (manual removal, DB rebuild, list cleanup), the orphan cleanup from #2757 resets the media to UNKNOWN but doesn't touch the request. The request stays APPROVED, so the duplicate-request guard keeps blocking re-requests while the media page renders as un-requested and the user can neither see it as requested nor request it again.

Cleanup now declines the approved requests bound to the orphaned media. DECLINED is the correct terminal state here (the request's fulfilment was abandoned) and it's the one status that clears the duplicate guard, so the user can simply request again. The decline runs through the normal request path, so the standard **`MEDIA_DECLINED` notification fires**, which is still appropriate here, since removing an in-flight item from the servarr is an implicit cancellation.

This PR also adds an empty-scan guard. If a server returns an empty list, orphan cleanup for that profile type is skipped. A servarr mid-rebuild serving `200 []` would otherwise look like "every movie was deleted" and mass-orphan (and now mass-decline) the whole library. Genuinely-deleted items are still cleaned up on the next scan once the servarr is populated again.

Orphan cleanup no longer treats an empty servarr response as "everything deleted." Existing tests that encoded deletion as an empty list were updated to use a populated scan missing the target instead.

## How Has This Been Tested?

(Only via unit tests)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) (for unit tests)
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically decline approved media requests for orphaned movies and TV shows when they are no longer found on the scanner service, including both standard and 4K variants.

* **Tests**
  * Added comprehensive test coverage for orphaned request handling across scanner types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->