### PR TITLE
fix(airdatebadge): anchor day diff to UTC midnight instead of raw ms delta


### DIFF
--- a/src/components/AirDateBadge/index.tsx
+++ b/src/components/AirDateBadge/index.tsx
@@ -12,25 +12,21 @@ type AirDateBadgeProps = {
 };
 
 const AirDateBadge = ({ airDate }: AirDateBadgeProps) => {
-  const WEEK = 1000 * 60 * 60 * 24 * 8;
+  const DAY_MS = 1000 * 60 * 60 * 24;
+  const RELATIVE_WINDOW_MS = DAY_MS * 8;
   const intl = useIntl();
+  // TMDB air_date has no time/tz, it's just the origin country's local date.
+  // We pin it to UTC anyway for consistency.
+  // https://www.themoviedb.org/talk/6365be67d7107e008d777337
   const dAirDate = new Date(airDate);
-  const nowDate = new Date();
-  const alreadyAired = dAirDate.getTime() < nowDate.getTime();
-  const compareWeek = new Date(
-    alreadyAired ? Date.now() - WEEK : Date.now() + WEEK
-  );
-  let showRelative = false;
-  if (
-    (alreadyAired && dAirDate.getTime() > compareWeek.getTime()) ||
-    (!alreadyAired && dAirDate.getTime() < compareWeek.getTime())
-  ) {
-    showRelative = true;
-  }
-
-  const diffInDays = Math.round(
-    (dAirDate.getTime() - nowDate.getTime()) / (1000 * 60 * 60 * 24)
-  );
+  dAirDate.setUTCHours(0, 0, 0, 0);
+  const todayUtc = new Date();
+  todayUtc.setUTCHours(0, 0, 0, 0);
+  const diffMs = dAirDate.getTime() - todayUtc.getTime();
+  // The air date itself counts as "Airing" and "Aired" starts the next UTC day.
+  const alreadyAired = diffMs < 0;
+  const showRelative = Math.abs(diffMs) <= RELATIVE_WINDOW_MS;
+  const diffInDays = diffMs / DAY_MS;
 
   return (
     <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Description

`AirDateBadge` computed the relative day count by rounding a raw millisecond delta between the exact current instant and a UTC-midnight air date, so the day boundary landed at noon UTC instead of an actual calendar day change. On an episode's air date the badge flipped from "Aired today" to "Aired yesterday" starting at noon UTC, and the day before an air date it showed "Airing today" from noon UTC onward for an episode that doesn't air until the next day.

Both dates are now truncated to UTC midnight before diffing, so the day count is always a whole number with no rounding involved. TMDB's `air_date` has no time or timezone attached, it's just the origin country's local date, so UTC isn't more "correct" here, it's just deterministic just like the absolute date badge next to it, which is already rendered in UTC. As a side effect, the Aired/Airing split changes slightly as the badge now reads "Airing" for the entire UTC day an episode airs and switches to "Aired" starting the following UTC day, instead of flipping almost immediately after midnight like before. Also renamed the WEEK constant to make it less confusing.

- Fixes #3268

## How Has This Been Tested?

- Simulated the code logic with an injectable clock, and compared side by side with the old logic

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air date labels by standardizing relative-date calculations using UTC midnight timestamps.
  * Fixed incorrect “upcoming” vs “already aired” results near day boundaries and across time zones.
  * Refined when relative-date text appears by using a consistent UTC-based 8-day window.
  * Enhanced date-difference accuracy for clearer scheduling information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->