### PR TITLE
feat(ui): use yellow for partially available status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
+# Seerr — Custom Fork: Yellow Partial Availability Badges
+
+> ⚠️ This is a personal fork of [seerr-team/seerr](https://github.com/seerr-team/seerr).
+> For the official project, install instructions, and support, use the upstream repo.
+
+## What this fork changes
+
+This fork changes the color of the **Partially Available** status so it's visually
+distinct from fully Available media:
+
+- ✅ **Available** — green (unchanged)
+- 🟡 **Partially Available** — now **yellow** instead of green, on both:
+  - The status badge on movie/show detail pages (`StatusBadge`)
+  - The mini status dot on poster thumbnails (`StatusBadgeMini`)
+
+### Why?
+
+In upstream Seerr, both "Available" and "Partially Available" render green, making it
+hard to tell at a glance whether a show is complete or still missing seasons/episodes
+(e.g., currently-airing shows). This fork makes partial availability instantly
+recognizable.
+
+## Files changed
+
+- `src/components/StatusBadge/index.tsx`
+- `src/components/Common/StatusBadgeMini/index.tsx`
+
+## Building
+
+```bash
+docker build --build-arg COMMIT_TAG=custom-v2 -t seerr-custom .
+```
+
+Then point your docker-compose at `seerr-custom:latest` instead of the official image.
+
+---
+
+*Original README below:*
+
+
+
+
 <p align="center">
 <img src="./public/logo_full.svg" alt="Seerr" style="margin: 20px 0;">
 </p>

--- a/src/components/Common/StatusBadgeMini/index.tsx
+++ b/src/components/Common/StatusBadgeMini/index.tsx
@@ -56,7 +56,7 @@ const StatusBadgeMini = ({
       break;
     case MediaStatus.PARTIALLY_AVAILABLE:
       badgeStyle.push(
-        'bg-green-500/80 border-green-400 ring-green-400 text-green-100'
+        'bg-yellow-500/80 border-yellow-400 ring-yellow-400 text-yellow-100'
       );
       indicatorIcon = <MinusSmallIcon />;
       break;

--- a/src/components/StatusBadge/index.tsx
+++ b/src/components/StatusBadge/index.tsx
@@ -232,7 +232,7 @@ const StatusBadge = ({
           }}
         >
           <Badge
-            badgeType="success"
+            badgeType="warning"
             href={mediaLink}
             className={`${
               inProgress && 'relative !bg-gray-700/80 !px-0 hover:!bg-gray-700'


### PR DESCRIPTION
## Description

Changes the color of the "Partially Available" status from green to yellow, making it visually distinct from fully "Available" media at a glance.

Currently both Available and Partially Available render green — on poster thumbnails and detail pages, there's no way to tell whether a show is complete or still missing seasons/episodes (e.g., currently-airing shows) without clicking into it.

With this change:
- Available — green (unchanged)
- Partially Available — yellow, matching the existing Pending badge style

Files changed:
- `src/components/StatusBadge/index.tsx` — detail page badge uses `badgeType="warning"` for `PARTIALLY_AVAILABLE`
- `src/components/Common/StatusBadgeMini/index.tsx` — thumbnail status dot uses yellow styling for `PARTIALLY_AVAILABLE` (minus icon unchanged, now more distinguishable from the green checkmark)

AI Disclosure: I used Claude (AI assistant) to help locate the relevant components and draft the changes. I applied, built, and tested them myself on my own instance.

## How Has This Been Tested?

Built a custom Docker image from this branch (`docker build`) and deployed it to my own Seerr instance (Windows Server, Docker Desktop, connected to Plex/Sonarr/Radarr). Verified visually that:
- Partially available shows (currently-airing series) display yellow badges on both thumbnails and detail pages
- Fully available media still displays green
- Pending, Processing, Blocklisted, and Deleted statuses are unaffected

## Screenshots / Logs (if applicable)
<img width="183" height="280" alt="image" src="https://github.com/user-attachments/assets/058b3e04-42c1-4adc-a8fb-c53029c4d7b3" />
<img width="591" height="340" alt="image" src="https://github.com/user-attachments/assets/64dc4969-e9e0-490b-9f8f-77026c785ae0" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the **Partially Available** status indicator from green to yellow on media detail pages and poster thumbnails for clearer status distinction.

* **Documentation**
  * Added fork-specific documentation, including the updated status styling and Docker build and deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->