### PR TITLE
fix: don't delete requests when removing media from arr

### DIFF
--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -203,17 +203,21 @@ class Media {
     Object.assign(this, init);
   }
 
-  public resetServiceData(): void {
-    this.serviceId = null;
-    this.serviceId4k = null;
-    this.externalServiceId = null;
-    this.externalServiceId4k = null;
-    this.externalServiceSlug = null;
-    this.externalServiceSlug4k = null;
-    this.ratingKey = null;
-    this.ratingKey4k = null;
-    this.jellyfinMediaId = null;
-    this.jellyfinMediaId4k = null;
+  public resetServiceData(is4k?: boolean): void {
+    if (is4k === undefined || !is4k) {
+      this.serviceId = null;
+      this.externalServiceId = null;
+      this.externalServiceSlug = null;
+      this.ratingKey = null;
+      this.jellyfinMediaId = null;
+    }
+    if (is4k === undefined || is4k) {
+      this.serviceId4k = null;
+      this.externalServiceId4k = null;
+      this.externalServiceSlug4k = null;
+      this.ratingKey4k = null;
+      this.jellyfinMediaId4k = null;
+    }
   }
 
   @AfterLoad()

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -280,7 +280,15 @@ mediaRoutes.delete(
           throw new Error('TVDB ID not found');
         }
         await (service as SonarrAPI).removeSeries(tvdbId);
+
+        for (const season of media.seasons) {
+          season[is4k ? 'status4k' : 'status'] = MediaStatus.DELETED;
+        }
       }
+
+      media[is4k ? 'status4k' : 'status'] = MediaStatus.DELETED;
+      media.resetServiceData(is4k);
+      await mediaRepository.save(media);
 
       return res.status(204).send();
     } catch (e) {

--- a/src/components/ManageSlideOver/index.tsx
+++ b/src/components/ManageSlideOver/index.tsx
@@ -149,7 +149,6 @@ const ManageSlideOver = ({
         await axios.delete(
           `/api/v1/media/${data.mediaInfo.id}/file?is4k=${is4k}`
         );
-        await axios.delete(`/api/v1/media/${data.mediaInfo.id}`);
       } catch (e) {
         if (!axios.isAxiosError(e) || e.response?.status !== 404) {
           addToast(intl.formatMessage(messages.removemediaerror), {

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -359,7 +359,6 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
         await axios.delete(
           `/api/v1/media/${request.media.id}/file?is4k=${request.is4k}`
         );
-        await axios.delete(`/api/v1/media/${request.media.id}`);
       } catch (e) {
         if (!axios.isAxiosError(e) || e.response?.status !== 404) {
           addToast(intl.formatMessage(messages.removemediaerror), {


### PR DESCRIPTION
## Description

> [!IMPORTANT]  
> Stacked on #3209, targets `fix/delete-media-already-removed-in-arr` temporarily meaning #3209 needs to be merged first 

Remove from {arr}, in both ManageSlideOver and the request list, was calling the same delete-media endpoint Clear Data uses, so pressing it hard-deleted the whole media record and cascaded to remove any requests tied to it. Clear Data's own confirmation copy is explicit about that ("including any requests") and remove from {arr} has no such warning and isn't supposed to do that.

The file-delete route now marks the media (and each season, for TV) DELETED for the affected service and resets only that service's linkage fields, instead of deleting anything. `MediaSubscriber` alreadycompletes the related request(s) when a media's status flips to DELETED, the same mechanism availability sync relies on when content disappears from Plex/Jellyfin/Emby. Re-requesting afterward works the same way it already does for anything availability sync marks deleted.

Clear Data keeps its current behavior unchanged.

## How Has This Been Tested?

- Should just work

## Screenshots / Logs (if applicable)

## Checklist:
- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
