### PR TITLE
fix: prevent cross-instance external ID collisions

### DIFF
--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -8,6 +8,8 @@ import type {
 import JellyfinAPI from '@server/api/jellyfin';
 import type { PlexMetadata } from '@server/api/plexapi';
 import PlexAPI from '@server/api/plexapi';
+import type { RadarrMovie } from '@server/api/servarr/radarr';
+import RadarrAPI from '@server/api/servarr/radarr';
 import type { SonarrSeason, SonarrSeries } from '@server/api/servarr/sonarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
 import TheMovieDb from '@server/api/themoviedb';
@@ -21,7 +23,7 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
-import type { SonarrSettings } from '@server/lib/settings';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
 
@@ -117,6 +119,19 @@ let getSeriesByIdImpl: (id: number) => Promise<SonarrSeries> = async () => {
 Object.defineProperty(SonarrAPI.prototype, 'getSeriesById', {
   get() {
     return async (id: number) => getSeriesByIdImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+// --- Mock RadarrAPI ---
+let getMovieImpl: (id: number) => Promise<RadarrMovie> = async () => {
+  throw new Error('404');
+};
+
+Object.defineProperty(RadarrAPI.prototype, 'getMovie', {
+  get() {
+    return async ({ id }: { id: number }) => getMovieImpl(id);
   },
   set() {},
   configurable: true,
@@ -232,6 +247,33 @@ function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
     ...o,
   })) as SonarrSettings[];
   settings.radarr = [];
+}
+
+function configureRadarr(overrides: Partial<RadarrSettings>[] = [{}]): void {
+  const settings = getSettings();
+  settings.radarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Radarr ${i}`,
+    hostname: 'localhost',
+    port: 7878,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeProfileName: 'Default',
+    activeDirectory: '/movies',
+    minimumAvailability: 'released',
+    tags: [],
+    is4k: false,
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    tagRequests: false,
+    overrideRule: [],
+    externalUrl: '',
+    ...o,
+  })) as RadarrSettings[];
+  settings.sonarr = [];
 }
 
 function configureJellyfin(): void {
@@ -386,6 +428,9 @@ describe('AvailabilitySync', () => {
     };
     getChildrenMetadataImpl = async () => [];
     getSeriesByIdImpl = async () => {
+      throw new Error('404');
+    };
+    getMovieImpl = async () => {
       throw new Error('404');
     };
     getTvShowImpl = async ({ tvId }) =>
@@ -1000,6 +1045,86 @@ describe('AvailabilitySync', () => {
       );
     });
 
+    it('should mark a deleted show as DELETED when a second standard Sonarr instance has a colliding externalServiceId', async () => {
+      configurePlex();
+      configureSonarr([{ syncEnabled: true }, { syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 3000;
+      media.tvdbId = 73255;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.AVAILABLE;
+      media.ratingKey = 'gone-from-plex-rk';
+      media.externalServiceId = 200;
+      media.serviceId = 0;
+      media.seasons = [
+        new Season({
+          seasonNumber: 1,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+        new Season({
+          seasonNumber: 2,
+          status: MediaStatus.AVAILABLE,
+          status4k: MediaStatus.UNKNOWN,
+        }),
+      ];
+
+      await mediaRepository.save(media);
+
+      // Probed once per standard instance with the same id (200): origin 404s
+      // (deleted); the other instance has a different series at 200.
+      let sonarrCall = 0;
+      getSeriesByIdImpl = async (id: number) => {
+        if (id !== 200) {
+          throw new Error('404');
+        }
+        sonarrCall += 1;
+        if (sonarrCall === 1) {
+          throw new Error('404');
+        }
+        return {
+          tvdbId: 999999,
+          id: 200,
+          title: 'Unrelated Colliding Series',
+          titleSlug: 'unrelated-colliding-series',
+          monitored: true,
+          statistics: {
+            episodeFileCount: 12,
+            totalEpisodeCount: 12,
+            episodeCount: 12,
+            percentOfEpisodes: 100,
+            sizeOnDisk: 0,
+            seasonCount: 1,
+          },
+          seasons: fakeSonarrSeasons(1, { 1: 12 }),
+        } as unknown as SonarrSeries;
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 3000 },
+        relations: ['seasons'],
+      });
+
+      for (const season of updated.seasons) {
+        assert.strictEqual(
+          season.status,
+          MediaStatus.DELETED,
+          `Season ${season.seasonNumber} should be DELETED (collision must not keep it available) but was ${season.status}`
+        );
+      }
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.DELETED,
+        'Show deleted from its origin instance and Plex must not be kept alive by a colliding externalServiceId on another standard instance'
+      );
+    });
+
     it('should assume season exists when getChildrenMetadata fails for episodes (safe fallback)', async () => {
       configurePlex();
       configureSonarr([{ syncEnabled: true }]);
@@ -1164,6 +1289,56 @@ describe('AvailabilitySync', () => {
         updated.status,
         MediaStatus.PARTIALLY_AVAILABLE,
         'Show should be PARTIALLY_AVAILABLE after season removal'
+      );
+    });
+  });
+
+  describe('movie availability - Radarr', () => {
+    it('should mark a deleted movie as DELETED when a second standard Radarr instance has a colliding externalServiceId', async () => {
+      configurePlex();
+      configureRadarr([{ syncEnabled: true }, { syncEnabled: true }]);
+
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 5000;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.AVAILABLE;
+      media.ratingKey = 'gone-from-plex-rk';
+      media.externalServiceId = 300;
+      media.serviceId = 0;
+
+      await mediaRepository.save(media);
+
+      // Probed once per standard instance with the same id (300): origin 404s
+      // (deleted); the other instance has a different movie at 300.
+      let radarrCall = 0;
+      getMovieImpl = async (id: number) => {
+        if (id !== 300) {
+          throw new Error('404');
+        }
+        radarrCall += 1;
+        if (radarrCall === 1) {
+          throw new Error('404');
+        }
+        return {
+          id: 300,
+          tmdbId: 999999,
+          title: 'Unrelated Colliding Movie',
+          hasFile: true,
+        } as unknown as RadarrMovie;
+      };
+
+      await availabilitySync.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 5000 },
+      });
+
+      assert.strictEqual(
+        updated.status,
+        MediaStatus.DELETED,
+        'Movie deleted from its origin instance and Plex must not be kept alive by a colliding externalServiceId on another standard instance'
       );
     });
   });

--- a/server/lib/availabilitySync.ts
+++ b/server/lib/availabilitySync.ts
@@ -694,6 +694,10 @@ class AvailabilitySync {
           });
         }
 
+        if (radarr && radarr.tmdbId !== media.tmdbId) {
+          continue;
+        }
+
         if (radarr && radarr.hasFile) {
           const resolution =
             radarr?.movieFile?.mediaInfo?.resolution?.split('x');
@@ -751,18 +755,26 @@ class AvailabilitySync {
 
         if (media.externalServiceId && !is4k) {
           sonarr = await sonarrAPI.getSeriesById(media.externalServiceId);
-          this.sonarrSeasonsCache[`${server.id}-${media.externalServiceId}`] =
-            sonarr.seasons;
         }
 
         if (media.externalServiceId4k && is4k) {
           sonarr = await sonarrAPI.getSeriesById(media.externalServiceId4k);
-          this.sonarrSeasonsCache[`${server.id}-${media.externalServiceId4k}`] =
-            sonarr.seasons;
         }
 
-        if (sonarr && sonarr.statistics.episodeFileCount > 0) {
-          existsInSonarr = true;
+        if (sonarr && media.tvdbId != null && sonarr.tvdbId !== media.tvdbId) {
+          continue;
+        }
+
+        if (sonarr) {
+          const externalServiceId = is4k
+            ? media.externalServiceId4k
+            : media.externalServiceId;
+          this.sonarrSeasonsCache[`${server.id}-${externalServiceId}`] =
+            sonarr.seasons;
+
+          if (sonarr.statistics.episodeFileCount > 0) {
+            existsInSonarr = true;
+          }
         }
       } catch (ex) {
         if (!ex.message.includes('404')) {


### PR DESCRIPTION
## Description

With two or more **standard** (non-4K) Sonarr/Radarr instances, availability sync could leave deleted media marked available, or stuck on `PARTIALLY_AVAILABLE`, after it was removed from its origin instance and the media server.

This was due to media existence being checked by `externalServiceId`, which is instance-local. Each instance has its own ID sequence, so the same ID hits an unrelated title on the other instance and gets counted as still present. The old logic only distinguished standard vs 4K, never two standard instances.

This PR verifies identity (`tvdbId`/`tmdbId`) before trusting a lookup and mismatches are skipped. Genuine 404s are unchanged.

- Fixes https://discord.com/channels/783137440809746482/1518737634967425094/1518886673705078844

## How Has This Been Tested?

- Tested with a unit test that replicates the exact scenario that the OP reported in the above linked thread.
- Fails on develop.
- Works on this fix

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved availability syncing so content isn’t incorrectly kept as available when different items share the same external service ID.
  * Added stricter matching for Radarr/TMDb and Sonarr/TVDb identifiers to prevent false positives.
  * TV show and season statuses now correctly switch to deleted when the content no longer exists on the originating instance.

* **Tests**
  * Expanded coverage for collision scenarios across multiple instances for both TV seasons and movies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->