### PR TITLE
fix: apply Discover Language filter to network & studio sliders

### DIFF
--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -304,7 +304,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ studioId: string }>(
   '/movies/studio/:studioId',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const studio = await tmdb.getStudio(Number(req.params.studioId));
@@ -611,7 +611,7 @@ discoverRoutes.get<{ genreId: string }>(
 discoverRoutes.get<{ networkId: string }>(
   '/tv/network/:networkId',
   async (req, res, next) => {
-    const tmdb = new TheMovieDb();
+    const tmdb = createTmdbWithRegionLanguage(req.user);
 
     try {
       const network = await tmdb.getNetwork(Number(req.params.networkId));


### PR DESCRIPTION
## Description

The `/tv/network/:networkId` and `/movies/studio/:studioId` discover routes construct a bare `new TheMovieDb()` instead of using `createTmdbWithRegionLanguage(req.user)` like every other discover route (`/movies`, `/tv`, `/movies/genre/:id`, `/tv/genre/:id`, etc.).

As a result, the **Original Language** setting (Settings → General → Discover Language) is silently ignored for **network sliders** (e.g. the built-in Netflix row, TMDB network `213`) and **studio sliders**, even though the main and genre rows honor it correctly. Non-English-original titles appear in those rows despite the filter being set — e.g. with Discover Language = English, "Human Vapor" (Japanese) shows up in the Netflix slider.

Both affected routes call `getDiscoverTv` / `getDiscoverMovies`, which already pass `with_original_language` to TMDB, so routing them through the region/language-aware client is all that's needed — the filter then applies consistently with the other discover rows. `git blame` shows the bare client on these routes predates the `createTmdbWithRegionLanguage` helper, so this looks like an incomplete retrofit rather than intentional behavior.

Scope note: this intentionally does **not** touch Trending / Search / Similar / Recommended. Those hit TMDB endpoints (`/trending/*`, `/search/*`, `/movie/{id}/similar`, `/{id}/recommendations`) that don't accept `with_original_language`, so they can't be filtered server-side without client-side post-filtering — a larger change with different UX tradeoffs, out of scope here. The `/keyword/:keywordId/movies` route was also left as-is: `getMoviesByKeyword` isn't a `/discover` call and doesn't accept the parameter, so swapping its client would be a no-op.

No linked issue.

## How Has This Been Tested?

Tested against a live v3.3.0 instance (`ghcr.io/seerr-team/seerr`) with Discover Language = English (`originalLanguage: "en"`):

- **Before:** `GET /api/v1/discover/tv/network/213` (Netflix) returned a mix of original languages — `en`, `ja` (incl. "Human Vapor"), `ko`, `es`, `zu`.
- **After:** the same endpoint returns `20/20` English-original titles, matching `GET /api/v1/discover/tv` (main TV row), and "Human Vapor" no longer appears.
- Studio route (`/movies/studio/:studioId`) similarly returns only English-original titles after the change.

Local checks on this branch (Node 22.23.1, pnpm 10.24.0):
- `pnpm typecheck` — passes (server + client)
- `pnpm build` — succeeds
- `pnpm lint` — 0 errors (only pre-existing warnings in unrelated files)
- `pnpm i18n:extract` — no translation-key changes

The full unit suite (`pnpm test`) was not run locally as it needs additional environment setup; the change touches no tested code paths (there are no discover-route tests) and is limited to swapping the TMDB client constructor to the existing helper.

## Screenshots / Logs (if applicable)

`/api/v1/discover/tv/network/213` original-language tallies, same instance/setting:

```
before:  1 zu, 2 es, 4 ko, 2 ja (incl. "Human Vapor"), 11 en
after:  20 en
```

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see below)
- [ ] I have updated the documentation accordingly. (N/A — no user-facing docs affected)
- [ ] All new and existing tests passed. (typecheck/build/lint pass; full test suite not run locally — see above)
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract` (no changes)
- [ ] Database migration (if required) (N/A — no schema change)

---

**AI Disclosure:** The root-cause investigation and this code change were produced with AI assistance (Claude Code). I reviewed the diagnosis and the diff, verified the behavior against my own live v3.3.0 instance (before/after original-language tallies above), and confirmed `pnpm typecheck`/`build`/`lint` pass locally. The PR description was AI-drafted and edited by me to follow the template. I understand the change and can answer questions about it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Movie studio and TV network discovery results now respect each user’s region and language preferences, improving localized browsing and search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->