### PR TITLE
fix(discover): use added sort in recent requests slider

### DIFF
--- a/src/components/Discover/RecentRequestsSlider/index.tsx
+++ b/src/components/Discover/RecentRequestsSlider/index.tsx
@@ -22,7 +22,7 @@ const RecentRequestsSlider = () => {
   const { hasPermission } = useUser();
   const { data: requests, error: requestError } =
     useSWR<RequestResultsResponse>(
-      '/api/v1/request?filter=all&take=10&sort=modified&skip=0',
+      '/api/v1/request?filter=all&take=10&sort=added&skip=0',
       {
         revalidateOnMount: true,
       }


### PR DESCRIPTION
## Description

The recent requests slider on the discover page was using `sort=modified`, which sorts by `updatedAt`. Since `updatedAt` is an `@UpdateDateColumn` that gets bumped whenever a request entity is saved, scanner-driven status transitions (availability sync, bulk deletions setting media to DELETED) would silently reorder the slider by floating affected requests to the top. 

This PR changes the sort to added, which uses `createdAt` and reflects actual submission order, consistent with what "Recent Requests" implies.

## How Has This Been Tested?

(dont need to)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ordering of recent requests so items now appear based on when they were added, rather than when they were last modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->