### PR TITLE
fix(proxy): proxy clients built before proxy init

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -1,4 +1,4 @@
-import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
+import { proxyRequestInterceptor } from '@server/utils/customProxyAgent';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import rateLimit from 'axios-rate-limit';
@@ -40,7 +40,7 @@ class ExternalAPI {
         ...options.headers,
       },
     });
-    this.axios.interceptors.request.use(requestInterceptorFunction);
+    this.axios.interceptors.request.use(proxyRequestInterceptor);
 
     if (options.rateLimit) {
       this.axios = rateLimit(this.axios, {

--- a/server/api/tautulli.ts
+++ b/server/api/tautulli.ts
@@ -1,7 +1,7 @@
 import type { User } from '@server/entity/User';
 import type { TautulliSettings } from '@server/lib/settings';
 import logger from '@server/logger';
-import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
+import { proxyRequestInterceptor } from '@server/utils/customProxyAgent';
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
 import { uniqWith } from 'lodash';
@@ -124,7 +124,7 @@ class TautulliAPI {
       }${settings.urlBase ?? ''}`,
       params: { apikey: settings.apiKey },
     });
-    this.axios.interceptors.request.use(requestInterceptorFunction);
+    this.axios.interceptors.request.use(proxyRequestInterceptor);
   }
 
   public async getInfo(): Promise<TautulliInfo> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,11 +26,12 @@ import avatarproxy from '@server/routes/avatarproxy';
 import imageproxy from '@server/routes/imageproxy';
 import { appDataPermissions } from '@server/utils/appDataVolume';
 import { getAppVersion } from '@server/utils/appVersion';
-import createCustomProxyAgent from '@server/utils/customProxyAgent';
+import createCustomProxyAgent, {
+  setForceIpv4First,
+} from '@server/utils/customProxyAgent';
 import { initializeDnsCache } from '@server/utils/dnsCache';
 import restartFlag from '@server/utils/restartFlag';
 import { getClientIp } from '@supercharge/request-ip';
-import axios from 'axios';
 import { TypeormStore } from 'connect-typeorm/out';
 import cookieParser from 'cookie-parser';
 import type { NextFunction, Request, Response } from 'express';
@@ -39,8 +40,6 @@ import * as OpenApiValidator from 'express-openapi-validator';
 import type { Store } from 'express-session';
 import session from 'express-session';
 import fs from 'fs/promises';
-import http from 'http';
-import https from 'https';
 import yaml from 'js-yaml';
 import next from 'next';
 import path from 'path';
@@ -86,10 +85,7 @@ app
 
     initI18n();
 
-    if (settings.network.forceIpv4First) {
-      axios.defaults.httpAgent = new http.Agent({ family: 4 });
-      axios.defaults.httpsAgent = new https.Agent({ family: 4 });
-    }
+    setForceIpv4First(settings.network.forceIpv4First);
 
     // Add DNS caching
     if (settings.network.dnsCache?.enabled) {

--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -1,5 +1,5 @@
 import logger from '@server/logger';
-import { requestInterceptorFunction } from '@server/utils/customProxyAgent';
+import { proxyRequestInterceptor } from '@server/utils/customProxyAgent';
 import axios, { type AxiosInstance } from 'axios';
 import rateLimit, { type rateLimitOptions } from 'axios-rate-limit';
 import { createHash } from 'crypto';
@@ -147,7 +147,7 @@ class ImageProxy {
       baseURL: baseUrl,
       headers: options.headers,
     });
-    this.axios.interceptors.request.use(requestInterceptorFunction);
+    this.axios.interceptors.request.use(proxyRequestInterceptor);
 
     if (options.rateLimitOptions) {
       this.axios = rateLimit(this.axios, options.rateLimitOptions);

--- a/server/utils/customProxyAgent.test.ts
+++ b/server/utils/customProxyAgent.test.ts
@@ -1,0 +1,72 @@
+import ExternalAPI from '@server/api/externalapi';
+import type { ProxySettings } from '@server/lib/settings';
+import createCustomProxyAgent from '@server/utils/customProxyAgent';
+import axios, {
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+class TestExternalAPI extends ExternalAPI {
+  public constructor() {
+    super('https://api.themoviedb.org/3', {}, {});
+  }
+
+  public async resolvedHttpsAgent(path = '/movie/123'): Promise<unknown> {
+    let captured: InternalAxiosRequestConfig | undefined;
+    this.axios.defaults.adapter = (config) => {
+      captured = config;
+      return Promise.resolve({
+        data: {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+        request: {},
+      } as AxiosResponse);
+    };
+    await this.axios.get(path);
+    return captured?.httpsAgent;
+  }
+}
+
+// constructed before any test configures the proxy, like BaseScanner.tmdb
+const preProxyClient = new TestExternalAPI();
+
+const proxySettings: ProxySettings = {
+  enabled: true,
+  hostname: 'proxy.test',
+  port: 3128,
+  useSsl: false,
+  user: '',
+  password: '',
+  bypassFilter: '*.bypass.test',
+  bypassLocalAddresses: true,
+};
+
+describe('proxy routing (construction-order independence)', () => {
+  beforeEach(() => {
+    mock.method(axios, 'head', async () => ({ status: 200 }));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it('routes a client constructed BEFORE the proxy was configured', async () => {
+    await createCustomProxyAgent(proxySettings);
+    const agent = await preProxyClient.resolvedHttpsAgent();
+    assert.ok(
+      agent instanceof HttpsProxyAgent,
+      'client created before proxy setup must still route through the proxy'
+    );
+  });
+
+  it('routes a client constructed AFTER the proxy was configured', async () => {
+    await createCustomProxyAgent(proxySettings);
+    const agent = await new TestExternalAPI().resolvedHttpsAgent();
+    assert.ok(agent instanceof HttpsProxyAgent);
+  });
+});

--- a/server/utils/customProxyAgent.ts
+++ b/server/utils/customProxyAgent.ts
@@ -162,7 +162,6 @@ export default async function createCustomProxyAgent(
       'Failed to connect to the proxy: ' + e.message + ': ' + e.cause,
       { label: 'Proxy' }
     );
-    setGlobalDispatcher(defaultAgent);
   }
 }
 

--- a/server/utils/customProxyAgent.ts
+++ b/server/utils/customProxyAgent.ts
@@ -1,14 +1,66 @@
 import type { ProxySettings } from '@server/lib/settings';
 import logger from '@server/logger';
-import axios, { type InternalAxiosRequestConfig } from 'axios';
+import type { InternalAxiosRequestConfig } from 'axios';
+import axios from 'axios';
+import http from 'http';
 import { HttpProxyAgent } from 'http-proxy-agent';
+import https from 'https';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import type { Dispatcher } from 'undici';
 import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 
-export let requestInterceptorFunction: (
+interface ProxyState {
+  httpAgent: HttpProxyAgent<string>;
+  httpsAgent: HttpsProxyAgent<string>;
+  skipUrl: (url: string | URL) => boolean;
+}
+
+let proxyState: ProxyState | null = null;
+let ipv4Agents: { httpAgent: http.Agent; httpsAgent: https.Agent } | null =
+  null;
+
+export function setForceIpv4First(enabled: boolean) {
+  ipv4Agents = enabled
+    ? {
+        httpAgent: new http.Agent({ family: 4 }),
+        httpsAgent: new https.Agent({ family: 4 }),
+      }
+    : null;
+}
+
+export function proxyRequestInterceptor(
   config: InternalAxiosRequestConfig
-) => InternalAxiosRequestConfig;
+): InternalAxiosRequestConfig {
+  let url: URL | undefined;
+  try {
+    if (config.baseURL) {
+      url = new URL(config.url ?? '', config.baseURL);
+    } else if (config.url) {
+      url = new URL(config.url);
+    }
+  } catch {
+    url = undefined;
+  }
+
+  if (proxyState) {
+    if (url && proxyState.skipUrl(url)) {
+      config.httpAgent = ipv4Agents?.httpAgent ?? false;
+      config.httpsAgent = ipv4Agents?.httpsAgent ?? false;
+    } else {
+      config.httpAgent = proxyState.httpAgent;
+      config.httpsAgent = proxyState.httpsAgent;
+    }
+    config.proxy = false;
+  } else if (ipv4Agents) {
+    config.httpAgent = ipv4Agents.httpAgent;
+    config.httpsAgent = ipv4Agents.httpsAgent;
+  }
+
+  return config;
+}
+
+// default instance only, axios.create() clients register this themselves
+axios.interceptors.request.use(proxyRequestInterceptor);
 
 export default async function createCustomProxyAgent(
   proxySettings: ProxySettings,
@@ -87,25 +139,18 @@ export default async function createCustomProxyAgent(
       scheduling: 'lifo' as const,
       family: forceIpv4First ? 4 : undefined,
     };
-    axios.defaults.httpAgent = new HttpProxyAgent(proxyUrl, agentOptions);
-    axios.defaults.httpsAgent = new HttpsProxyAgent(proxyUrl, agentOptions);
 
-    requestInterceptorFunction = (config) => {
-      const url = config.baseURL
-        ? new URL(config.baseURL + (config.url || ''))
-        : config.url;
-      if (url && skipUrl(url)) {
-        config.httpAgent = false;
-        config.httpsAgent = false;
-      }
-      return config;
+    proxyState = {
+      httpAgent: new HttpProxyAgent(proxyUrl, agentOptions),
+      httpsAgent: new HttpsProxyAgent(proxyUrl, agentOptions),
+      skipUrl,
     };
-    axios.interceptors.request.use(requestInterceptorFunction);
   } catch (e) {
     logger.error('Failed to connect to the proxy: ' + e.message, {
       label: 'Proxy',
     });
     setGlobalDispatcher(defaultAgent);
+    proxyState = null;
     return;
   }
 


### PR DESCRIPTION
## Description

TLDR; **proxy was only being applied to axios clients created after startup. The scanners' TMDB client is created at import, before the proxy is set up, so it never got it and went direct connection.** (This is for @gauthier-th 's benefit)


When a proxy is configured under Settings > Network, only part of Seerr's outbound traffic went through it. Plex and anything issued per-request after startup were proxied, but TMDB lookups during library scans, IMDb ratings, and similar requests bypassed the proxy and went straight out. That breaks setups with a strict outbound firewall and produces failed scans with nothing in the proxy logs.

The issue is the construction timing. All outbound HTTP goes through `axios`, and `axios` is only proxied via the per-instance `httpAgent`/`httpsAgent`. `axios.create()` snapshots `axios.defaults` when the instance is built and never re-reads it, so an instance created before the proxy is configured carries no proxy agent for its whole lifetime. `createCustomProxyAgent` runs in the async startup block in `server/index.ts`, but some clients are built earlier at module-import time, specifically the `tmdb` field on `BaseScanner` (which is shared by the Sonarr, Radarr, Plex, and Jellyfin scanners) and on `availabilitySync`, since those singletons sit at the top of the import graph. They snapshot an empty agent and bypass the proxy forever. Clients created per request after startup inherit the proxy, which is why only some traffic showed up in the logs.

This PR fixes this by not binding the proxy to the axios instance at construction. Proxy config now lives in a mutable module-level holder, and one stable interceptor resolves the agent per request from that holder. It's registered once on the default axios instance and once per ExternalAPI client, replacing the old late-bound interceptor that was undefined for any client built before setup. Since the agent is chosen at request time, an instance built before the proxy is configured routes through it as soon as it's enabled.

`forceIpv4First` had the same latent defect (it set agents on `axios.defaults` in the same async block), so it moves onto the same per-request resolution. Bypass-filter and local-address behavior are unchanged, env-var proxying is disabled when the in-app proxy is active, and on a proxy health-check failure the proxy state is kept instead of silently falling back to a blocked direct connection.



One thing the unit test doesn't cover is live transport through an axios-rate-limit client. The interceptor runs before axios-rate-limit wraps the adapter, so the resolved agent is preserved, but I checked that separately against a local proxy instead of adding a port-binding, timing-sensitive test to the suite.
- Fixes #3193

## How Has This Been Tested?

- [X] I confirmed this with a test rather than by testing it manually.
It builds an ExternalAPI client at import time, before the proxy is configured, then detects proxying by swapping in a stub axios adapter and reading the exact agent axios would hand to the transport, so it needs no network. 

**On develop the test fails**. The pre-existing client resolves no proxy agent and would go direct. A second client built after the proxy is configured passes on develop, ruling out a test that just always fails and showing the post-startup path was never broken. 
<img width="1437" height="952" alt="image" src="https://github.com/user-attachments/assets/08929e93-1055-4114-95a5-66beb4597dc0" />

After this fix is applied the test passes:
<img width="946" height="451" alt="image" src="https://github.com/user-attachments/assets/0db27d59-fc6d-4bee-ae64-570eaf6603f6" />

- [X] This fix can also be tested via the `preview-proxy-bypass-fix`. This was tested by the OP of the bug report (see, https://github.com/seerr-team/seerr/issues/3193#issuecomment-4783139458)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features / Refactor**
  * Unified proxy request handling across outgoing Axios requests using a shared interceptor.
  * Centralized “force IPv4 first” behavior so it’s applied at startup and respects proxy bypass rules.

* **Bug Fixes**
  * Improved proxy routing consistency regardless of when HTTP clients are created.

* **Tests**
  * Added coverage to verify proxy routing is independent of client construction order and that connectivity checks behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->