### PR TITLE
fix(plex): limit concurrent watchlist metadata requests

### DIFF
--- a/server/api/plextv.test.ts
+++ b/server/api/plextv.test.ts
@@ -1,0 +1,154 @@
+import PlexTvAPI, { WATCHLIST_METADATA_CONCURRENCY } from '@server/api/plextv';
+import cacheManager from '@server/lib/cache';
+import type {
+  AxiosAdapter,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+class TestPlexTvAPI extends PlexTvAPI {
+  public installAdapter(adapter: AxiosAdapter): void {
+    this.axios.defaults.adapter = adapter;
+  }
+}
+
+function axiosResponse<T>(
+  config: InternalAxiosRequestConfig,
+  data: T,
+  headers: Record<string, string> = {}
+): AxiosResponse<T> {
+  return {
+    data,
+    status: 200,
+    statusText: 'OK',
+    headers,
+    config,
+    request: {},
+  };
+}
+
+function watchlistResponse(count: number) {
+  return {
+    MediaContainer: {
+      totalSize: count,
+      Metadata: Array.from({ length: count }, (_, index) => ({
+        ratingKey: `rk-${index + 1}`,
+      })),
+    },
+  };
+}
+
+function metadataResponse(ratingKey: string) {
+  const id = ratingKey.replace('rk-', '');
+
+  return {
+    MediaContainer: {
+      Metadata: [
+        {
+          ratingKey,
+          type: 'movie' as const,
+          title: `Movie ${id}`,
+          Guid: [{ id: `tmdb://${id}` as const }],
+        },
+      ],
+    },
+  };
+}
+
+function isMetadataRequest(url: string | undefined): boolean {
+  return !!url?.includes('/library/metadata/');
+}
+
+function isWatchlistRequest(url: string | undefined): boolean {
+  return !!url?.includes('/library/sections/watchlist/all');
+}
+
+describe('PlexTvAPI.getWatchlist metadata fetching', () => {
+  beforeEach(() => {
+    cacheManager.getCache('plexwatchlist').flush();
+    cacheManager.getCache('plextv').flush();
+  });
+
+  afterEach(() => {
+    cacheManager.getCache('plexwatchlist').flush();
+    cacheManager.getCache('plextv').flush();
+  });
+
+  it('limits concurrent metadata requests', async () => {
+    const itemCount = 12;
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const api = new TestPlexTvAPI('test-token');
+    api.installAdapter(async (config) => {
+      const url = config.url;
+
+      if (isWatchlistRequest(url)) {
+        return axiosResponse(config, watchlistResponse(itemCount), {
+          etag: 'test-etag',
+        });
+      }
+
+      if (isMetadataRequest(url)) {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        inFlight--;
+
+        const ratingKey = url?.split('/library/metadata/')[1] ?? '';
+        return axiosResponse(config, metadataResponse(ratingKey));
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await api.getWatchlist({ size: itemCount });
+
+    assert.strictEqual(result.items.length, itemCount);
+    assert.ok(
+      maxInFlight <= WATCHLIST_METADATA_CONCURRENCY,
+      `expected at most ${WATCHLIST_METADATA_CONCURRENCY} concurrent metadata requests, saw ${maxInFlight}`
+    );
+  });
+
+  it('returns partial results when individual metadata requests fail', async () => {
+    const itemCount = 8;
+
+    const api = new TestPlexTvAPI('test-token');
+    api.installAdapter(async (config) => {
+      const url = config.url;
+
+      if (isWatchlistRequest(url)) {
+        return axiosResponse(config, watchlistResponse(itemCount), {
+          etag: 'test-etag',
+        });
+      }
+
+      if (isMetadataRequest(url)) {
+        const ratingKey = url?.split('/library/metadata/')[1] ?? '';
+
+        if (Number(ratingKey.replace('rk-', '')) % 2 === 0) {
+          const error = new Error('connect ETIMEDOUT') as Error & {
+            code: string;
+          };
+          error.code = 'ETIMEDOUT';
+          throw error;
+        }
+
+        return axiosResponse(config, metadataResponse(ratingKey));
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await api.getWatchlist({ size: itemCount });
+
+    assert.strictEqual(result.items.length, 4);
+    assert.ok(
+      result.items.every((item) => Number(item.tmdbId) % 2 === 1),
+      'only odd-numbered watchlist items should be returned'
+    );
+  });
+});

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -135,6 +135,38 @@ export interface PlexWatchlistCache {
   response: WatchlistResponse;
 }
 
+export const WATCHLIST_METADATA_CONCURRENCY = 5;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) {
+        return;
+      }
+
+      results[index] = await fn(items[index]);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker())
+  );
+
+  return results;
+}
+
 class PlexTvAPI extends ExternalAPI {
   private authToken: string;
 
@@ -268,6 +300,65 @@ class PlexTvAPI extends ExternalAPI {
     return parsedXml;
   }
 
+  private async fetchWatchlistItemMetadata(watchlistItem: {
+    ratingKey: string;
+  }): Promise<PlexWatchlistItem | null> {
+    let detailedResponse: MetadataResponse;
+    try {
+      detailedResponse = await this.getRolling<MetadataResponse>(
+        `/library/metadata/${watchlistItem.ratingKey}`,
+        {
+          baseURL: 'https://discover.provider.plex.tv',
+        }
+      );
+    } catch (e) {
+      if (e.response?.status === 404) {
+        logger.warn(
+          `Item with ratingKey ${watchlistItem.ratingKey} not found, it may have been removed from the server.`,
+          { label: 'Plex.TV Metadata API' }
+        );
+      } else {
+        logger.warn(
+          `Failed to fetch metadata for ratingKey ${watchlistItem.ratingKey}`,
+          {
+            label: 'Plex.TV Metadata API',
+            errorMessage: e.message,
+          }
+        );
+      }
+      return null;
+    }
+
+    const metadata =
+      detailedResponse.MediaContainer.Metadata?.[0] ??
+      detailedResponse.MediaContainer.Video?.[0];
+
+    if (!metadata) {
+      logger.warn(
+        `Item with ratingKey ${watchlistItem.ratingKey} returned no metadata, skipping.`,
+        { label: 'Plex.TV Metadata API' }
+      );
+      return null;
+    }
+
+    const tmdbString = metadata.Guid?.find((guid) =>
+      guid.id.startsWith('tmdb')
+    );
+    const tvdbString = metadata.Guid?.find((guid) =>
+      guid.id.startsWith('tvdb')
+    );
+
+    return {
+      ratingKey: metadata.ratingKey,
+      // This should always be set? But I guess it also cannot be?
+      // We will filter out the 0's afterwards
+      tmdbId: tmdbString ? Number(tmdbString.id.split('//')[1]) : 0,
+      tvdbId: tvdbString ? Number(tvdbString.id.split('//')[1]) : undefined,
+      title: metadata.title,
+      type: metadata.type,
+    };
+  }
+
   public async getWatchlist({
     offset = 0,
     size = 20,
@@ -311,61 +402,10 @@ class PlexTvAPI extends ExternalAPI {
         );
       }
 
-      const watchlistDetails = await Promise.all(
-        (cachedWatchlist?.response.MediaContainer.Metadata ?? []).map(
-          async (watchlistItem) => {
-            let detailedResponse: MetadataResponse;
-            try {
-              detailedResponse = await this.getRolling<MetadataResponse>(
-                `/library/metadata/${watchlistItem.ratingKey}`,
-                {
-                  baseURL: 'https://discover.provider.plex.tv',
-                }
-              );
-            } catch (e) {
-              if (e.response?.status === 404) {
-                logger.warn(
-                  `Item with ratingKey ${watchlistItem.ratingKey} not found, it may have been removed from the server.`,
-                  { label: 'Plex.TV Metadata API' }
-                );
-                return null;
-              } else {
-                throw e;
-              }
-            }
-
-            const metadata =
-              detailedResponse.MediaContainer.Metadata?.[0] ??
-              detailedResponse.MediaContainer.Video?.[0];
-
-            if (!metadata) {
-              logger.warn(
-                `Item with ratingKey ${watchlistItem.ratingKey} returned no metadata, skipping.`,
-                { label: 'Plex.TV Metadata API' }
-              );
-              return null;
-            }
-
-            const tmdbString = metadata.Guid?.find((guid) =>
-              guid.id.startsWith('tmdb')
-            );
-            const tvdbString = metadata.Guid?.find((guid) =>
-              guid.id.startsWith('tvdb')
-            );
-
-            return {
-              ratingKey: metadata.ratingKey,
-              // This should always be set? But I guess it also cannot be?
-              // We will filter out the 0's afterwards
-              tmdbId: tmdbString ? Number(tmdbString.id.split('//')[1]) : 0,
-              tvdbId: tvdbString
-                ? Number(tvdbString.id.split('//')[1])
-                : undefined,
-              title: metadata.title,
-              type: metadata.type,
-            };
-          }
-        )
+      const watchlistDetails = await mapWithConcurrency(
+        cachedWatchlist?.response.MediaContainer.Metadata ?? [],
+        WATCHLIST_METADATA_CONCURRENCY,
+        (watchlistItem) => this.fetchWatchlistItemMetadata(watchlistItem)
       );
 
       const filteredList = watchlistDetails.filter(


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The PR makes Plex Discover watchlist syncing a bit more robust.

Previously, all metadata requests were fired at the same time, which worked fine in most cases but could cause problems in Docker. After a bit of testing, limiting the number of concurrent requests to 5 turned out to be a good balance and avoids the connection timeouts.

It also changes the sync behavior so that if fetching metadata for a single watchlist item fails (for example with `ETIMEDOUT` or `ENETUNREACH`), that item is simply skipped instead of causing the entire sync to fail.

The issue seemed to be specific to opening a large number of simultaneous HTTPS connections to `discover.provider.plex.tv.`

- Fixes #3235

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test + docker.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
