### PR TITLE
Fix "hide blocklist items" setting description

### DIFF
--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -54,7 +54,7 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   streamingRegionTip: 'Show streaming sites by regional availability',
   hideBlocklisted: 'Hide Blocklisted Items',
   hideBlocklistedTip:
-    'Hide blocklisted items from discover pages for all users with the "Manage Blocklist" permission',
+    'Hide blocklisted items from discover pages for all users without the "View Blocklisted Media" permission',
   toastApiKeySuccess: 'New API key generated successfully!',
   toastApiKeyFailure: 'Something went wrong while generating a new API key.',
   toastSettingsSuccess: 'Settings saved successfully!',


### PR DESCRIPTION
## Description

Setting description currently incorrectly states it hides blocklisted items for users with the manage blocklist items permissions when it does the opposite. Also should specifically say the "view blocklisted media" permission, instead of "manage blocklist" as users can be assigned the view permission, without the manage permission.

## How Has This Been Tested?

Haven't tested, but its only a description change

## Screenshots / Logs (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

No AI