### PR TITLE
fix(next): add next-env.d.ts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ lcov.info
 # next.js
 /.next/
 /out/
-.next-env.d.ts
+/next-env.d.ts
 
 # production
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lcov.info
 # next.js
 /.next/
 /out/
+.next-env.d.ts
 
 # production
 /build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Description
This PR adds the `next-env.d.ts` file to `.gitignore`, as it should be to avoid unecesarry changes.

- See https://github.com/vercel/next.js/issues/85738

## How Has This Been Tested?

N/A

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude a generated environment file from version control.
  * Cleaned up the generated environment type declaration so it no longer contains type reference or route imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->