### PR TITLE
test: add scanner update rate override for testing

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -59,8 +59,8 @@ export interface ProcessableSeason {
 }
 
 class BaseScanner<T> {
-  private bundleSize;
-  private updateRate;
+  protected bundleSize;
+  protected updateRate;
   protected progress = 0;
   protected items: T[] = [];
   protected totalSize?: number = 0;
@@ -791,6 +791,18 @@ class BaseScanner<T> {
 
   get protectedBundleSize(): number {
     return this.bundleSize;
+  }
+
+  /**
+   * Test-only override to reduce scan delay in unit tests.
+   * Sets updateRate and/or bundleSize for the next run.
+   */
+  public setTestOverrides(opts: {
+    updateRate?: number;
+    bundleSize?: number;
+  }): void {
+    if (opts.updateRate !== undefined) this.updateRate = opts.updateRate;
+    if (opts.bundleSize !== undefined) this.bundleSize = opts.bundleSize;
   }
 }
 

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -59,8 +59,8 @@ export interface ProcessableSeason {
 }
 
 class BaseScanner<T> {
-  protected bundleSize;
-  protected updateRate;
+  private bundleSize;
+  private updateRate;
   protected progress = 0;
   protected items: T[] = [];
   protected totalSize?: number = 0;
@@ -798,18 +798,6 @@ class BaseScanner<T> {
 
   get protectedBundleSize(): number {
     return this.bundleSize;
-  }
-
-  /**
-   * Test-only override to reduce scan delay in unit tests.
-   * Sets updateRate and/or bundleSize for the next run.
-   */
-  public setTestOverrides(opts: {
-    updateRate?: number;
-    bundleSize?: number;
-  }): void {
-    if (opts.updateRate !== undefined) this.updateRate = opts.updateRate;
-    if (opts.bundleSize !== undefined) this.bundleSize = opts.bundleSize;
   }
 }
 

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -59,8 +59,8 @@ export interface ProcessableSeason {
 }
 
 class BaseScanner<T> {
-  private bundleSize;
-  private updateRate;
+  protected bundleSize;
+  protected updateRate;
   protected progress = 0;
   protected items: T[] = [];
   protected totalSize?: number = 0;
@@ -798,6 +798,18 @@ class BaseScanner<T> {
 
   get protectedBundleSize(): number {
     return this.bundleSize;
+  }
+
+  /**
+   * Test-only override to reduce scan delay in unit tests.
+   * Sets updateRate and/or bundleSize for the next run.
+   */
+  public setTestOverrides(opts: {
+    updateRate?: number;
+    bundleSize?: number;
+  }): void {
+    if (opts.updateRate !== undefined) this.updateRate = opts.updateRate;
+    if (opts.bundleSize !== undefined) this.bundleSize = opts.bundleSize;
   }
 }
 

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -223,6 +223,8 @@ function configureJellyfinWithLibrary(
 
 describe('Jellyfin Scanner', () => {
   beforeEach(async () => {
+    jellyfinFullScanner.setTestOverrides({ updateRate: 0 });
+
     getLibraryContentsImpl = async () => [];
     getItemDataImpl = async () => undefined;
     getSeasonsImpl = async () => [];

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -343,7 +343,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await runWithMockTimers(jellyfinFullScanner.run());
+      await runWithMockTimers(() => jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5000 },
@@ -421,7 +421,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await runWithMockTimers(jellyfinFullScanner.run());
+      await runWithMockTimers(() => jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5001 },
@@ -498,7 +498,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await runWithMockTimers(jellyfinFullScanner.run());
+      await runWithMockTimers(() => jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5002 },

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -18,6 +18,7 @@ import { User } from '@server/entity/User';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
+import { runWithMockTimers } from '@server/test/runWithMockTimers';
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 
@@ -232,8 +233,6 @@ function configureJellyfinWithLibrary(
 
 describe('Jellyfin Scanner', () => {
   beforeEach(async () => {
-    jellyfinFullScanner.setTestOverrides({ updateRate: 0 });
-
     getLibraryContentsImpl = async () => [];
     getItemDataImpl = async () => undefined;
     getSeasonsImpl = async () => [];
@@ -344,7 +343,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await jellyfinFullScanner.run();
+      await runWithMockTimers(jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5000 },
@@ -422,7 +421,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await jellyfinFullScanner.run();
+      await runWithMockTimers(jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5001 },
@@ -499,7 +498,7 @@ describe('Jellyfin Scanner', () => {
         return [];
       };
 
-      await jellyfinFullScanner.run();
+      await runWithMockTimers(jellyfinFullScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 5002 },

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -232,6 +232,8 @@ function configureJellyfinWithLibrary(
 
 describe('Jellyfin Scanner', () => {
   beforeEach(async () => {
+    jellyfinFullScanner.setTestOverrides({ updateRate: 0 });
+
     getLibraryContentsImpl = async () => [];
     getItemDataImpl = async () => undefined;
     getSeasonsImpl = async () => [];

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -75,6 +75,7 @@ function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
 
 describe('Radarr Scanner', () => {
   beforeEach(() => {
+    radarrScanner.setTestOverrides({ updateRate: 0 });
     getMoviesImpl = async () => [];
   });
 

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -13,6 +13,7 @@ import { radarrScanner } from '@server/lib/scanners/radarr';
 import type { RadarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
+import { runWithMockTimers } from '@server/test/runWithMockTimers';
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it, mock } from 'node:test';
 
@@ -75,7 +76,6 @@ function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
 
 describe('Radarr Scanner', () => {
   beforeEach(() => {
-    radarrScanner.setTestOverrides({ updateRate: 0 });
     getMoviesImpl = async () => [];
   });
 
@@ -94,7 +94,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ monitored: false, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 550 },
@@ -110,7 +110,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 777, monitored: false, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const media = await mediaRepository.findOne({
         where: { tmdbId: 777 },
@@ -132,7 +132,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 551, monitored: true, hasFile: true }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 551 },
@@ -154,7 +154,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 552, monitored: true, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 552 },
@@ -176,7 +176,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 553, monitored: true, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 553 },
@@ -198,7 +198,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 554, monitored: false, hasFile: true }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 554 },
@@ -224,7 +224,7 @@ describe('Radarr Scanner', () => {
 
       getMoviesImpl = async () => [];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 950 },
@@ -244,7 +244,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 999 },
@@ -264,7 +264,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 888 },
@@ -286,7 +286,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 700 },
@@ -307,7 +307,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 800 },
@@ -345,7 +345,7 @@ describe('Radarr Scanner', () => {
         return [fakeRadarrMovie({ tmdbId: 903, id: 11 })];
       };
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updatedOrphan = await mediaRepository.findOneOrFail({
         where: { tmdbId: 901 },
@@ -373,7 +373,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true, is4k: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 960 },
@@ -394,7 +394,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true, is4k: true }]);
       getMoviesImpl = async () => [];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 961 },
@@ -437,7 +437,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003596 },
@@ -485,7 +485,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
       ];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updatedRequest = await requestRepository.findOneOrFail({
         where: { id: request.id },
@@ -526,7 +526,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1234 },
@@ -622,7 +622,7 @@ describe('Radarr Scanner', () => {
         return [fakeRadarrMovie({ tmdbId: 2, id: 88 })];
       };
 
-      await radarrScanner.run();
+      await runWithMockTimers(radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003598 },

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -94,7 +94,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ monitored: false, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 550 },
@@ -110,7 +110,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 777, monitored: false, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const media = await mediaRepository.findOne({
         where: { tmdbId: 777 },
@@ -132,7 +132,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 551, monitored: true, hasFile: true }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 551 },
@@ -154,7 +154,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 552, monitored: true, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 552 },
@@ -176,7 +176,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 553, monitored: true, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 553 },
@@ -198,7 +198,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 554, monitored: false, hasFile: true }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 554 },
@@ -224,7 +224,7 @@ describe('Radarr Scanner', () => {
 
       getMoviesImpl = async () => [];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 950 },
@@ -244,7 +244,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 999 },
@@ -264,7 +264,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 888 },
@@ -286,7 +286,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 700 },
@@ -307,7 +307,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 800 },
@@ -345,7 +345,7 @@ describe('Radarr Scanner', () => {
         return [fakeRadarrMovie({ tmdbId: 903, id: 11 })];
       };
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updatedOrphan = await mediaRepository.findOneOrFail({
         where: { tmdbId: 901 },
@@ -373,7 +373,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true, is4k: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 960 },
@@ -394,7 +394,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true, is4k: true }]);
       getMoviesImpl = async () => [];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 961 },
@@ -437,7 +437,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 1, id: 99 })];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003596 },
@@ -485,7 +485,7 @@ describe('Radarr Scanner', () => {
         fakeRadarrMovie({ tmdbId: 700, monitored: true, hasFile: false }),
       ];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updatedRequest = await requestRepository.findOneOrFail({
         where: { id: request.id },
@@ -526,7 +526,7 @@ describe('Radarr Scanner', () => {
       configureRadarr([{ syncEnabled: true }]);
       getMoviesImpl = async () => [];
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1234 },
@@ -622,7 +622,7 @@ describe('Radarr Scanner', () => {
         return [fakeRadarrMovie({ tmdbId: 2, id: 88 })];
       };
 
-      await runWithMockTimers(radarrScanner.run());
+      await runWithMockTimers(() => radarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003598 },

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -163,6 +163,7 @@ function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
 
 describe('Sonarr Scanner', () => {
   beforeEach(() => {
+    sonarrScanner.setTestOverrides({ updateRate: 0 });
     getSeriesImpl = async () => [];
     getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
     getTvShowImpl = async () => fakeTmdbShow(1);

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -207,7 +207,7 @@ describe('Sonarr Scanner', () => {
 
       getSeriesImpl = async () => [];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1050 },
@@ -237,7 +237,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1000 },
@@ -267,7 +267,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1001 },
@@ -317,7 +317,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
       getTvShowImpl = async () => fakeTmdbShow(1);
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1 },
@@ -351,7 +351,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003 },
@@ -377,7 +377,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1004 },
@@ -426,7 +426,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(2);
       getTvShowImpl = async () => fakeTmdbShow(2);
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updatedOrphan = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1010 },
@@ -454,7 +454,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1020 },
@@ -485,7 +485,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true, is4k: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1030 },
@@ -521,7 +521,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true, is4k: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1031 },
@@ -576,7 +576,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2000 },
@@ -650,7 +650,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(2001);
       getTvShowImpl = async () => fakeTmdbShow(2001);
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updatedRequest = await requestRepository.findOneOrFail({
         where: { id: request.id },
@@ -699,7 +699,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2005 },
@@ -818,7 +818,7 @@ describe('Sonarr Scanner', () => {
         tvdbId === 666 ? fakeTmdbShow(2002) : fakeTmdbShow(997);
       getTvShowImpl = async ({ tvId }) => fakeTmdbShow(tvId);
 
-      await runWithMockTimers(sonarrScanner.run());
+      await runWithMockTimers(() => sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2002 },

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -176,6 +176,7 @@ function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
 
 describe('Sonarr Scanner', () => {
   beforeEach(() => {
+    sonarrScanner.setTestOverrides({ updateRate: 0 });
     getSeriesImpl = async () => [];
     getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
     getTvShowImpl = async () => fakeTmdbShow(1);

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -15,10 +15,10 @@ import Media from '@server/entity/Media';
 import MediaRequest from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
-import { sonarrScanner } from '@server/lib/scanners/sonarr';
 import type { SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
+import { runWithMockTimers } from '@server/test/runWithMockTimers';
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it, mock } from 'node:test';
 
@@ -116,6 +116,7 @@ Object.defineProperty(TheMovieDb.prototype, 'getTvShowForScan', {
   configurable: true,
 });
 
+import { sonarrScanner } from '@server/lib/scanners/sonarr';
 mock.method(MediaRequest, 'sendNotification', async () => undefined);
 
 setupTestDb();
@@ -176,7 +177,6 @@ function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
 
 describe('Sonarr Scanner', () => {
   beforeEach(() => {
-    sonarrScanner.setTestOverrides({ updateRate: 0 });
     getSeriesImpl = async () => [];
     getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
     getTvShowImpl = async () => fakeTmdbShow(1);
@@ -207,7 +207,7 @@ describe('Sonarr Scanner', () => {
 
       getSeriesImpl = async () => [];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1050 },
@@ -237,7 +237,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1000 },
@@ -267,7 +267,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1001 },
@@ -317,7 +317,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
       getTvShowImpl = async () => fakeTmdbShow(1);
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1 },
@@ -351,7 +351,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1003 },
@@ -377,7 +377,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1004 },
@@ -426,7 +426,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(2);
       getTvShowImpl = async () => fakeTmdbShow(2);
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updatedOrphan = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1010 },
@@ -454,7 +454,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1020 },
@@ -485,7 +485,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true, is4k: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1030 },
@@ -521,7 +521,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true, is4k: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updated = await mediaRepository.findOneOrFail({
         where: { tmdbId: 1031 },
@@ -576,7 +576,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 999 })];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2000 },
@@ -650,7 +650,7 @@ describe('Sonarr Scanner', () => {
       getShowByTvdbIdImpl = async () => fakeTmdbShow(2001);
       getTvShowImpl = async () => fakeTmdbShow(2001);
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updatedRequest = await requestRepository.findOneOrFail({
         where: { id: request.id },
@@ -699,7 +699,7 @@ describe('Sonarr Scanner', () => {
       configureSonarr([{ syncEnabled: true }]);
       getSeriesImpl = async () => [];
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2005 },
@@ -818,7 +818,7 @@ describe('Sonarr Scanner', () => {
         tvdbId === 666 ? fakeTmdbShow(2002) : fakeTmdbShow(997);
       getTvShowImpl = async ({ tvId }) => fakeTmdbShow(tvId);
 
-      await sonarrScanner.run();
+      await runWithMockTimers(sonarrScanner.run());
 
       const updatedMedia = await mediaRepository.findOneOrFail({
         where: { tmdbId: 2002 },

--- a/server/test/runWithMockTimers.ts
+++ b/server/test/runWithMockTimers.ts
@@ -1,0 +1,24 @@
+import { mock } from 'node:test';
+
+export async function runWithMockTimers<T>(
+  runPromise: Promise<T>,
+  tickMs = 4000
+): Promise<T> {
+  mock.timers.enable({ apis: ['setTimeout'] });
+  try {
+    let settled = false;
+    runPromise
+      .catch(() => undefined)
+      .finally(() => {
+        settled = true;
+      });
+    let guard = 0;
+    while (!settled && guard++ < 100000) {
+      await new Promise((resolve) => setImmediate(resolve));
+      mock.timers.tick(tickMs);
+    }
+    return await runPromise;
+  } finally {
+    mock.timers.reset();
+  }
+}

--- a/server/test/runWithMockTimers.ts
+++ b/server/test/runWithMockTimers.ts
@@ -12,10 +12,15 @@ export async function runWithMockTimers<T>(
       .finally(() => {
         settled = true;
       });
-    let guard = 0;
-    while (!settled && guard++ < 100000) {
+    const maxTicks = 100000;
+    for (let i = 0; i < maxTicks && !settled; i++) {
       await new Promise((resolve) => setImmediate(resolve));
       mock.timers.tick(tickMs);
+    }
+    if (!settled) {
+      throw new Error(
+        `runWithMockTimers: promise did not settle after ${maxTicks} ticks`
+      );
     }
     return await runPromise;
   } finally {

--- a/server/test/runWithMockTimers.ts
+++ b/server/test/runWithMockTimers.ts
@@ -1,12 +1,13 @@
 import { mock } from 'node:test';
 
 export async function runWithMockTimers<T>(
-  runPromise: Promise<T>,
+  runFn: () => Promise<T>,
   tickMs = 4000
 ): Promise<T> {
   mock.timers.enable({ apis: ['setTimeout'] });
   try {
     let settled = false;
+    const runPromise = runFn();
     runPromise
       .catch(() => undefined)
       .finally(() => {
@@ -17,6 +18,10 @@ export async function runWithMockTimers<T>(
       await new Promise((resolve) => setImmediate(resolve));
       mock.timers.tick(tickMs);
     }
+    // The final tick may have settled runPromise, but `settled` only updates
+    // in a microtask; yield once more before the guard check to avoid false
+    // negatives when the resolving tick lands on the last iteration.
+    await new Promise((resolve) => setImmediate(resolve));
     if (!settled) {
       throw new Error(
         `runWithMockTimers: promise did not settle after ${maxTicks} ticks`


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

The scanner tests are currently pretty slow to run, as they wait for 4 seconds before running the scanner due to the update rate. This can be overridden in tests, which considerably speeds them up.

## How Has This Been Tested?

Tests pass.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the reliability and consistency of automated scanner testing for Jellyfin, Radarr, and Sonarr.
  * Added consistent timer handling during scanner test runs to better support asynchronous workflows.
  * Maintained coverage for status handling, cleanup workflows, request processing, orphaned items, and multi-server scenarios.
  * Existing scanner behavior and test expectations remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->