### PR TITLE
fix(deps): override handlebars to 4.7.9 (CVE-2026-33937)

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,8 @@
       "sqlite3>node-gyp": "8.4.1",
       "@types/express-session": "1.18.2",
       "@types/react": "19.2.14",
-      "@types/react-dom": "19.2.3"
+      "@types/react-dom": "19.2.3",
+      "handlebars": "4.7.9"
     }
   },
   "scarfSettings": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@types/express-session': 1.18.2
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
+  handlebars: 4.7.9
 
 importers:
 
@@ -82,7 +83,7 @@ importers:
         version: 0.2.9
       email-templates:
         specifier: 13.0.1
-        version: 13.0.1(@babel/core@7.29.0)(handlebars@4.7.8)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)
+        version: 13.0.1(@babel/core@7.29.0)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -1665,7 +1666,7 @@ packages:
       haml-coffee: ^1.14.1
       hamlet: ^0.3.3
       hamljs: ^0.6.2
-      handlebars: ^4.7.6
+      handlebars: 4.7.9
       hogan.js: ^3.0.2
       htmling: ^0.0.8
       jazz: ^0.0.18
@@ -4636,8 +4637,8 @@ packages:
     resolution: {integrity: sha512-AiU83cghGg2D8vAUwrMXCByejkkm4RtLwMNGmPU7VhqBYhsxcBCV0SAzRpYNbUCpTci5v46J/KFKPmDYaG2oyA==}
     engines: {node: '>=12'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -9611,10 +9612,9 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@ladjs/consolidate@1.0.4(@babel/core@7.29.0)(handlebars@4.7.8)(lodash@4.18.1)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)':
+  '@ladjs/consolidate@1.0.4(@babel/core@7.29.0)(lodash@4.18.1)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)':
     optionalDependencies:
       '@babel/core': 7.29.0
-      handlebars: 4.7.8
       lodash: 4.18.1
       mustache: 4.2.0
       pug: 3.0.4
@@ -11983,9 +11983,9 @@ snapshots:
 
   electron-to-chromium@1.5.344: {}
 
-  email-templates@13.0.1(@babel/core@7.29.0)(handlebars@4.7.8)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7):
+  email-templates@13.0.1(@babel/core@7.29.0)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7):
     dependencies:
-      '@ladjs/consolidate': 1.0.4(@babel/core@7.29.0)(handlebars@4.7.8)(lodash@4.18.1)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)
+      '@ladjs/consolidate': 1.0.4(@babel/core@7.29.0)(lodash@4.18.1)(mustache@4.2.0)(pug@3.0.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(underscore@1.13.7)
       '@ladjs/i18n': 10.0.0
       get-paths: 0.0.7
       html-to-text: 9.0.5
@@ -12988,7 +12988,7 @@ snapshots:
       md5-hex: 4.0.0
       type-fest: 1.4.0
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -16465,7 +16465,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 30.2.0(@types/node@22.19.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.6.5(@swc/helpers@0.5.15))(@types/node@22.19.0)(typescript@5.4.5))
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Description

`handlebars` is pulled in transitively (`email-templates@13.0.1` → `@ladjs/consolidate@1.0.4` → `handlebars@4.7.8`). Versions `4.0.0`–`4.7.8` are affected by **CVE-2026-33937** — a JavaScript injection / RCE in Handlebars.js: `Handlebars.compile()` also accepts a pre-parsed AST, and the `value` field of a `NumberLiteral` node is emitted into the generated function body without sanitization, so code that passes an attacker-controlled value to `compile()` can be made to execute arbitrary code. It is fixed in **4.7.9**.

This adds a `handlebars` entry to `pnpm.overrides` forcing the patched `4.7.9`. `4.7.9` is a patch release and is semver-compatible with the `^4.7.6` peer requirement of `@ladjs/consolidate`, so there is no API or behaviour change.

Scope note: seerr only compiles its own (string) email templates through `email-templates`, so it does not pass attacker-controlled input to `Handlebars.compile()` — real exploitability here is low. This is defense-in-depth, and it clears the CRITICAL finding that image scanners (Trivy / Grype) currently report on the published image.

Disclosure: this change was prepared with AI assistance and reviewed by me before submission.

Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-33937

## How Has This Been Tested?

- Added the `handlebars: "4.7.9"` override and regenerated `pnpm-lock.yaml` with the project's pinned `pnpm@10.24.0`.
- Verified the lockfile diff is limited to `handlebars` (`4.7.8` → `4.7.9`) and the peer-dependency suffixes that reference it — no other dependency is touched.
- Confirmed `4.7.9` satisfies the `^4.7.6` peer requirement of `@ladjs/consolidate`.
- I did not run a full `pnpm build` locally (my Node is 20, below the project's `^22.19.0` engine). The change is a transitive **runtime** dependency override with no source changes, so it has no build-time impact.

## Screenshots / Logs (if applicable)

N/A — dependency-only change.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice)) — prepared with AI assistance, reviewed by me.
- [ ] I have updated the documentation accordingly. _(no documentation change required for a dependency override)_
- [ ] All new and existing tests passed. _(not run locally — Node engine mismatch; no source change)_
- [ ] Successful build `pnpm build` _(not run locally — Node engine mismatch; no build-time impact)_
- [ ] Translation keys `pnpm i18n:extract` _(N/A — no strings changed)_
- [ ] Database migration (if required) _(N/A)_