### PR TITLE
feat(person): add job filter to 'Crew' section

### DIFF
--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -177,9 +177,15 @@ const PersonDetails = () => {
         value={currentJobType}
         className="rounded-r-only"
       >
-        <option value="all">All</option>
+        <option key="all" value="all">
+          {intl.formatMessage(globalMessages.all)}
+        </option>
         {uniqueJobs?.map((job) => {
-          return <option value={job}>{job}</option>;
+          return (
+            <option key={job} value={job}>
+              {job}
+            </option>
+          );
         })}
       </select>
     </div>

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -33,6 +33,7 @@ const PersonDetails = () => {
   const intl = useIntl();
   const router = useRouter();
   const [currentMediaType, setCurrentMediaType] = useState<string>('all');
+  const [currentJobType, setCurrentJobType] = useState<string>('all');
   const { data, error } = useSWR<PersonDetailsType>(
     `/api/v1/person/${router.query.personId}`
   );
@@ -85,6 +86,10 @@ const PersonDetails = () => {
       }
       return 1;
     });
+  }, [combinedCredits, currentMediaType]);
+
+  const uniqueJobs = useMemo(() => {
+    return [...new Set(sortedCrew.flatMap((obj) => obj.job.split(', ')))];
   }, [combinedCredits, currentMediaType]);
 
   if (!data && !error) {
@@ -158,6 +163,28 @@ const PersonDetails = () => {
     </div>
   );
 
+  const jobPicker = (
+    <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
+      <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+        <CircleStackIcon className="h-6 w-6" />
+      </span>
+      <select
+        id="jobType"
+        name="jobType"
+        onChange={(e) => {
+          setCurrentJobType(e.target.value);
+        }}
+        value={currentJobType}
+        className="rounded-r-only"
+      >
+        <option value="all">All</option>
+        {uniqueJobs?.map((job) => {
+          return <option value={job}>{job}</option>;
+        })}
+      </select>
+    </div>
+  );
+
   const cast = (sortedCast ?? []).length > 0 && (
     <>
       <div className="slider-header">
@@ -202,38 +229,45 @@ const PersonDetails = () => {
   const crew = (sortedCrew ?? []).length > 0 && (
     <>
       <div className="slider-header">
-        <div className="slider-title">
+        <div className="slider-title flex w-full justify-center justify-between">
           <span>{intl.formatMessage(messages.crewmember)}</span>
+          <div>{jobPicker}</div>
         </div>
       </div>
       <ul className="cards-vertical">
-        {sortedCrew?.map((media, index) => {
-          return (
-            <li key={`list-crew-item-${media.id}-${index}`}>
-              <TitleCard
-                key={media.id}
-                id={media.id}
-                title={media.mediaType === 'movie' ? media.title : media.name}
-                userScore={media.voteAverage}
-                year={
-                  media.mediaType === 'movie'
-                    ? media.releaseDate
-                    : media.firstAirDate
-                }
-                image={media.posterPath}
-                summary={media.overview}
-                mediaType={media.mediaType as 'movie' | 'tv'}
-                status={media.mediaInfo?.status}
-                canExpand
-              />
-              {media.job && (
-                <div className="mt-2 w-full truncate text-center text-xs text-gray-300">
-                  {media.job}
-                </div>
-              )}
-            </li>
-          );
-        })}
+        {sortedCrew
+          ?.filter((media) => {
+            return (
+              currentJobType === 'all' || media.job.includes(currentJobType)
+            );
+          })
+          .map((media, index) => {
+            return (
+              <li key={`list-crew-item-${media.id}-${index}`}>
+                <TitleCard
+                  key={media.id}
+                  id={media.id}
+                  title={media.mediaType === 'movie' ? media.title : media.name}
+                  userScore={media.voteAverage}
+                  year={
+                    media.mediaType === 'movie'
+                      ? media.releaseDate
+                      : media.firstAirDate
+                  }
+                  image={media.posterPath}
+                  summary={media.overview}
+                  mediaType={media.mediaType as 'movie' | 'tv'}
+                  status={media.mediaInfo?.status}
+                  canExpand
+                />
+                {media.job && (
+                  <div className="mt-2 w-full truncate text-center text-xs text-gray-300">
+                    {media.job}
+                  </div>
+                )}
+              </li>
+            );
+          })}
       </ul>
     </>
   );

--- a/src/components/PersonDetails/index.tsx
+++ b/src/components/PersonDetails/index.tsx
@@ -244,7 +244,8 @@ const PersonDetails = () => {
         {sortedCrew
           ?.filter((media) => {
             return (
-              currentJobType === 'all' || media.job.includes(currentJobType)
+              currentJobType === 'all' ||
+              media.job.split(', ').includes(currentJobType)
             );
           })
           .map((media, index) => {


### PR DESCRIPTION

## Description

This commit adds a job filter to the 'Crew' section on `/person/[id]`.

Say I want to download every movie directed by Akira Kurosawa - his `/person` page has many results where he was not the director, which makes it more difficult to get only the movies I want.

AI usage disclaimer:
- Used Claude Code to search the repo for existing issues/PRs related to this feature
- Used Claude Code in a chat-only manner to assist with a few minor errors I ran into (just TS noob stuff)
- All code was written by hand

## How Has This Been Tested?

Ran full test suite locally; all pass. Tested functionality in browser.

## Screenshots / Logs (if applicable)

<img width="1559" height="657" alt="image" src="https://github.com/user-attachments/assets/16d9e35c-ea79-4bb2-a16c-e629b68a3f5d" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a job-type filter to the crew list.
  * Users can choose a specific job type or switch back to viewing all crew.
  * Crew members’ job titles continue to display when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->