### PR TITLE
fix(api): prevent 500 when TMDB omits credits/keywords

### DIFF
--- a/server/models/Movie.ts
+++ b/server/models/Movie.ts
@@ -132,8 +132,8 @@ export const mapMovieDetails = (
   runtime: movie.runtime,
   tagline: movie.tagline,
   credits: {
-    cast: movie.credits.cast.map(mapCast),
-    crew: movie.credits.crew.map(mapCrew),
+    cast: (movie.credits?.cast ?? []).map(mapCast),
+    crew: (movie.credits?.crew ?? []).map(mapCrew),
   },
   collection: movie.belongs_to_collection
     ? {
@@ -146,7 +146,7 @@ export const mapMovieDetails = (
   externalIds: mapExternalIds(movie.external_ids),
   mediaInfo: media,
   watchProviders: mapWatchProviders(movie['watch/providers']?.results ?? {}),
-  keywords: movie.keywords.keywords.map((keyword) => ({
+  keywords: (movie.keywords?.keywords ?? []).map((keyword) => ({
     id: keyword.id,
     name: keyword.name,
   })),

--- a/server/models/Tv.ts
+++ b/server/models/Tv.ts
@@ -215,11 +215,11 @@ export const mapTvDetails = (
     : undefined,
   posterPath: show.poster_path,
   credits: {
-    cast: show.aggregate_credits.cast.map(mapAggregateCast),
-    crew: show.credits.crew.map(mapCrew),
+    cast: (show.aggregate_credits?.cast ?? []).map(mapAggregateCast),
+    crew: (show.credits?.crew ?? []).map(mapCrew),
   },
   externalIds: mapExternalIds(show.external_ids),
-  keywords: show.keywords.results.map((keyword) => ({
+  keywords: (show.keywords?.results ?? []).map((keyword) => ({
     id: keyword.id,
     name: keyword.name,
   })),


### PR DESCRIPTION
## Description

TMDB intermittently omits appended sub-objects (`credits`, `keywords`, `aggregate_credits`) from movie/TV detail responses, even though they are requested via `append_to_response`. When that happens, `mapMovieDetails` / `mapTvDetails` access `movie.credits.cast` on an `undefined` value and throw:

```
Cannot read properties of undefined (reading 'cast')
```

The error is caught by the route handler and the **entire** detail page returns a 500 ("Unable to retrieve movie/series"), so the title becomes completely unviewable.

Observed in the wild, e.g.:

```
[debug][API]: Something went wrong retrieving movie {"errorMessage":"Cannot read properties of undefined (reading 'cast')","movieId":"1119449"}
```

## Change

Guard the credits/keywords accesses in the model mappers with optional chaining and fall back to empty arrays:

- `server/models/Movie.ts` — `credits.cast`, `credits.crew`, `keywords.keywords`
- `server/models/Tv.ts` — `aggregate_credits.cast`, `credits.crew`, `keywords.results`

The title now loads with empty cast/crew/keywords instead of failing outright. This mirrors how other optional appended data (e.g. `watch/providers`) is already handled with `?.` + a fallback.

## Notes

- Scope intentionally kept to the runtime mappers. The TMDB interface types still declare these fields as required; tightening them to optional would cascade required guards into many scanner/route files and is out of scope for this fix.
- No behavior change for the common case where TMDB returns the appended data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing cast, crew, and keyword data so movie and TV details load more reliably.
  * Prevented errors when some optional credits or keyword fields are unavailable by using safer fallbacks.
  * Kept the displayed details structure unchanged while making data mapping more resilient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->