### PR TITLE
fix(frontend): only redirect to /login when the session check returns 401/403

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -28,13 +28,15 @@ export const UserContext = ({ initialUser, children }: UserContextProps) => {
     // the user navigated away, or the server was briefly unreachable)
     // rejects without a response; redirecting on those kicks logged-in
     // users to /login and can even cancel an in-flight navigation to
-    // another site, dragging the browser back to the app.
+    // another site, dragging the browser back to the app. A transiently
+    // empty user (first fetch still in flight) must not navigate either —
+    // unauthenticated page loads are already redirected server-side.
     const sessionInvalid =
       error?.response?.status === 401 || error?.response?.status === 403;
 
     if (
       !router.pathname.match(/(setup|login|resetpassword)/) &&
-      (!user || sessionInvalid) &&
+      sessionInvalid &&
       !routing.current
     ) {
       routing.current = true;

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -23,9 +23,18 @@ export const UserContext = ({ initialUser, children }: UserContextProps) => {
   }, [router.pathname, revalidate]);
 
   useEffect(() => {
+    // Only treat the session as invalid when the server actually rejected
+    // it. A check that never completed (e.g. the fetch was aborted because
+    // the user navigated away, or the server was briefly unreachable)
+    // rejects without a response; redirecting on those kicks logged-in
+    // users to /login and can even cancel an in-flight navigation to
+    // another site, dragging the browser back to the app.
+    const sessionInvalid =
+      error?.response?.status === 401 || error?.response?.status === 403;
+
     if (
       !router.pathname.match(/(setup|login|resetpassword)/) &&
-      (!user || error) &&
+      (!user || sessionInvalid) &&
       !routing.current
     ) {
       routing.current = true;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -2,6 +2,7 @@ import { UserType } from '@server/constants/user';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
 import { hasPermission, Permission } from '@server/lib/permissions';
 import type { NotificationAgentKey } from '@server/lib/settings';
+import type { AxiosError } from 'axios';
 import { useRouter } from 'next/router';
 import type { MutatorCallback } from 'swr';
 import useSWR from 'swr';
@@ -41,7 +42,7 @@ export interface UserSettings {
 interface UserHookResponse {
   user?: User;
   loading: boolean;
-  error: string;
+  error?: AxiosError;
   revalidate: (
     data?: User | Promise<User> | MutatorCallback<User> | undefined,
     shouldRevalidate?: boolean | undefined


### PR DESCRIPTION

## Description

If you're on any Seerr page and type a different site's URL into the address bar, Seerr sometimes cancels that navigation and drags you back to itself. I hit this regularly on iOS Safari and it took a while to work out what was actually happening.

The chain: `useUser` revalidates `/api/v1/auth/me` on window focus and every 30s. Tapping the address bar fires the focus revalidation; committing the navigation then aborts that fetch. The abort surfaces as an axios error with no `response`, and `UserContext` treats *any* error as a dead session and sets `location.href = '/login'`. The old page's JS keeps running until the new document commits, so that assignment races the user's navigation and wins (WebKit's slow commit makes it easy to hit). The session is actually still valid, so `/login` immediately 307s back to `/` — the visible result is "I typed another URL and ended up back on Seerr."

The fix: only treat the session as invalid when `auth/me` actually comes back 401/403. A rejection with no HTTP response (aborted fetch, offline blip, brief server restart mid-poll) no longer logs you out. The `error` field in `UserHookResponse` was declared `string` but is an `AxiosError` at runtime; fixed the type so the status check compiles. The other two consumers of `error` only check truthiness, so nothing else changes.

Disclosure: I used Claude to help trace this (it dug the failure sequence out of my reverse-proxy logs and drafted the patch); I've reviewed the change and the analysis myself.

## How Has This Been Tested?

Diagnosed from reverse-proxy access logs on my instance — one occurrence captured end to end:

```
01:23:55.186  GET other-app/            -> 200   typed navigation, HTML delivered
01:23:55.453  GET seerr/api/v1/auth/me  -> 499   fetch aborted by the navigation
01:23:55.468  GET seerr/login           -> 307   UserContext redirect; session still valid
01:23:55.504  GET seerr/                -> 200   full reload, back on Seerr
01:24:00.288  GET other-app/            -> 200   second attempt sticks
```

I run a source build with this patch applied since 5 July and the yank has not recurred (monitored via the same access logs).

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly. (n/a — behavior fix)
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build` (not run locally; the same two-file patch builds and runs in my production docker image)
- [x] Translation keys `pnpm i18n:extract` (n/a — no strings changed)
- [x] Database migration (if required) (n/a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login redirection so users are sent to the login page only when their session is invalid or missing, not for unrelated errors.
  * Reduced unnecessary redirects caused by non-authentication-related failures.
  * Enhanced user-related error reporting to better reflect actual request failures during sign-in flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->