### PR TITLE
fix(requests): skip empty announced seasons when requesting all seasons

### DIFF
--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -1,0 +1,45 @@
+import type { TmdbTvSeasonResult } from '@server/api/themoviedb/interfaces';
+import { getRequestableSeasonNumbers } from '@server/entity/MediaRequest';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+function season(
+  seasonNumber: number,
+  episodeCount: number
+): TmdbTvSeasonResult {
+  return {
+    id: 1000 + seasonNumber,
+    air_date: '2020-01-01',
+    episode_count: episodeCount,
+    name: `Season ${seasonNumber}`,
+    overview: '',
+    season_number: seasonNumber,
+  };
+}
+
+describe('getRequestableSeasonNumbers', () => {
+  it('excludes specials (season 0)', () => {
+    const result = getRequestableSeasonNumbers([season(0, 5), season(1, 10)]);
+
+    assert.deepStrictEqual(result, [1]);
+  });
+
+  it('excludes announced seasons that have no episodes yet', () => {
+    // TMDB commonly lists a placeholder future season with episode_count 0
+    // (e.g. an announced-but-unproduced season). It must not be requested,
+    // otherwise watchlist sync re-creates a phantom request on every run.
+    const result = getRequestableSeasonNumbers([
+      season(1, 10),
+      season(2, 8),
+      season(3, 0),
+    ]);
+
+    assert.deepStrictEqual(result, [1, 2]);
+  });
+
+  it('returns every real season when all of them have episodes', () => {
+    const result = getRequestableSeasonNumbers([season(1, 10), season(2, 8)]);
+
+    assert.deepStrictEqual(result, [1, 2]);
+  });
+});

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -1,6 +1,9 @@
 import TheMovieDb from '@server/api/themoviedb';
 import { ANIME_KEYWORD_ID } from '@server/api/themoviedb/constants';
-import type { TmdbKeyword } from '@server/api/themoviedb/interfaces';
+import type {
+  TmdbKeyword,
+  TmdbTvSeasonResult,
+} from '@server/api/themoviedb/interfaces';
 import {
   MediaRequestStatus,
   MediaStatus,
@@ -41,6 +44,24 @@ export class BlocklistedMediaError extends Error {}
 type MediaRequestOptions = {
   isAutoRequest?: boolean;
 };
+
+/**
+ * Resolve the season numbers that should be requested for a "request all
+ * seasons" request from a show's TMDB season list.
+ *
+ * Specials (season 0) are always excluded, and so are seasons that do not yet
+ * have any episodes. TMDB frequently lists placeholder entries for
+ * announced-but-unproduced seasons with `episode_count: 0`. Requesting those
+ * creates phantom season requests that can never be fulfilled - most visibly
+ * via watchlist sync, which re-creates the request on every run after it is
+ * deleted. See seerr-team/seerr#2646.
+ */
+export const getRequestableSeasonNumbers = (
+  seasons: TmdbTvSeasonResult[]
+): number[] =>
+  seasons
+    .filter((season) => season.season_number !== 0 && season.episode_count > 0)
+    .map((season) => season.season_number);
 
 @Entity()
 export class MediaRequest {
@@ -416,9 +437,7 @@ export class MediaRequest {
       >;
       let requestedSeasons =
         requestBody.seasons === 'all'
-          ? tmdbMediaShow.seasons
-              .filter((season) => season.season_number !== 0)
-              .map((season) => season.season_number)
+          ? getRequestableSeasonNumbers(tmdbMediaShow.seasons)
           : (requestBody.seasons as number[]);
       if (!settings.main.enableSpecialEpisodes) {
         requestedSeasons = requestedSeasons.filter((sn) => sn > 0);


### PR DESCRIPTION
## Description

Fixes #2646

When a show is requested with "all seasons" (which is what Plex watchlist sync does internally), Seerr was including every non-special season TMDB returned — even ones that don't actually have any episodes yet. TMDB routinely lists a placeholder entry for an announced-but-unproduced season with `episode_count: 0`, and Plex Discover surfaces the same phantom season. The result is an auto-approved request for a season that can never be fulfilled, and because the item stays on the user's watchlist, deleting the request just recreates it on the next sync (with another approval email).

This limits the "all seasons" resolution to seasons that have at least one episode, in addition to the existing specials (season 0) exclusion. I pulled the resolution out into a small helper (`getRequestableSeasonNumbers`) so the behaviour is covered by a unit test. Explicit season selections from the request modal are unaffected — only the `seasons: 'all'` path changes.

## How Has This Been Tested?

- Added a unit test for `getRequestableSeasonNumbers` covering: specials are excluded, seasons with `episode_count: 0` are excluded, and normal seasons are all returned. Confirmed the "empty season" case fails on develop and passes with this change.
- Ran the existing request and watchlist-sync suites alongside it — all pass (20/20).
- `pnpm lint`, `pnpm format:check`, and `pnpm typecheck:server` are clean. I did not run a full `pnpm build` locally — flagging that so CI's build step is the source of truth there.

Environment: Node 22.x, SQLite (default).

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] Disclosed any use of AI (see below).
- [ ] I have updated the documentation accordingly. (No user-facing docs affected.)
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build` (ran lint/typecheck/tests locally; left the full build to CI)
- [ ] Translation keys `pnpm i18n:extract` (no strings changed)
- [ ] Database migration (not required)

AI Disclosure: AI-assisted. I used Claude Code to help locate the code path and draft the test; I reviewed every line, decided the scope (limiting the change to the `seasons: 'all'` path), and verified the behaviour myself. The wording of this PR is my own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * “Request all seasons” now excludes specials and seasons with no available episodes.
  * Prevented unfulfillable requests for announced or placeholder seasons without episodes.

* **Tests**
  * Added coverage verifying season filtering for specials, empty seasons, and valid seasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->