### PR TITLE
fix(subscriber): await request status updates

### DIFF
--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -8,6 +8,7 @@ import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
+import logger from '@server/logger';
 import type { EntitySubscriberInterface, UpdateEvent } from 'typeorm';
 import { EventSubscriber, In } from 'typeorm';
 
@@ -122,22 +123,46 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
   }
 
   public async beforeUpdate(event: UpdateEvent<Media>): Promise<void> {
-    if (!event.entity) {
+    if (!event.entity || !event.databaseEntity) {
       return;
     }
 
-    if (
-      event.entity.status === MediaStatus.AVAILABLE &&
-      event.databaseEntity.status === MediaStatus.PENDING
-    ) {
-      this.updateChildRequestStatus(event.entity as Media, false);
+    try {
+      if (
+        event.entity.status === MediaStatus.AVAILABLE &&
+        event.databaseEntity?.status === MediaStatus.PENDING
+      ) {
+        await this.updateChildRequestStatus(event.entity as Media, false);
+      }
+    } catch (e) {
+      logger.error(
+        'Error while updating child request status in beforeUpdate subscriber',
+        {
+          label: 'Media',
+          mediaId: event.entity.id,
+          is4k: false,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
+      );
     }
 
-    if (
-      event.entity.status4k === MediaStatus.AVAILABLE &&
-      event.databaseEntity.status4k === MediaStatus.PENDING
-    ) {
-      this.updateChildRequestStatus(event.entity as Media, true);
+    try {
+      if (
+        event.entity.status4k === MediaStatus.AVAILABLE &&
+        event.databaseEntity?.status4k === MediaStatus.PENDING
+      ) {
+        await this.updateChildRequestStatus(event.entity as Media, true);
+      }
+    } catch (e) {
+      logger.error(
+        'Error while updating child request status in beforeUpdate subscriber',
+        {
+          label: 'Media',
+          mediaId: event.entity.id,
+          is4k: true,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
+      );
     }
 
     // Manually load related seasons into databaseEntity
@@ -153,7 +178,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
   }
 
   public async afterUpdate(event: UpdateEvent<Media>): Promise<void> {
-    if (!event.entity) {
+    if (!event.entity || !event.databaseEntity) {
       return;
     }
 
@@ -174,28 +199,53 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       });
     };
 
-    if (
-      (event.entity.status !== event.databaseEntity?.status ||
-        (event.entity.mediaType === MediaType.TV &&
-          seasonStatusCheck(false))) &&
-      validStatuses.includes(event.entity.status)
-    ) {
-      this.updateRelatedMediaRequest(
-        event.entity as Media,
-        event.databaseEntity as Media,
-        false
+    try {
+      if (
+        (event.entity.status !== event.databaseEntity?.status ||
+          (event.entity.mediaType === MediaType.TV &&
+            seasonStatusCheck(false))) &&
+        validStatuses.includes(event.entity.status)
+      ) {
+        await this.updateRelatedMediaRequest(
+          event.entity as Media,
+          event.databaseEntity as Media,
+          false
+        );
+      }
+    } catch (e) {
+      logger.error(
+        'Error while updating related requests in afterUpdate subscriber',
+        {
+          label: 'Media',
+          mediaId: event.entity.id,
+          is4k: false,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
       );
     }
 
-    if (
-      (event.entity.status4k !== event.databaseEntity?.status4k ||
-        (event.entity.mediaType === MediaType.TV && seasonStatusCheck(true))) &&
-      validStatuses.includes(event.entity.status4k)
-    ) {
-      this.updateRelatedMediaRequest(
-        event.entity as Media,
-        event.databaseEntity as Media,
-        true
+    try {
+      if (
+        (event.entity.status4k !== event.databaseEntity?.status4k ||
+          (event.entity.mediaType === MediaType.TV &&
+            seasonStatusCheck(true))) &&
+        validStatuses.includes(event.entity.status4k)
+      ) {
+        await this.updateRelatedMediaRequest(
+          event.entity as Media,
+          event.databaseEntity as Media,
+          true
+        );
+      }
+    } catch (e) {
+      logger.error(
+        'Error while updating related requests in afterUpdate subscriber',
+        {
+          label: 'Media',
+          mediaId: event.entity.id,
+          is4k: true,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        }
       );
     }
   }


### PR DESCRIPTION
## Description

Similar to #2760, while working on a fix for availability sync job, I noticed that `MediaSubscriber`'s `beforeUpdate` and `afterUpdate` call `updateChildRequestStatus` and `updateRelatedMediaRequest` without awaiting them, and neither method has its own error handling. Since Seerr has no global `unhandledRejection` handler, any rejection from either call is silently lost on Node 15+, and an unhandled rejection with no handler terminates the process by
default. Any transient failure in this request-sync path (a DB error, a constraint violation, anything) can crash the running server, not just fail one status update.

This surfaced while working on unrelated availability sync fixes: a test that inserted a real MediaRequest and triggered a status change would intermittently report an unhandled rejection after the test had already completed. The screenshot below shows that failure; the underlying risk is the same in production, just without a test runner around to catch it.

Both calls are now awaited and wrapped in try/catch, so a failure in the request-sync side effect is logged instead of taking down the process, and can't interfere with the primary media save.

<img width="2853" height="391" alt="image" src="https://github.com/user-attachments/assets/996b51ec-96de-4b76-9a65-cb62709acf0d" />

## How Has This Been Tested?

- Tested with the unit test from #3224

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of related media request status updates during save operations.
  * Added safer handling when status information is missing to prevent update failures.
  * Errors encountered during both 4k and non-4k request updates are now logged for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->