### PR TITLE
fix: changes the suggested url from plex's "hosted" app

### DIFF
--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -66,7 +66,7 @@ const messages = defineMessages('components.Settings', {
   validationPortRequired: 'You must provide a valid port number',
   webAppUrl: '<WebAppLink>Web App</WebAppLink> URL',
   webAppUrlTip:
-    'Optionally direct users to the web app on your server instead of the "hosted" web app',
+    'Optionally direct users to the web app on your server instead of the https://app.plex.tv/desktop',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
     'Optionally configure the settings for your Tautulli server. Seerr fetches watch history data for your Plex media from Tautulli.',
@@ -597,7 +597,7 @@ const SettingsPlex = ({ onComplete }: SettingsPlexProps) => {
                       inputMode="url"
                       id="webAppUrl"
                       name="webAppUrl"
-                      placeholder="https://app.plex.tv/desktop"
+                      placeholder="https://your-server-fqdn.com/web/index.html"
                     />
                   </div>
                   {errors.webAppUrl &&

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -66,7 +66,7 @@ const messages = defineMessages('components.Settings', {
   validationPortRequired: 'You must provide a valid port number',
   webAppUrl: '<WebAppLink>Web App</WebAppLink> URL',
   webAppUrlTip:
-    'Optionally direct users to the web app on your server instead of the https://app.plex.tv/desktop',
+    'Optionally direct users to the web app on your server instead of https://app.plex.tv/desktop',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
     'Optionally configure the settings for your Tautulli server. Seerr fetches watch history data for your Plex media from Tautulli.',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1308,7 +1308,7 @@
   "components.Settings.validationUrlTrailingSlash": "URL must not end in a trailing slash",
   "components.Settings.valueRequired": "You must provide a value.",
   "components.Settings.webAppUrl": "<WebAppLink>Web App</WebAppLink> URL",
-  "components.Settings.webAppUrlTip": "Optionally direct users to the web app on your server instead of the https://app.plex.tv/desktop",
+  "components.Settings.webAppUrlTip": "Optionally direct users to the web app on your server instead of https://app.plex.tv/desktop",
   "components.Settings.webhook": "Webhook",
   "components.Settings.webpush": "Web Push",
   "components.Settings.yes": "Yes",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1308,7 +1308,7 @@
   "components.Settings.validationUrlTrailingSlash": "URL must not end in a trailing slash",
   "components.Settings.valueRequired": "You must provide a value.",
   "components.Settings.webAppUrl": "<WebAppLink>Web App</WebAppLink> URL",
-  "components.Settings.webAppUrlTip": "Optionally direct users to the web app on your server instead of the \"hosted\" web app",
+  "components.Settings.webAppUrlTip": "Optionally direct users to the web app on your server instead of the https://app.plex.tv/desktop",
   "components.Settings.webhook": "Webhook",
   "components.Settings.webpush": "Web Push",
   "components.Settings.yes": "Yes",


### PR DESCRIPTION
changes the suggested url from plex's "hosted" app to recommend the users server url


<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This changes the suggested url from plex's hosted app I.E. https://app.plex.tv/desktop to recommend setting it to your servers fqdn for example https://your-servers-fqdn.com/web/index.html allowing you to have the users to click on the open in plex button when looking at media and have it open directly on the servers web app.

- Fixes #3220

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [x] have ran pnpm dev
- [x] have ran pnpm build

## Screenshots / Logs (if applicable)

<img width="1404" height="951" alt="Screenshot From 2026-07-15 12-05-40" src="https://github.com/user-attachments/assets/6b589f78-d08b-49e4-bb33-d97909a41b8a" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


### AI Disclosure

AI was not used in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated Plex web app setup guidance to point users to the default destination URL more explicitly.
  * Changed the web app URL field placeholder to an example server-based path (`https://your-server-fqdn.com/web/index.html`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->