### PR TITLE
fix: quota bypass when editing a pending request's seasons

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -349,6 +349,28 @@ describe('PUT /request/:requestId (tv, season quota enforcement)', () => {
     );
     assert.strictEqual(saved.ignoreQuota, true);
   });
+
+  it('allows swapping seasons at full quota when the count stays the same', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedTvRequestAtQuota(90005);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [3, 4],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [3, 4]
+    );
+  });
 });
 
 describe('POST /request/:requestId/:status', () => {

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -371,6 +371,90 @@ describe('PUT /request/:requestId (tv, season quota enforcement)', () => {
       [3, 4]
     );
   });
+
+  it('rejects a non-bypass edit that swaps seasons on an ignoreQuota-exempt request past quota used elsewhere', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+    friend.tvQuotaLimit = 2;
+    friend.tvQuotaDays = undefined;
+    await userRepo.save(friend);
+
+    // A request already exempted from quota counting (ignoreQuota persisted
+    // from a prior authorized edit or from creation).
+    const exemptMedia = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId: 90006,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+    const exemptRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.TV,
+        status: MediaRequestStatus.PENDING,
+        media: exemptMedia,
+        requestedBy: friend,
+        is4k: false,
+        ignoreQuota: true,
+        seasons: [1, 2].map(
+          (seasonNumber) =>
+            new SeasonRequest({
+              seasonNumber,
+              status: MediaRequestStatus.PENDING,
+            })
+        ),
+      })
+    );
+
+    // A separate, normally-counted request that already consumes the full quota.
+    const countedMedia = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId: 90007,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+    await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.TV,
+        status: MediaRequestStatus.PENDING,
+        media: countedMedia,
+        requestedBy: friend,
+        is4k: false,
+        seasons: [3, 4].map(
+          (seasonNumber) =>
+            new SeasonRequest({
+              seasonNumber,
+              status: MediaRequestStatus.PENDING,
+            })
+        ),
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${exemptRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 5],
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: exemptRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+  });
 });
 
 describe('POST /request/:requestId/:status', () => {

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -9,6 +9,7 @@ import {
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
+import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
 import { getSettings } from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
@@ -210,6 +211,143 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.serverId, 3);
     assert.strictEqual(saved.profileId, 7);
     assert.strictEqual(saved.rootFolder, '/updated/movies');
+  });
+});
+
+describe('PUT /request/:requestId (tv, season quota enforcement)', () => {
+  async function seedTvRequestAtQuota(tmdbId: number) {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+    friend.tvQuotaLimit = 2;
+    friend.tvQuotaDays = undefined;
+    await userRepo.save(friend);
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const created = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.TV,
+        status: MediaRequestStatus.PENDING,
+        media,
+        requestedBy: friend,
+        is4k: false,
+        seasons: [1, 2].map(
+          (seasonNumber) =>
+            new SeasonRequest({
+              seasonNumber,
+              status: MediaRequestStatus.PENDING,
+            })
+        ),
+      })
+    );
+
+    return requestRepo.findOneOrFail({
+      where: { id: created.id },
+      relations: { requestedBy: true, seasons: true },
+    });
+  }
+
+  it('rejects adding a season beyond the requester quota', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedTvRequestAtQuota(90001);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+  });
+
+  it('rejects an admin edit beyond quota without the explicit ignoreQuota flag', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedTvRequestAtQuota(90002);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+  });
+
+  it('rejects a non-admin attempting to set ignoreQuota themselves', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedTvRequestAtQuota(90003);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+      ignoreQuota: true,
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+  });
+
+  it('allows an admin to bypass quota via the explicit ignoreQuota flag', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedTvRequestAtQuota(90004);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+      ignoreQuota: true,
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+      relations: { seasons: true },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2, 3]
+    );
+    assert.strictEqual(saved.ignoreQuota, true);
   });
 });
 

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -570,10 +570,15 @@ requestRoutes.put<{ requestId: string }>(
 
         // Seasons dropped by this same edit are still counted in quota.tv.used
         // (getQuota() reads the persisted rows before we save below), so they
-        // must be credited back before comparing against newSeasons.
-        const removedSeasonsCount = request.seasons.filter(
-          (rs) => !requestedSeasons.includes(rs.seasonNumber)
-        ).length;
+        // must be credited back before comparing against newSeasons. But if
+        // the request already has ignoreQuota persisted, those seasons were
+        // never counted in quota.tv.used in the first place, so crediting
+        // them back would inflate the allowed threshold.
+        const removedSeasonsCount = request.ignoreQuota
+          ? 0
+          : request.seasons.filter(
+              (rs) => !requestedSeasons.includes(rs.seasonNumber)
+            ).length;
 
         if (newSeasons.length > 0) {
           const quota = await requestUser.getQuota();
@@ -592,8 +597,8 @@ requestRoutes.put<{ requestId: string }>(
               );
             } else if (
               quota.tv.limit &&
-              newSeasons.length >
-                (quota.tv.remaining ?? 0) + removedSeasonsCount
+              quota.tv.used - removedSeasonsCount + newSeasons.length >
+                quota.tv.limit
             ) {
               throw new QuotaRestrictedError('Series Quota exceeded.');
             }

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -568,6 +568,32 @@ requestRoutes.put<{ requestId: string }>(
           (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
         );
 
+        if (newSeasons.length > 0) {
+          const quota = await requestUser.getQuota();
+          const canBypassQuota = !!req.user?.hasPermission(
+            Permission.MANAGE_REQUESTS
+          );
+          const ignoreQuota =
+            req.body.ignoreQuota === true &&
+            canBypassQuota &&
+            (quota.tv.limit ?? 0) > 0;
+
+          if (!ignoreQuota) {
+            if (req.body.ignoreQuota && !canBypassQuota) {
+              throw new RequestPermissionError(
+                'You do not have permission to bypass user quota limits.'
+              );
+            } else if (
+              quota.tv.limit &&
+              newSeasons.length > (quota.tv.remaining ?? 0)
+            ) {
+              throw new QuotaRestrictedError('Series Quota exceeded.');
+            }
+          } else {
+            request.ignoreQuota = true;
+          }
+        }
+
         request.seasons = request.seasons.filter((rs) =>
           filteredSeasons.includes(rs.seasonNumber)
         );
@@ -593,6 +619,13 @@ requestRoutes.put<{ requestId: string }>(
 
       return res.status(200).json(request);
     } catch (e) {
+      if (
+        e instanceof QuotaRestrictedError ||
+        e instanceof RequestPermissionError
+      ) {
+        return next({ status: 403, message: e.message });
+      }
+
       next({ status: 500, message: e.message });
     }
   }

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -568,6 +568,13 @@ requestRoutes.put<{ requestId: string }>(
           (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
         );
 
+        // Seasons dropped by this same edit are still counted in quota.tv.used
+        // (getQuota() reads the persisted rows before we save below), so they
+        // must be credited back before comparing against newSeasons.
+        const removedSeasonsCount = request.seasons.filter(
+          (rs) => !requestedSeasons.includes(rs.seasonNumber)
+        ).length;
+
         if (newSeasons.length > 0) {
           const quota = await requestUser.getQuota();
           const canBypassQuota = !!req.user?.hasPermission(
@@ -585,7 +592,8 @@ requestRoutes.put<{ requestId: string }>(
               );
             } else if (
               quota.tv.limit &&
-              newSeasons.length > (quota.tv.remaining ?? 0)
+              newSeasons.length >
+                (quota.tv.remaining ?? 0) + removedSeasonsCount
             ) {
               throw new QuotaRestrictedError('Series Quota exceeded.');
             }

--- a/src/components/RequestModal/CollectionRequestModal.tsx
+++ b/src/components/RequestModal/CollectionRequestModal.tsx
@@ -57,10 +57,7 @@ const CollectionRequestModal = ({
   const intl = useIntl();
   const { user, hasPermission } = useUser();
   const { data: quota } = useSWR<QuotaResponse>(
-    user &&
-      (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
-      : null
+    user ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota` : null
   );
 
   const currentlyRemaining =

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -64,10 +64,7 @@ const MovieRequestModal = ({
   const intl = useIntl();
   const { user, hasPermission } = useUser();
   const { data: quota } = useSWR<QuotaResponse>(
-    user &&
-      (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
-      : null
+    user ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota` : null
   );
 
   useEffect(() => {

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -89,10 +89,7 @@ const TvRequestModal = ({
   });
   const [tvdbId, setTvdbId] = useState<number | undefined>(undefined);
   const { data: quota } = useSWR<QuotaResponse>(
-    user &&
-      (!requestOverrides?.user?.id || hasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota`
-      : null
+    user ? `/api/v1/user/${requestOverrides?.user?.id ?? user.id}/quota` : null
   );
 
   const currentlyRemaining =


### PR DESCRIPTION
## Description

Editing a pending TV request's seasons didn't re-check the requester's quota against the new season list. `quota.tv.remaining` is computed from the currently persisted seasons, so any seasons being removed in the same edit were still counted as "used". A user (or an admin editing on a user's behalf) could add seasons beyond the quota limit as long as the request already existed, bypassing the quota enforcement that applies to new requests.

This adds a quota check on edit: removed seasons are credited back before comparing the new season count against the remaining quota, and an edit that would exceed quota is rejected (403) unless a manager explicitly passes `ignoreQuota` (only usable by accounts with `MANAGE_REQUESTS` permission; non-managers passing it get rejected).

Also fixes the 3 request modals (`MovieRequestModal`, `TvRequestModal`, `CollectionRequestModal`) fetching quota only for the modal owner or a manager: a non-manager editing their own existing request via `requestOverrides` wasn't shown their own quota.

Fixes #633

**AI Disclosure:** This PR was written primarily by Claude Code, reviewed and directed by the account holder.

## How Has This Been Tested?

Added a test suite in `server/routes/request.test.ts` covering: rejecting an edit beyond quota, rejecting a manager edit beyond quota without `ignoreQuota`, rejecting a non-manager attempting to set `ignoreQuota` themselves, allowing a manager to bypass quota via `ignoreQuota`, and allowing a same-count season swap at full quota. Full suite passes (`pnpm test`, 126/126), along with `pnpm lint` and `pnpm build`.

## Screenshots / Logs (if applicable)

N/A: backend/logic fix, no visual change.

## Checklist:

- [x] I have read and followed the contribution guidelines.
- [x] Disclosed any use of AI (see our policy).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV season quota enforcement by correctly accounting for seasons removed during edits.
  * Season swaps and replacements are now allowed when the final season count stays within quota.
  * Updated admin quota-bypass behavior and ensured unauthorized bypass attempts are rejected.
  * Quota/permission failures now consistently return clear access-denied responses.
* **Improvements**
  * Request modals now fetch and display quota information consistently for the currently selected requester (including overrides) across movies, TV, and collections.
* **Tests**
  * Added coverage for TV quota enforcement and ignore-quota bypass behavior, including edge cases with concurrent request counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
