### PR TITLE
feat(discover): add setting to hide requested media from discover pages

### DIFF
--- a/docs/using-seerr/settings/general.md
+++ b/docs/using-seerr/settings/general.md
@@ -65,6 +65,14 @@ Available media will still appear in search results, however, so it is possible 
 
 This setting is **disabled** by default.
 
+## Hide Requested Media
+
+When enabled, movies and series with at least one pending or approved request will not appear on the "Discover" home page, or in the "Recommended" or "Similar" categories or other links on media detail pages. This includes partially requested series (e.g. when only some seasons have been requested) and 4K requests. Media with only declined, failed, or completed requests is not hidden.
+
+Requested media will still appear in search results, however, so it is possible to locate and view hidden items by searching for them by title.
+
+This setting is **disabled** by default.
+
 ## Hide Blocklisted Items
 
 When enabled, media that has been blocklisted will not appear on the "Discover" home page, for all administrators. This can be useful to hide content that you don't want to see, such as content with specific tags or content that has been manually blocklisted when you have the "Manage Blocklist" permission.

--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -232,6 +232,9 @@ components:
         hideAvailable:
           type: boolean
           example: false
+        hideRequested:
+          type: boolean
+          example: false
         partialRequestsEnabled:
           type: boolean
           example: false
@@ -1296,6 +1299,11 @@ components:
           readOnly: true
           items:
             $ref: '#/components/schemas/MediaRequest'
+        hasActiveRequest:
+          type: boolean
+          readOnly: true
+          nullable: true
+          description: Only populated when the "Hide Requested Media" setting is enabled. True if at least one request is pending or approved.
         createdAt:
           type: string
           example: '2020-09-12T10:00:27.000Z'

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -1,6 +1,10 @@
 import RadarrAPI from '@server/api/servarr/radarr';
 import SonarrAPI from '@server/api/servarr/sonarr';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import { getRepository } from '@server/datasource';
 import { Blocklist } from '@server/entity/Blocklist';
@@ -53,9 +57,35 @@ class Media {
         .where(' media.tmdbId in (:...finalIds)', { finalIds })
         .getMany();
 
-      return media.filter((m) =>
+      const relatedMedia = media.filter((m) =>
         items.some((i) => i.tmdbId === m.tmdbId && i.mediaType === m.mediaType)
       );
+
+      // Only fetch active request state when it is actually used for
+      // filtering, so the default configuration adds no extra query. Only
+      // media IDs are selected; no request or user data leaves the server.
+      if (getSettings().main.hideRequested && relatedMedia.length > 0) {
+        const activeRequestMediaIds = await mediaRepository
+          .createQueryBuilder('media')
+          .select('media.id', 'id')
+          .distinct(true)
+          .innerJoin('media.requests', 'request')
+          .where('media.id IN (:...mediaIds)', {
+            mediaIds: relatedMedia.map((m) => m.id),
+          })
+          .andWhere('request.status IN (:...statuses)', {
+            statuses: [MediaRequestStatus.PENDING, MediaRequestStatus.APPROVED],
+          })
+          .getRawMany<{ id: number }>();
+
+        const activeIds = new Set(activeRequestMediaIds.map((row) => row.id));
+
+        relatedMedia.forEach((m) => {
+          m.hasActiveRequest = activeIds.has(m.id);
+        });
+      }
+
+      return relatedMedia;
     } catch (e) {
       logger.error(e.message);
       return [];
@@ -187,6 +217,12 @@ class Media {
 
   public serviceUrl?: string;
   public serviceUrl4k?: string;
+  /**
+   * Transient flag set by `getRelatedMedia` when the "Hide Requested Media"
+   * setting is enabled: true if at least one request (any season, standard or
+   * 4K) is pending or approved.
+   */
+  public hasActiveRequest?: boolean;
   public downloadStatus?: DownloadingItem[] = [];
   public downloadStatus4k?: DownloadingItem[] = [];
 

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -31,6 +31,7 @@ export interface PublicSettingsResponse {
   applicationUrl: string;
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -141,6 +141,7 @@ export interface MainSettings {
   };
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   newPlexLogin: boolean;
@@ -193,6 +194,7 @@ interface FullPublicSettings extends PublicSettings {
   applicationUrl: string;
   hideAvailable: boolean;
   hideBlocklisted: boolean;
+  hideRequested: boolean;
   localLogin: boolean;
   mediaServerLogin: boolean;
   movie4kEnabled: boolean;
@@ -414,6 +416,7 @@ class Settings {
         },
         hideAvailable: false,
         hideBlocklisted: false,
+        hideRequested: false,
         localLogin: true,
         mediaServerLogin: true,
         newPlexLogin: true,
@@ -709,6 +712,7 @@ class Settings {
       applicationUrl: this.data.main.applicationUrl,
       hideAvailable: this.data.main.hideAvailable,
       hideBlocklisted: this.data.main.hideBlocklisted,
+      hideRequested: this.data.main.hideRequested,
       localLogin: this.data.main.localLogin,
       mediaServerLogin: this.data.main.mediaServerLogin,
       jellyfinExternalHost: this.data.jellyfin.externalHostname,

--- a/server/test/entity/Media.test.ts
+++ b/server/test/entity/Media.test.ts
@@ -1,0 +1,209 @@
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import SeasonRequest from '@server/entity/SeasonRequest';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+// Prevent the AfterInsert/AfterUpdate hooks on MediaRequest from reaching
+// out to TMDB / notification agents while seeding requests.
+Object.defineProperty(MediaRequest, 'sendNotification', {
+  value: async () => undefined,
+  writable: true,
+  configurable: true,
+});
+
+setupTestDb();
+
+async function seedMedia(
+  tmdbId: number,
+  mediaType: MediaType,
+  status: MediaStatus = MediaStatus.UNKNOWN
+): Promise<Media> {
+  const mediaRepository = getRepository(Media);
+  return mediaRepository.save(
+    new Media({
+      tmdbId,
+      mediaType,
+      status,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+}
+
+async function seedRequest(
+  media: Media,
+  status: MediaRequestStatus,
+  { is4k = false, seasons = [] as number[] } = {}
+): Promise<MediaRequest> {
+  const userRepository = getRepository(User);
+  const admin = await userRepository.findOneOrFail({ where: { id: 1 } });
+
+  const requestRepository = getRepository(MediaRequest);
+  return requestRepository.save(
+    new MediaRequest({
+      media,
+      requestedBy: admin,
+      status,
+      type: media.mediaType,
+      is4k,
+      seasons: seasons.map(
+        (seasonNumber) => new SeasonRequest({ seasonNumber, status })
+      ),
+    })
+  );
+}
+
+async function getRelatedSingle(media: Media): Promise<Media> {
+  const results = await Media.getRelatedMedia(undefined, [
+    { tmdbId: media.tmdbId, mediaType: media.mediaType },
+  ]);
+
+  assert.strictEqual(results.length, 1);
+  return results[0];
+}
+
+describe('Media.getRelatedMedia active request state', () => {
+  afterEach(() => {
+    getSettings().main.hideRequested = false;
+  });
+
+  it('does not compute hasActiveRequest when hideRequested is disabled', async () => {
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.PENDING);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, undefined);
+  });
+
+  it('flags media with a PENDING request', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.PENDING);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, true);
+  });
+
+  it('flags media with an APPROVED request', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.APPROVED);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, true);
+  });
+
+  it('does not flag media with only DECLINED, FAILED, or COMPLETED requests', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.DECLINED);
+    await seedRequest(movie, MediaRequestStatus.FAILED);
+    await seedRequest(movie, MediaRequestStatus.COMPLETED);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, false);
+  });
+
+  it('does not flag media without any requests', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, false);
+  });
+
+  it('flags a 4K-only request', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.PENDING, { is4k: true });
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.hasActiveRequest, true);
+  });
+
+  it('flags a partially available series with an active season request', async () => {
+    getSettings().main.hideRequested = true;
+
+    const tv = await seedMedia(
+      200,
+      MediaType.TV,
+      MediaStatus.PARTIALLY_AVAILABLE
+    );
+    await seedRequest(tv, MediaRequestStatus.COMPLETED, { seasons: [1] });
+    await seedRequest(tv, MediaRequestStatus.PENDING, { seasons: [2] });
+
+    const related = await getRelatedSingle(tv);
+
+    assert.strictEqual(related.status, MediaStatus.PARTIALLY_AVAILABLE);
+    assert.strictEqual(related.hasActiveRequest, true);
+  });
+
+  it('does not flag a partially available series without active requests', async () => {
+    getSettings().main.hideRequested = true;
+
+    const tv = await seedMedia(
+      200,
+      MediaType.TV,
+      MediaStatus.PARTIALLY_AVAILABLE
+    );
+    await seedRequest(tv, MediaRequestStatus.COMPLETED, { seasons: [1] });
+
+    const related = await getRelatedSingle(tv);
+
+    assert.strictEqual(related.hasActiveRequest, false);
+  });
+
+  it('handles multiple media in a single batch', async () => {
+    getSettings().main.hideRequested = true;
+
+    const requested = await seedMedia(100, MediaType.MOVIE);
+    const unrequested = await seedMedia(101, MediaType.MOVIE);
+    await seedRequest(requested, MediaRequestStatus.PENDING);
+
+    const results = await Media.getRelatedMedia(undefined, [
+      { tmdbId: requested.tmdbId, mediaType: MediaType.MOVIE },
+      { tmdbId: unrequested.tmdbId, mediaType: MediaType.MOVIE },
+    ]);
+
+    assert.strictEqual(results.length, 2);
+    const byTmdbId = new Map(results.map((m) => [m.tmdbId, m]));
+    assert.strictEqual(byTmdbId.get(100)?.hasActiveRequest, true);
+    assert.strictEqual(byTmdbId.get(101)?.hasActiveRequest, false);
+  });
+
+  it('does not expose request or user data in the result', async () => {
+    getSettings().main.hideRequested = true;
+
+    const movie = await seedMedia(100, MediaType.MOVIE);
+    await seedRequest(movie, MediaRequestStatus.PENDING);
+
+    const related = await getRelatedSingle(movie);
+
+    assert.strictEqual(related.requests, undefined);
+
+    const serialized = JSON.stringify(related);
+    assert.ok(!serialized.includes('"requests"'));
+    assert.ok(!serialized.includes('"requestedBy"'));
+    assert.ok(!serialized.includes('"modifiedBy"'));
+  });
+});

--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -4,6 +4,7 @@ import Slider from '@app/components/Slider';
 import TitleCard from '@app/components/TitleCard';
 import useSettings from '@app/hooks/useSettings';
 import { useUser } from '@app/hooks/useUser';
+import { filterVisibleTitles } from '@app/utils/mediaFilters';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/outline';
 import { MediaStatus } from '@server/constants/media';
 import { Permission } from '@server/lib/permissions';
@@ -65,22 +66,11 @@ const MediaSlider = ({
     [] as (MovieResult | TvResult | PersonResult)[]
   );
 
-  if (settings.currentSettings.hideAvailable) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
-        i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE
-    );
-  }
-
-  if (settings.currentSettings.hideBlocklisted) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.BLOCKLISTED
-    );
-  }
+  titles = filterVisibleTitles(titles, {
+    hideAvailable: settings.currentSettings.hideAvailable,
+    hideBlocklisted: settings.currentSettings.hideBlocklisted,
+    hideRequested: settings.currentSettings.hideRequested,
+  });
 
   useEffect(() => {
     if (

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -34,7 +34,7 @@ const Search = () => {
     {
       query: router.query.query,
     },
-    { hideAvailable: false, hideBlocklisted: false }
+    { hideAvailable: false, hideBlocklisted: false, hideRequested: false }
   );
 
   if (error) {

--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -62,6 +62,9 @@ const messages = defineMessages('components.Settings.SettingsMain', {
   hideAvailable: 'Hide Available Media',
   hideAvailableTip:
     'Hide available media from the discover pages but not search results',
+  hideRequested: 'Hide Requested Media',
+  hideRequestedTip:
+    'Hide media with pending or approved requests, including partially requested series, from the discover pages but not search results',
   cacheImages: 'Enable Image Caching',
   cacheImagesTip:
     'Cache externally sourced images (requires a significant amount of disk space)',
@@ -171,6 +174,7 @@ const SettingsMain = () => {
             applicationUrl: data?.applicationUrl,
             hideAvailable: data?.hideAvailable,
             hideBlocklisted: data?.hideBlocklisted,
+            hideRequested: data?.hideRequested,
             locale: data?.locale ?? 'en',
             discoverRegion: data?.discoverRegion,
             originalLanguage: data?.originalLanguage,
@@ -193,6 +197,7 @@ const SettingsMain = () => {
                 applicationUrl: values.applicationUrl,
                 hideAvailable: values.hideAvailable,
                 hideBlocklisted: values.hideBlocklisted,
+                hideRequested: values.hideRequested,
                 locale: values.locale,
                 discoverRegion: values.discoverRegion,
                 streamingRegion: values.streamingRegion,
@@ -511,6 +516,27 @@ const SettingsMain = () => {
                       name="hideAvailable"
                       onChange={() => {
                         setFieldValue('hideAvailable', !values.hideAvailable);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="form-row">
+                  <label htmlFor="hideRequested" className="checkbox-label">
+                    <span className="mr-2">
+                      {intl.formatMessage(messages.hideRequested)}
+                    </span>
+                    <SettingsBadge badgeType="experimental" />
+                    <span className="label-tip">
+                      {intl.formatMessage(messages.hideRequestedTip)}
+                    </span>
+                  </label>
+                  <div className="form-input-area">
+                    <Field
+                      type="checkbox"
+                      id="hideRequested"
+                      name="hideRequested"
+                      onChange={() => {
+                        setFieldValue('hideRequested', !values.hideRequested);
                       }}
                     />
                   </div>

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -14,6 +14,7 @@ const defaultSettings = {
   applicationUrl: '',
   hideAvailable: false,
   hideBlocklisted: false,
+  hideRequested: false,
   localLogin: true,
   mediaServerLogin: true,
   movie4kEnabled: false,

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -1,6 +1,7 @@
 import useToasts from '@app/hooks/useToasts';
 import globalMessages from '@app/i18n/globalMessages';
-import { MediaStatus } from '@server/constants/media';
+import { filterVisibleTitles } from '@app/utils/mediaFilters';
+import type { MediaStatus } from '@server/constants/media';
 import { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import useSWRInfinite from 'swr/infinite';
@@ -19,6 +20,7 @@ interface BaseMedia {
   mediaType: string;
   mediaInfo?: {
     status: MediaStatus;
+    hasActiveRequest?: boolean;
   };
 }
 
@@ -58,7 +60,7 @@ const useDiscover = <
 >(
   endpoint: string,
   options?: O,
-  { hideAvailable = true, hideBlocklisted = true } = {}
+  { hideAvailable = true, hideBlocklisted = true, hideRequested = true } = {}
 ): DiscoverResult<T, S> => {
   const settings = useSettings();
   const { hasPermission } = useUser();
@@ -121,33 +123,37 @@ const useDiscover = <
     return [...a, ...results];
   }, [] as T[]);
 
-  if (settings.currentSettings.hideAvailable && hideAvailable) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
-        i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE
-    );
-  }
+  titles = filterVisibleTitles(titles, {
+    hideAvailable: settings.currentSettings.hideAvailable && hideAvailable,
+    hideBlocklisted:
+      settings.currentSettings.hideBlocklisted &&
+      hideBlocklisted &&
+      hasPermission(Permission.MANAGE_BLOCKLIST),
+    hideRequested: settings.currentSettings.hideRequested && hideRequested,
+  });
 
-  if (
-    settings.currentSettings.hideBlocklisted &&
-    hideBlocklisted &&
-    hasPermission(Permission.MANAGE_BLOCKLIST)
-  ) {
-    titles = titles.filter(
-      (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.BLOCKLISTED
-    );
-  }
-
-  const isEmpty = !isLoadingInitialData && titles?.length === 0;
+  const isEmpty =
+    !isLoadingInitialData && !isLoadingMore && titles?.length === 0;
   const isReachingEnd =
-    isEmpty ||
-    (!!data && (data[data?.length - 1]?.results.length ?? 0) < 20) ||
-    (!!data && (data[data?.length - 1]?.totalResults ?? 0) <= size * 20) ||
-    (!!data && (data[data?.length - 1]?.totalResults ?? 0) < 41);
+    (!!data && (data[data.length - 1]?.results.length ?? 0) < 20) ||
+    (!!data && (data[data.length - 1]?.totalResults ?? 0) <= size * 20) ||
+    (!!data && (data[data.length - 1]?.totalResults ?? 0) < 41);
+
+  // When client-side filters (hide available/blocklisted/requested) empty out
+  // entire pages, keep fetching a bounded number of extra pages so the view
+  // does not appear exhausted while the server still has results.
+  useEffect(() => {
+    if (
+      !!data &&
+      titles.length < 20 &&
+      size < 5 &&
+      !isReachingEnd &&
+      !isLoadingMore &&
+      !isValidating
+    ) {
+      setSize(size + 1);
+    }
+  }, [data, titles, size, isReachingEnd, isLoadingMore, isValidating, setSize]);
 
   useEffect(() => {
     if (error && titles.length) {

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -132,8 +132,6 @@ const useDiscover = <
     hideRequested: settings.currentSettings.hideRequested && hideRequested,
   });
 
-  const isEmpty =
-    !isLoadingInitialData && !isLoadingMore && titles?.length === 0;
   const isReachingEnd =
     (!!data && (data[data.length - 1]?.results.length ?? 0) < 20) ||
     (!!data && (data[data.length - 1]?.totalResults ?? 0) <= size * 20) ||
@@ -142,18 +140,20 @@ const useDiscover = <
   // When client-side filters (hide available/blocklisted/requested) empty out
   // entire pages, keep fetching a bounded number of extra pages so the view
   // does not appear exhausted while the server still has results.
+  const willBackfill =
+    !!data && titles.length < 20 && size < 5 && !isReachingEnd;
+
+  const isEmpty =
+    !isLoadingInitialData &&
+    !isLoadingMore &&
+    !willBackfill &&
+    titles?.length === 0;
+
   useEffect(() => {
-    if (
-      !!data &&
-      titles.length < 20 &&
-      size < 5 &&
-      !isReachingEnd &&
-      !isLoadingMore &&
-      !isValidating
-    ) {
+    if (willBackfill && !isLoadingMore && !isValidating) {
       setSize(size + 1);
     }
-  }, [data, titles, size, isReachingEnd, isLoadingMore, isValidating, setSize]);
+  }, [willBackfill, size, isLoadingMore, isValidating, setSize]);
 
   useEffect(() => {
     if (error && titles.length) {

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1030,6 +1030,8 @@
   "components.Settings.SettingsMain.hideAvailableTip": "Hide available media from the discover pages but not search results",
   "components.Settings.SettingsMain.hideBlocklisted": "Hide Blocklisted Items",
   "components.Settings.SettingsMain.hideBlocklistedTip": "Hide blocklisted items from discover pages for all users with the \"Manage Blocklist\" permission",
+  "components.Settings.SettingsMain.hideRequested": "Hide Requested Media",
+  "components.Settings.SettingsMain.hideRequestedTip": "Hide media with pending or approved requests, including partially requested series, from the discover pages but not search results",
   "components.Settings.SettingsMain.locale": "Display Language",
   "components.Settings.SettingsMain.originallanguage": "Discover Language",
   "components.Settings.SettingsMain.originallanguageTip": "Filter content by original language",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -243,6 +243,7 @@ CoreApp.getInitialProps = async (initialProps) => {
     applicationUrl: '',
     hideAvailable: false,
     hideBlocklisted: false,
+    hideRequested: false,
     movie4kEnabled: false,
     series4kEnabled: false,
     localLogin: true,

--- a/src/utils/mediaFilters.ts
+++ b/src/utils/mediaFilters.ts
@@ -1,0 +1,58 @@
+import { MediaStatus } from '@server/constants/media';
+
+interface FilterableMedia {
+  mediaType: string;
+  mediaInfo?: {
+    status?: MediaStatus;
+    hasActiveRequest?: boolean;
+  };
+}
+
+export interface MediaFilterOptions {
+  hideAvailable?: boolean;
+  hideBlocklisted?: boolean;
+  hideRequested?: boolean;
+}
+
+/**
+ * Shared visibility check for discover-style listings. Only movies and
+ * series are ever hidden; people, collections, and any other result types
+ * always remain visible.
+ */
+export const isVisibleTitle = (
+  title: FilterableMedia,
+  {
+    hideAvailable = false,
+    hideBlocklisted = false,
+    hideRequested = false,
+  }: MediaFilterOptions
+): boolean => {
+  if (title.mediaType !== 'movie' && title.mediaType !== 'tv') {
+    return true;
+  }
+
+  const status = title.mediaInfo?.status;
+
+  if (
+    hideAvailable &&
+    (status === MediaStatus.AVAILABLE ||
+      status === MediaStatus.PARTIALLY_AVAILABLE)
+  ) {
+    return false;
+  }
+
+  if (hideBlocklisted && status === MediaStatus.BLOCKLISTED) {
+    return false;
+  }
+
+  if (hideRequested && title.mediaInfo?.hasActiveRequest) {
+    return false;
+  }
+
+  return true;
+};
+
+export const filterVisibleTitles = <T extends FilterableMedia>(
+  titles: T[],
+  options: MediaFilterOptions
+): T[] => titles.filter((title) => isVisibleTitle(title, options));


### PR DESCRIPTION
## Description

This PR adds a new **"Hide Requested Media"** setting (default: off) to Settings → General. When enabled, movies and series with **at least one pending or approved request** are hidden from the Discover home page, sliders, and the Recommended/Similar sections on detail pages. This includes partially requested series (e.g. only some seasons requested) and 4K-only requests. Search results are intentionally unaffected, so hidden items can still be found by title.

It is an alternative to #1855 that implements the review feedback given there. Credit to the original author for the settings plumbing, which this PR reuses largely unchanged.

### Semantics

| Request state | Discover visibility |
| --- | --- |
| At least one `PENDING` or `APPROVED` request (any season, standard or 4K) | Hidden |
| Only `DECLINED`, `FAILED`, or `COMPLETED` requests | Visible |
| No requests (incl. media only monitored in Radarr/Sonarr) | Visible |

`FAILED` stays visible on purpose so failed requests remain discoverable and can be retried. `PARTIALLY_AVAILABLE` series are hidden only while a season request is actually active — `hasActiveRequest` is the source of truth, not the media status.

### Implementation notes

Unlike #1855, no request entities are loaded or serialized (see the review concern about `leftJoinAndSelect('media.requests')`, which would leak request metadata to every user, multiply rows against the existing watchlist join, and bloat the payload):

- When the setting is enabled, `Media.getRelatedMedia()` runs **one** additional grouped query per batch that selects only the IDs of media with active requests, and exposes a transient `mediaInfo.hasActiveRequest: boolean`. No request, requester, or season data leaves the server.
- When the setting is disabled, no extra query is executed at all.
- No N+1 queries, no join multiplication, payload grows by one boolean per locally known media item.
- No database migration required.

Client-side changes:

- Visibility filtering is centralized in a new pure helper (`src/utils/mediaFilters.ts`), used by both `useDiscover` and `MediaSlider`. This also fixes a pre-existing bug where the `hideAvailable`/`hideBlocklisted` filters dropped person and collection results from mixed sliders.
- `useDiscover` now fetches a bounded number of extra pages (max 5, mirroring the existing `MediaSlider` behavior) when client-side filters empty out entire pages, so lists no longer appear exhausted while the server still has results. The `isEmpty` shortcut was removed from `isReachingEnd` for the same reason.

## How Has This Been Tested?

- 10 new integration tests in `server/test/entity/Media.test.ts` (node:test with the real SQLite test DB) covering: pending/approved → flagged; declined/failed/completed → not flagged; 4K-only requests; partially available series with and without an active season request; batch behavior; no extra computation when the setting is disabled; and that the serialized result contains no `requests`/`requestedBy`/`modifiedBy` data.
  - Note: the test lives under `server/test/entity/` rather than next to the entity because the TypeORM configs glob `server/entity/**/*.ts` as entity classes (and the server build ships `dist/entity/**/*.js`), so a colocated test file would be loaded as an entity.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (131/131), and `pnpm build` all pass on this branch.
- Manually verified on a self-hosted instance (Docker, SQLite): toggling the setting via UI and API, hidden/visible behavior for all request states above via the discover and search endpoints, and that search results and person/collection cards remain visible.

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] Disclosed any use of AI (see our policy): implementation was AI-assisted; design, review, and testing were done by me.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required) — not required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Hide Requested Media” setting for Discover pages.
  * Movies and series with pending or approved requests are hidden, including partially requested and 4K requests.
  * Media with declined, failed, or completed requests remains visible.
  * Search results are unaffected.
  * Added automatic pagination handling to fill listings when filtering removes results.

* **Documentation**
  * Documented the new setting and its default disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->