### PR TITLE
feat: respect per-user library and label restrictions when reporting availability (Plex, Jellyfin, Emby)

### DIFF
--- a/server/api/externalapi.ts
+++ b/server/api/externalapi.ts
@@ -101,6 +101,31 @@ class ExternalAPI {
     return response.data;
   }
 
+  protected async put<T>(
+    endpoint: string,
+    data?: Record<string, unknown>,
+    config?: AxiosRequestConfig,
+    ttl?: number
+  ): Promise<T> {
+    const cacheKey = this.serializeCacheKey(endpoint, {
+      config: config?.params,
+      ...(data ? { data } : {}),
+    });
+
+    const cachedItem = this.cache?.get<T>(cacheKey);
+    if (cachedItem) {
+      return cachedItem;
+    }
+
+    const response = await this.axios.put<T>(endpoint, data, config);
+
+    if (this.cache && ttl !== 0) {
+      this.cache.set(cacheKey, response.data, ttl ?? DEFAULT_TTL);
+    }
+
+    return response.data;
+  }
+
   protected async getRolling<T>(
     endpoint: string,
     config?: AxiosRequestConfig,

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -28,6 +28,20 @@ export interface JellyfinUserResponse {
     EnabledFolders?: string[];
     /** Legacy Emby counterpart of `EnabledFolders`. */
     BlockedMediaFolders?: string[];
+    /**
+     * Tag based restrictions, the counterpart of Plex labels. The two servers
+     * disagree on how they are expressed, which was established against real
+     * servers rather than taken from the documentation:
+     *
+     * - Jellyfin uses two independent lists, `AllowedTags` and `BlockedTags`,
+     *   and applies both, a denied tag winning over an allowed one.
+     * - Emby keeps a single list in `BlockedTags` whose polarity is flipped by
+     *   `IsTagBlockingModeInclusive`: false denies those tags, true allows only
+     *   those tags. Its `IncludeTags` field has no effect.
+     */
+    AllowedTags?: string[];
+    BlockedTags?: string[];
+    IsTagBlockingModeInclusive?: boolean;
   };
   PrimaryImageTag?: string;
 }
@@ -80,6 +94,12 @@ interface JellyfinMediaFolder {
   Id: string;
   Type: string;
   CollectionType: string;
+  /**
+   * Emby only. Its user policy references libraries by this value while `Id`
+   * stays numeric, so both have to be kept to match a policy entry. Jellyfin
+   * does not return it, its `Id` already being the guid.
+   */
+  Guid?: string;
 }
 
 export interface JellyfinLibrary {
@@ -87,6 +107,8 @@ export interface JellyfinLibrary {
   key: string;
   title: string;
   agent: string;
+  /** Emby's alternative identifier for the same library, see `JellyfinMediaFolder`. */
+  guid?: string;
 }
 
 export interface JellyfinLibraryItem {
@@ -103,6 +125,10 @@ export interface JellyfinLibraryItem {
   IndexNumberEnd?: number;
   ParentIndexNumber?: number;
   MediaType: string;
+  /** Only populated when requested through `fields`. Jellyfin answers with
+   * `Tags`, Emby with `TagItems`, so callers have to read both. */
+  Tags?: string[];
+  TagItems?: { Name: string }[];
 }
 
 export interface JellyfinMediaStream {
@@ -452,14 +478,20 @@ class JellyfinAPI extends ExternalAPI {
           title: Item.Name,
           type: Item.CollectionType === 'movies' ? 'movie' : 'show',
           agent: 'jellyfin',
+          guid: Item.Guid,
         };
       });
   }
 
-  public async getLibraryContents(id: string): Promise<JellyfinLibraryItem[]> {
+  public async getLibraryContents(
+    id: string,
+    { fields }: { fields?: string } = {}
+  ): Promise<JellyfinLibraryItem[]> {
     try {
       const libraryItemsResponse = await this.get<any>(
-        `/Items?SortBy=SortName&SortOrder=Ascending&IncludeItemTypes=Series,Movie,Others&Recursive=true&StartIndex=0&ParentId=${id}&collapseBoxSetItems=false`
+        `/Items?SortBy=SortName&SortOrder=Ascending&IncludeItemTypes=Series,Movie,Others&Recursive=true&StartIndex=0&ParentId=${id}&collapseBoxSetItems=false${
+          fields ? `&Fields=${fields}` : ''
+        }`
       );
 
       return libraryItemsResponse.Items.filter(

--- a/server/api/jellyfin.ts
+++ b/server/api/jellyfin.ts
@@ -18,6 +18,16 @@ export interface JellyfinUserResponse {
   };
   Policy: {
     IsAdministrator: boolean;
+    /**
+     * Library access, as configured per user under Access. When
+     * `EnableAllFolders` is set the user reaches every library and
+     * `EnabledFolders` is empty; otherwise it lists the library item ids the
+     * user is allowed to browse.
+     */
+    EnableAllFolders?: boolean;
+    EnabledFolders?: string[];
+    /** Legacy Emby counterpart of `EnabledFolders`. */
+    BlockedMediaFolders?: string[];
   };
   PrimaryImageTag?: string;
 }

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -93,6 +93,17 @@ interface PlexMetadataResponse {
   };
 }
 
+interface PlexLabelResponse {
+  MediaContainer: {
+    Metadata?: {
+      librarySectionID?: number | string;
+      Label?: {
+        tag: string;
+      }[];
+    }[];
+  };
+}
+
 class PlexAPI extends ExternalAPI {
   constructor({
     plexToken,
@@ -237,6 +248,67 @@ class PlexAPI extends ExternalAPI {
     } while (offset < totalSize);
 
     return ratingKeys;
+  }
+
+  /**
+   * Adds a label to a library item, keeping the labels it already carries.
+   *
+   * Plex replaces the whole label set on write, so existing labels have to be
+   * sent again alongside the new one.
+   */
+  public async addLabel(
+    ratingKey: string,
+    type: 'movie' | 'show',
+    label: string
+  ): Promise<void> {
+    const { sectionId, labels: existing } = await this.getItemLabels(ratingKey);
+
+    if (!sectionId) {
+      throw new Error(
+        `Unable to resolve the library section of Plex item ${ratingKey}`
+      );
+    }
+
+    if (existing.some((l) => l.toLowerCase() === label.toLowerCase())) {
+      return;
+    }
+
+    const labels = [...existing, label];
+    const params = new URLSearchParams({
+      type: type === 'show' ? '2' : '1',
+      id: ratingKey,
+      'label.locked': '1',
+    });
+
+    labels.forEach((value, index) => {
+      params.append(`label[${index}].tag.tag`, value);
+    });
+
+    // ExternalAPI does not wrap PUT, so the axios instance is used directly.
+    await this.axios.put(
+      `/library/sections/${sectionId}/all?${params.toString()}`
+    );
+  }
+
+  /**
+   * Returns the labels currently set on a library item, along with the section
+   * it belongs to, which is required to write labels back.
+   */
+  public async getItemLabels(
+    ratingKey: string
+  ): Promise<{ sectionId?: string; labels: string[] }> {
+    const response = await this.get<PlexLabelResponse>(
+      `/library/metadata/${ratingKey}`
+    );
+
+    const metadata = response.MediaContainer.Metadata?.[0];
+
+    return {
+      sectionId: metadata?.librarySectionID
+        ? `${metadata.librarySectionID}`
+        : undefined,
+      labels: (metadata?.Label ?? []).map((label) => label.tag),
+    };
   }
 
   public async getMetadata(

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -199,6 +199,46 @@ class PlexAPI extends ExternalAPI {
     };
   }
 
+  /**
+   * Returns the rating keys of every item in a library section carrying the
+   * given label.
+   *
+   * Plex never returns labels in bulk library listings, whatever the requested
+   * fields, but it does support filtering by label. Resolving one request per
+   * label is therefore far cheaper than fetching metadata item by item.
+   */
+  public async getRatingKeysByLabel(
+    sectionId: string,
+    label: string
+  ): Promise<string[]> {
+    const ratingKeys: string[] = [];
+    const size = 500;
+    let offset = 0;
+    let totalSize = 0;
+
+    do {
+      const response = await this.get<PlexLibraryResponse>(
+        `/library/sections/${sectionId}/all?label=${encodeURIComponent(label)}`,
+        {
+          headers: {
+            'X-Plex-Container-Start': `${offset}`,
+            'X-Plex-Container-Size': `${size}`,
+          },
+        }
+      );
+
+      totalSize = response.MediaContainer.totalSize ?? 0;
+      ratingKeys.push(
+        ...(response.MediaContainer.Metadata ?? []).map(
+          (item) => item.ratingKey
+        )
+      );
+      offset += size;
+    } while (offset < totalSize);
+
+    return ratingKeys;
+  }
+
   public async getMetadata(
     key: string,
     options: { includeChildren?: boolean } = {}

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -251,10 +251,11 @@ class PlexAPI extends ExternalAPI {
   }
 
   /**
-   * Adds a label to a library item, keeping the labels it already carries.
+   * Adds a label to a library item.
    *
-   * Plex replaces the whole label set on write, so existing labels have to be
-   * sent again alongside the new one.
+   * Plex merges the labels sent with the ones already set, so the existing set
+   * is never read back and replayed: two concurrent grants on the same item
+   * cannot drop each other's label.
    */
   public async addLabel(
     ratingKey: string,
@@ -273,21 +274,14 @@ class PlexAPI extends ExternalAPI {
       return;
     }
 
-    const labels = [...existing, label];
     const params = new URLSearchParams({
       type: type === 'show' ? '2' : '1',
       id: ratingKey,
+      'label[0].tag.tag': label,
       'label.locked': '1',
     });
 
-    labels.forEach((value, index) => {
-      params.append(`label[${index}].tag.tag`, value);
-    });
-
-    // ExternalAPI does not wrap PUT, so the axios instance is used directly.
-    await this.axios.put(
-      `/library/sections/${sectionId}/all?${params.toString()}`
-    );
+    await this.put(`/library/sections/${sectionId}/all?${params.toString()}`);
   }
 
   /**

--- a/server/api/plextv.test.ts
+++ b/server/api/plextv.test.ts
@@ -1,0 +1,109 @@
+import {
+  isAllowedByLabelFilter,
+  parsePlexLabelFilter,
+} from '@server/api/plextv';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('parsePlexLabelFilter', () => {
+  it('returns empty lists when no restriction is set', () => {
+    for (const value of [undefined, null, '']) {
+      assert.deepEqual(parsePlexLabelFilter(value), { allow: [], deny: [] });
+    }
+  });
+
+  it('parses a single allowed label', () => {
+    assert.deepEqual(parsePlexLabelFilter('label=Family'), {
+      allow: ['Family'],
+      deny: [],
+    });
+  });
+
+  it('parses several comma separated labels', () => {
+    assert.deepEqual(parsePlexLabelFilter('label=Family,Kids'), {
+      allow: ['Family', 'Kids'],
+      deny: [],
+    });
+  });
+
+  it('decodes url encoded values, as returned by plex.tv', () => {
+    assert.deepEqual(parsePlexLabelFilter('label=Family%2CKids'), {
+      allow: ['Family', 'Kids'],
+      deny: [],
+    });
+  });
+
+  it('parses negated restrictions into the deny list', () => {
+    assert.deepEqual(parsePlexLabelFilter('label!=Private'), {
+      allow: [],
+      deny: ['Private'],
+    });
+  });
+
+  it('handles allow and deny clauses in the same filter', () => {
+    assert.deepEqual(parsePlexLabelFilter('label=Family&label!=Private'), {
+      allow: ['Family'],
+      deny: ['Private'],
+    });
+  });
+
+  it('ignores clauses that are not label based', () => {
+    assert.deepEqual(parsePlexLabelFilter('contentRating=PG&label=Family'), {
+      allow: ['Family'],
+      deny: [],
+    });
+  });
+
+  it('drops empty values and surrounding whitespace', () => {
+    assert.deepEqual(parsePlexLabelFilter('label= Family , ,Kids '), {
+      allow: ['Family', 'Kids'],
+      deny: [],
+    });
+  });
+});
+
+describe('isAllowedByLabelFilter', () => {
+  it('allows anything when no restriction applies', () => {
+    assert.equal(isAllowedByLabelFilter({ allow: [], deny: [] }, []), true);
+    assert.equal(
+      isAllowedByLabelFilter({ allow: [], deny: [] }, ['Family']),
+      true
+    );
+  });
+
+  it('requires one of the allowed labels', () => {
+    const filter = { allow: ['Family', 'Kids'], deny: [] };
+
+    assert.equal(isAllowedByLabelFilter(filter, ['Family']), true);
+    assert.equal(isAllowedByLabelFilter(filter, ['Other', 'Kids']), true);
+    assert.equal(isAllowedByLabelFilter(filter, ['Other']), false);
+  });
+
+  it('hides unlabelled media when an allow list is set', () => {
+    assert.equal(
+      isAllowedByLabelFilter({ allow: ['Family'], deny: [] }, []),
+      false
+    );
+  });
+
+  it('denies media carrying a denied label, even when also allowed', () => {
+    assert.equal(
+      isAllowedByLabelFilter({ allow: ['Family'], deny: ['Private'] }, [
+        'Family',
+        'Private',
+      ]),
+      false
+    );
+  });
+
+  it('compares labels case insensitively', () => {
+    assert.equal(
+      isAllowedByLabelFilter({ allow: ['family'], deny: [] }, ['Family']),
+      true
+    );
+    assert.equal(
+      isAllowedByLabelFilter({ allow: [], deny: ['private'] }, ['PRIVATE']),
+      false
+    );
+  });
+});

--- a/server/api/plextv.test.ts
+++ b/server/api/plextv.test.ts
@@ -54,6 +54,21 @@ describe('parsePlexLabelFilter', () => {
     });
   });
 
+  it('keeps encoded separators inside a label value', () => {
+    // %26 is `&`, which must not be mistaken for a clause separator.
+    assert.deepEqual(parsePlexLabelFilter('label=Tom%20%26%20Jerry'), {
+      allow: ['Tom & Jerry'],
+      deny: [],
+    });
+  });
+
+  it('does not throw on a malformed encoding', () => {
+    assert.deepEqual(parsePlexLabelFilter('label=100%'), {
+      allow: ['100%'],
+      deny: [],
+    });
+  });
+
   it('drops empty values and surrounding whitespace', () => {
     assert.deepEqual(parsePlexLabelFilter('label= Family , ,Kids '), {
       allow: ['Family', 'Kids'],
@@ -63,6 +78,15 @@ describe('parsePlexLabelFilter', () => {
 });
 
 describe('isAllowedByLabelFilter', () => {
+  it('hides everything when the restrictions cannot be satisfied', () => {
+    assert.equal(
+      isAllowedByLabelFilter({ allow: [], deny: [], allowNothing: true }, [
+        'Family',
+      ]),
+      false
+    );
+  });
+
   it('allows anything when no restriction applies', () => {
     assert.equal(isAllowedByLabelFilter({ allow: [], deny: [] }, []), true);
     assert.equal(

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -80,6 +80,7 @@ interface ServerResponse {
     lastSeenAt: string;
     numLibraries: string;
     owned: string;
+    allLibraries?: string;
   };
 }
 
@@ -92,11 +93,160 @@ interface UsersResponse {
         username: string;
         email: string;
         thumb: string;
+        restricted?: string;
+        home?: string;
+        // Sharing restrictions, as configured in Plex under
+        // Library -> Restrictions. Values are URL encoded, e.g.
+        // `label=Family%2CKids` or `label!=Private`.
+        filterAll?: string;
+        filterMovies?: string;
+        filterTelevision?: string;
+        filterMusic?: string;
+        filterPhotos?: string;
       };
       Server: ServerResponse[];
     }[];
   };
 }
+
+/**
+ * Label based sharing restrictions for a single library type.
+ *
+ * A media item is visible to the user when it carries at least one of the
+ * `allow` labels (or `allow` is empty, meaning no restriction) and none of
+ * the `deny` labels.
+ */
+export interface PlexLabelFilter {
+  allow: string[];
+  deny: string[];
+}
+
+interface SharedServersResponse {
+  MediaContainer: {
+    SharedServer?: {
+      $: {
+        id: string;
+        username: string;
+        email: string;
+        userID: string;
+        machineIdentifier?: string;
+        allLibraries?: string;
+        owned?: string;
+        filterAll?: string;
+        filterMovies?: string;
+        filterTelevision?: string;
+        filterMusic?: string;
+        filterPhotos?: string;
+      };
+      Section?: {
+        $: {
+          id: string;
+          /** Library section key on the server itself, e.g. `1`. */
+          key: string;
+          title: string;
+          type: string;
+          shared: string;
+        };
+      }[];
+    }[];
+  };
+}
+
+export interface PlexUserSharingRules {
+  /** The user has access to every library on the server. */
+  allLibraries: boolean;
+  /**
+   * Section keys of the libraries actually shared with the user, matching the
+   * keys returned by the server's own `/library/sections`. Empty when
+   * `allLibraries` is set, since every library is then accessible.
+   */
+  sharedSectionKeys: string[];
+  movies: PlexLabelFilter;
+  tv: PlexLabelFilter;
+}
+
+const EMPTY_LABEL_FILTER: PlexLabelFilter = { allow: [], deny: [] };
+
+/**
+ * Parses a Plex restriction string into its label allow/deny lists.
+ *
+ * Plex encodes restrictions as `key=value` clauses, where several values are
+ * comma separated and several clauses are separated by `&` or `|`. Only the
+ * `label` key is relevant here; other keys (`contentRating`, ...) are ignored.
+ */
+export const parsePlexLabelFilter = (
+  filter?: string | null
+): PlexLabelFilter => {
+  if (!filter) {
+    return { ...EMPTY_LABEL_FILTER };
+  }
+
+  const allow: string[] = [];
+  const deny: string[] = [];
+
+  for (const clause of decodeURIComponent(filter).split(/[&|]/)) {
+    const match = clause.trim().match(/^label(!?)=(.*)$/i);
+
+    if (!match) {
+      continue;
+    }
+
+    const labels = match[2]
+      .split(',')
+      .map((label) => label.trim())
+      .filter((label) => label.length > 0);
+
+    (match[1] === '!' ? deny : allow).push(...labels);
+  }
+
+  return { allow, deny };
+};
+
+/**
+ * Combines the server wide restriction (`filterAll`) with a per library type
+ * one. Allow lists are intersected when both are set, since the user has to
+ * satisfy both, while deny lists simply add up.
+ */
+const mergeLabelFilters = (
+  all: PlexLabelFilter,
+  specific: PlexLabelFilter
+): PlexLabelFilter => {
+  let allow: string[];
+
+  if (!all.allow.length) {
+    allow = [...specific.allow];
+  } else if (!specific.allow.length) {
+    allow = [...all.allow];
+  } else {
+    allow = all.allow.filter((label) => specific.allow.includes(label));
+  }
+
+  return {
+    allow: [...new Set(allow)],
+    deny: [...new Set([...all.deny, ...specific.deny])],
+  };
+};
+
+/**
+ * Evaluates label based restrictions against the labels carried by a media
+ * item. Items without labels are only visible when no allow list applies.
+ */
+export const isAllowedByLabelFilter = (
+  filter: PlexLabelFilter,
+  labels: string[]
+): boolean => {
+  const normalized = labels.map((label) => label.toLowerCase());
+
+  if (filter.deny.some((label) => normalized.includes(label.toLowerCase()))) {
+    return false;
+  }
+
+  if (!filter.allow.length) {
+    return true;
+  }
+
+  return filter.allow.some((label) => normalized.includes(label.toLowerCase()));
+};
 
 interface WatchlistResponse {
   MediaContainer: {
@@ -266,6 +416,87 @@ class PlexTvAPI extends ExternalAPI {
       response.data
     )) as UsersResponse;
     return parsedXml;
+  }
+
+  /**
+   * Returns the label based sharing restrictions the server owner configured
+   * for a shared user, so availability can be evaluated from that user's point
+   * of view instead of the owner's.
+   *
+   * Returns `null` when no restriction applies, which is the case for the
+   * owner, for users sharing every library, and whenever the rules cannot be
+   * determined. Callers must treat `null` as "no filtering".
+   */
+  public async getUserSharingRules(
+    plexUserId: number
+  ): Promise<PlexUserSharingRules | null> {
+    const settings = getSettings();
+
+    if (!settings.plex.machineId) {
+      return null;
+    }
+
+    try {
+      // `shared_servers` exposes the filters *and* the shared sections in a
+      // single call, unlike `/api/users` which only reports a library count.
+      const response = await this.axios.get(
+        `/api/servers/${settings.plex.machineId}/shared_servers`,
+        {
+          transformResponse: [],
+          responseType: 'text',
+        }
+      );
+
+      const parsedXml = (await xml2js.parseStringPromise(
+        response.data
+      )) as SharedServersResponse;
+
+      const sharedServer = parsedXml.MediaContainer.SharedServer?.find(
+        (s) => parseInt(s.$.userID) === plexUserId
+      );
+
+      // No entry means the library is not shared with this user at all; that
+      // case is handled by checkUserAccess() rather than by filtering here.
+      if (!sharedServer) {
+        return null;
+      }
+
+      const all = parsePlexLabelFilter(sharedServer.$.filterAll);
+      const movies = mergeLabelFilters(
+        all,
+        parsePlexLabelFilter(sharedServer.$.filterMovies)
+      );
+      const tv = mergeLabelFilters(
+        all,
+        parsePlexLabelFilter(sharedServer.$.filterTelevision)
+      );
+
+      const allLibraries = sharedServer.$.allLibraries === '1';
+      const sharedSectionKeys = allLibraries
+        ? []
+        : (sharedServer.Section ?? [])
+            .filter((section) => section.$.shared === '1')
+            .map((section) => section.$.key);
+
+      const hasLabelRestrictions =
+        movies.allow.length > 0 ||
+        movies.deny.length > 0 ||
+        tv.allow.length > 0 ||
+        tv.deny.length > 0;
+
+      if (allLibraries && !hasLabelRestrictions) {
+        return null;
+      }
+
+      return { allLibraries, sharedSectionKeys, movies, tv };
+    } catch (e) {
+      logger.error('Failed to retrieve Plex sharing rules for user', {
+        label: 'Plex.tv API',
+        plexUserId,
+        errorMessage: e.message,
+      });
+      return null;
+    }
   }
 
   public async getWatchlist({

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -127,34 +127,36 @@ export interface PlexLabelFilter {
   allowNothing?: boolean;
 }
 
+interface PlexSharedServer {
+  $: {
+    id: string;
+    username: string;
+    email: string;
+    userID: string;
+    machineIdentifier?: string;
+    allLibraries?: string;
+    owned?: string;
+    filterAll?: string;
+    filterMovies?: string;
+    filterTelevision?: string;
+    filterMusic?: string;
+    filterPhotos?: string;
+  };
+  Section?: {
+    $: {
+      id: string;
+      /** Library section key on the server itself, e.g. `1`. */
+      key: string;
+      title: string;
+      type: string;
+      shared: string;
+    };
+  }[];
+}
+
 interface SharedServersResponse {
   MediaContainer: {
-    SharedServer?: {
-      $: {
-        id: string;
-        username: string;
-        email: string;
-        userID: string;
-        machineIdentifier?: string;
-        allLibraries?: string;
-        owned?: string;
-        filterAll?: string;
-        filterMovies?: string;
-        filterTelevision?: string;
-        filterMusic?: string;
-        filterPhotos?: string;
-      };
-      Section?: {
-        $: {
-          id: string;
-          /** Library section key on the server itself, e.g. `1`. */
-          key: string;
-          title: string;
-          type: string;
-          shared: string;
-        };
-      }[];
-    }[];
+    SharedServer?: PlexSharedServer[];
   };
 }
 
@@ -172,6 +174,43 @@ export interface PlexUserSharingRules {
 }
 
 const EMPTY_LABEL_FILTER: PlexLabelFilter = { allow: [], deny: [] };
+
+/**
+ * Turns a `shared_servers` entry into the restrictions that apply to that user,
+ * or `null` when none do.
+ */
+const parseSharingRules = (
+  sharedServer: PlexSharedServer
+): PlexUserSharingRules | null => {
+  const all = parsePlexLabelFilter(sharedServer.$.filterAll);
+  const movies = mergeLabelFilters(
+    all,
+    parsePlexLabelFilter(sharedServer.$.filterMovies)
+  );
+  const tv = mergeLabelFilters(
+    all,
+    parsePlexLabelFilter(sharedServer.$.filterTelevision)
+  );
+
+  const allLibraries = sharedServer.$.allLibraries === '1';
+  const sharedSectionKeys = allLibraries
+    ? []
+    : (sharedServer.Section ?? [])
+        .filter((section) => section.$.shared === '1')
+        .map((section) => section.$.key);
+
+  const hasLabelRestrictions =
+    movies.allow.length > 0 ||
+    movies.deny.length > 0 ||
+    tv.allow.length > 0 ||
+    tv.deny.length > 0;
+
+  if (allLibraries && !hasLabelRestrictions) {
+    return null;
+  }
+
+  return { allLibraries, sharedSectionKeys, movies, tv };
+};
 
 /**
  * Decodes a single restriction value. Plex url encodes them, but a malformed
@@ -461,65 +500,16 @@ class PlexTvAPI extends ExternalAPI {
   public async getUserSharingRules(
     plexUserId: number
   ): Promise<PlexUserSharingRules | null> {
-    const settings = getSettings();
-
-    if (!settings.plex.machineId) {
-      return null;
-    }
-
     try {
-      // `shared_servers` exposes the filters *and* the shared sections in a
-      // single call, unlike `/api/users` which only reports a library count.
-      const response = await this.axios.get(
-        `/api/servers/${settings.plex.machineId}/shared_servers`,
-        {
-          transformResponse: [],
-          responseType: 'text',
-        }
-      );
-
-      const parsedXml = (await xml2js.parseStringPromise(
-        response.data
-      )) as SharedServersResponse;
-
-      const sharedServer = parsedXml.MediaContainer.SharedServer?.find(
-        (s) => parseInt(s.$.userID) === plexUserId
-      );
+      const sharedServers = await this.getSharedServers();
 
       // No entry means the library is not shared with this user at all; that
       // case is handled by checkUserAccess() rather than by filtering here.
-      if (!sharedServer) {
-        return null;
-      }
-
-      const all = parsePlexLabelFilter(sharedServer.$.filterAll);
-      const movies = mergeLabelFilters(
-        all,
-        parsePlexLabelFilter(sharedServer.$.filterMovies)
-      );
-      const tv = mergeLabelFilters(
-        all,
-        parsePlexLabelFilter(sharedServer.$.filterTelevision)
+      const sharedServer = sharedServers?.find(
+        (s) => parseInt(s.$.userID) === plexUserId
       );
 
-      const allLibraries = sharedServer.$.allLibraries === '1';
-      const sharedSectionKeys = allLibraries
-        ? []
-        : (sharedServer.Section ?? [])
-            .filter((section) => section.$.shared === '1')
-            .map((section) => section.$.key);
-
-      const hasLabelRestrictions =
-        movies.allow.length > 0 ||
-        movies.deny.length > 0 ||
-        tv.allow.length > 0 ||
-        tv.deny.length > 0;
-
-      if (allLibraries && !hasLabelRestrictions) {
-        return null;
-      }
-
-      return { allLibraries, sharedSectionKeys, movies, tv };
+      return sharedServer ? parseSharingRules(sharedServer) : null;
     } catch (e) {
       logger.error('Failed to retrieve Plex sharing rules for user', {
         label: 'Plex.tv API',
@@ -528,6 +518,61 @@ class PlexTvAPI extends ExternalAPI {
       });
       return null;
     }
+  }
+
+  /**
+   * Returns the sharing rules of every restricted user, keyed by Plex user id.
+   *
+   * Needed to tell how exclusive a label is before granting it: a label several
+   * users are allowed to see cannot be used to give access to one of them
+   * alone. Unrestricted users are left out, since they already see everything
+   * and applying a label changes nothing for them.
+   */
+  public async getAllUserSharingRules(): Promise<
+    Map<number, PlexUserSharingRules>
+  > {
+    const rulesByUserId = new Map<number, PlexUserSharingRules>();
+
+    try {
+      for (const sharedServer of (await this.getSharedServers()) ?? []) {
+        const rules = parseSharingRules(sharedServer);
+
+        if (rules) {
+          rulesByUserId.set(parseInt(sharedServer.$.userID), rules);
+        }
+      }
+    } catch (e) {
+      logger.error('Failed to retrieve Plex sharing rules', {
+        label: 'Plex.tv API',
+        errorMessage: e.message,
+      });
+    }
+
+    return rulesByUserId;
+  }
+
+  private async getSharedServers(): Promise<PlexSharedServer[] | undefined> {
+    const settings = getSettings();
+
+    if (!settings.plex.machineId) {
+      return undefined;
+    }
+
+    // `shared_servers` exposes the filters *and* the shared sections in a
+    // single call, unlike `/api/users` which only reports a library count.
+    const response = await this.axios.get(
+      `/api/servers/${settings.plex.machineId}/shared_servers`,
+      {
+        transformResponse: [],
+        responseType: 'text',
+      }
+    );
+
+    const parsedXml = (await xml2js.parseStringPromise(
+      response.data
+    )) as SharedServersResponse;
+
+    return parsedXml.MediaContainer.SharedServer;
   }
 
   public async getWatchlist({

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -1,6 +1,7 @@
 import type { PlexDevice } from '@server/interfaces/api/plexInterfaces';
 import cacheManager from '@server/lib/cache';
 import { getSettings } from '@server/lib/settings';
+import { isAllowedByTagRestriction } from '@server/lib/tagrestrictions';
 import logger from '@server/logger';
 import { randomUUID } from 'node:crypto';
 import xml2js from 'xml2js';
@@ -300,23 +301,7 @@ const mergeLabelFilters = (
 export const isAllowedByLabelFilter = (
   filter: PlexLabelFilter,
   labels: string[]
-): boolean => {
-  if (filter.allowNothing) {
-    return false;
-  }
-
-  const normalized = labels.map((label) => label.toLowerCase());
-
-  if (filter.deny.some((label) => normalized.includes(label.toLowerCase()))) {
-    return false;
-  }
-
-  if (!filter.allow.length) {
-    return true;
-  }
-
-  return filter.allow.some((label) => normalized.includes(label.toLowerCase()));
-};
+): boolean => isAllowedByTagRestriction(filter, labels);
 
 interface WatchlistResponse {
   MediaContainer: {

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -119,6 +119,12 @@ interface UsersResponse {
 export interface PlexLabelFilter {
   allow: string[];
   deny: string[];
+  /**
+   * Set when the combined restrictions cannot be satisfied by any label, so
+   * nothing in the library is visible. Distinguishes that case from an empty
+   * `allow` list, which means "no allow restriction".
+   */
+  allowNothing?: boolean;
 }
 
 interface SharedServersResponse {
@@ -168,6 +174,18 @@ export interface PlexUserSharingRules {
 const EMPTY_LABEL_FILTER: PlexLabelFilter = { allow: [], deny: [] };
 
 /**
+ * Decodes a single restriction value. Plex url encodes them, but a malformed
+ * sequence must not turn parsing a filter into an exception.
+ */
+const decodeLabel = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/**
  * Parses a Plex restriction string into its label allow/deny lists.
  *
  * Plex encodes restrictions as `key=value` clauses, where several values are
@@ -184,14 +202,17 @@ export const parsePlexLabelFilter = (
   const allow: string[] = [];
   const deny: string[] = [];
 
-  for (const clause of decodeURIComponent(filter).split(/[&|]/)) {
+  // Clauses are split on the raw string, so an encoded `&` or `|` inside a
+  // label value is not mistaken for a separator. Values are then decoded before
+  // being split on commas, because Plex encodes the comma that separates them.
+  for (const clause of filter.split(/[&|]/)) {
     const match = clause.trim().match(/^label(!?)=(.*)$/i);
 
     if (!match) {
       continue;
     }
 
-    const labels = match[2]
+    const labels = decodeLabel(match[2])
       .split(',')
       .map((label) => label.trim())
       .filter((label) => label.length > 0);
@@ -211,20 +232,26 @@ const mergeLabelFilters = (
   all: PlexLabelFilter,
   specific: PlexLabelFilter
 ): PlexLabelFilter => {
+  const deny = [...new Set([...all.deny, ...specific.deny])];
   let allow: string[];
+  let allowNothing = false;
 
   if (!all.allow.length) {
     allow = [...specific.allow];
   } else if (!specific.allow.length) {
     allow = [...all.allow];
   } else {
-    allow = all.allow.filter((label) => specific.allow.includes(label));
+    const specificLower = new Set(
+      specific.allow.map((label) => label.toLowerCase())
+    );
+    allow = all.allow.filter((label) => specificLower.has(label.toLowerCase()));
+
+    // Two allow lists sharing no label cannot both be satisfied. Treating the
+    // empty result as "no restriction" would grant access to everything.
+    allowNothing = allow.length === 0;
   }
 
-  return {
-    allow: [...new Set(allow)],
-    deny: [...new Set([...all.deny, ...specific.deny])],
-  };
+  return { allow: [...new Set(allow)], deny, allowNothing };
 };
 
 /**
@@ -235,6 +262,10 @@ export const isAllowedByLabelFilter = (
   filter: PlexLabelFilter,
   labels: string[]
 ): boolean => {
+  if (filter.allowNothing) {
+    return false;
+  }
+
   const normalized = labels.map((label) => label.toLowerCase());
 
   if (filter.deny.some((label) => normalized.includes(label.toLowerCase()))) {

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -8,7 +8,10 @@ import type { User } from '@server/entity/User';
 import { Watchlist } from '@server/entity/Watchlist';
 import type { DownloadingItem } from '@server/lib/downloadtracker';
 import downloadTracker from '@server/lib/downloadtracker';
-import { getVisibleRatingKeys } from '@server/lib/plexsharing';
+import {
+  getMediaServerItemIds,
+  getVisibleMediaIds,
+} from '@server/lib/librarysharing';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
@@ -77,9 +80,10 @@ class Media {
   /**
    * Hides availability of media the user has no access to on the media server.
    *
-   * Plex lets the owner restrict a shared user to specific libraries or labels,
-   * but availability is otherwise computed for the whole library. Without this,
-   * a restricted user is told a title is available and then cannot play it.
+   * Media servers let the owner restrict a shared user to specific libraries,
+   * and Plex additionally to specific labels, but availability is otherwise
+   * computed for the whole library. Without this, a restricted user is told a
+   * title is available and then cannot play it.
    *
    * The status is downgraded rather than the item removed, so the user can
    * still request it and be granted access.
@@ -88,23 +92,24 @@ class Media {
     user: User,
     media: Media[]
   ): Promise<Media[]> {
-    const visibleRatingKeys = await getVisibleRatingKeys(user);
+    const visibleIds = await getVisibleMediaIds(user);
 
     // `null` means the user is unrestricted, the common case.
-    if (!visibleRatingKeys) {
+    if (!visibleIds) {
       return media;
     }
 
-    const isHidden = (ratingKey?: string | null): boolean =>
-      !ratingKey || !visibleRatingKeys.has(ratingKey);
+    const isHidden = (itemId?: string | null): boolean =>
+      !itemId || !visibleIds.has(itemId);
 
     const isAvailable = (status: MediaStatus): boolean =>
       status === MediaStatus.AVAILABLE ||
       status === MediaStatus.PARTIALLY_AVAILABLE;
 
     for (const item of media) {
-      const hidden = isHidden(item.ratingKey);
-      const hidden4k = isHidden(item.ratingKey4k);
+      const { id, id4k } = getMediaServerItemIds(item);
+      const hidden = isHidden(id);
+      const hidden4k = isHidden(id4k);
 
       if (isAvailable(item.status) && hidden) {
         item.status = MediaStatus.UNKNOWN;
@@ -115,8 +120,8 @@ class Media {
       }
 
       // Seasons carry their own status, which the UI displays independently of
-      // the show's, so they have to be downgraded as well. Plex restricts
-      // access at show level, hence the show's own visibility is used.
+      // the show's, so they have to be downgraded as well. Access is granted at
+      // show level, hence the show's own visibility is used.
       for (const season of item.seasons ?? []) {
         if (isAvailable(season.status) && hidden) {
           season.status = MediaStatus.UNKNOWN;

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -111,12 +111,25 @@ class Media {
       const hidden = isHidden(id);
       const hidden4k = isHidden(id4k);
 
-      if (isAvailable(item.status) && hidden) {
-        item.status = MediaStatus.UNKNOWN;
+      if (hidden) {
+        if (isAvailable(item.status)) {
+          item.status = MediaStatus.UNKNOWN;
+        }
+
+        // Deep links are built from the media server id regardless of status,
+        // so they have to be dropped as well: a restricted user must not be
+        // handed a working "play" link to media they cannot open.
+        item.mediaUrl = undefined;
+        item.iOSPlexUrl = undefined;
       }
 
-      if (isAvailable(item.status4k) && hidden4k) {
-        item.status4k = MediaStatus.UNKNOWN;
+      if (hidden4k) {
+        if (isAvailable(item.status4k)) {
+          item.status4k = MediaStatus.UNKNOWN;
+        }
+
+        item.mediaUrl4k = undefined;
+        item.iOSPlexUrl4k = undefined;
       }
 
       // Seasons carry their own status, which the UI displays independently of

--- a/server/entity/Media.ts
+++ b/server/entity/Media.ts
@@ -8,6 +8,7 @@ import type { User } from '@server/entity/User';
 import { Watchlist } from '@server/entity/Watchlist';
 import type { DownloadingItem } from '@server/lib/downloadtracker';
 import downloadTracker from '@server/lib/downloadtracker';
+import { getVisibleRatingKeys } from '@server/lib/plexsharing';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
@@ -31,7 +32,12 @@ import Season from './Season';
 class Media {
   public static async getRelatedMedia(
     user: User | undefined,
-    items: { tmdbId: number; mediaType: string }[]
+    items: { tmdbId: number; mediaType: string }[],
+    // Background jobs work from the library's point of view, not a user's, so
+    // they opt out to avoid acting on an artificially downgraded status.
+    {
+      applySharingRestrictions = true,
+    }: { applySharingRestrictions?: boolean } = {}
   ): Promise<Media[]> {
     const mediaRepository = getRepository(Media);
 
@@ -53,18 +59,84 @@ class Media {
         .where(' media.tmdbId in (:...finalIds)', { finalIds })
         .getMany();
 
-      return media.filter((m) =>
+      const relatedMedia = media.filter((m) =>
         items.some((i) => i.tmdbId === m.tmdbId && i.mediaType === m.mediaType)
       );
+
+      if (!user || !applySharingRestrictions) {
+        return relatedMedia;
+      }
+
+      return await Media.applySharingRestrictions(user, relatedMedia);
     } catch (e) {
       logger.error(e.message);
       return [];
     }
   }
 
+  /**
+   * Hides availability of media the user has no access to on the media server.
+   *
+   * Plex lets the owner restrict a shared user to specific libraries or labels,
+   * but availability is otherwise computed for the whole library. Without this,
+   * a restricted user is told a title is available and then cannot play it.
+   *
+   * The status is downgraded rather than the item removed, so the user can
+   * still request it and be granted access.
+   */
+  public static async applySharingRestrictions(
+    user: User,
+    media: Media[]
+  ): Promise<Media[]> {
+    const visibleRatingKeys = await getVisibleRatingKeys(user);
+
+    // `null` means the user is unrestricted, the common case.
+    if (!visibleRatingKeys) {
+      return media;
+    }
+
+    const isHidden = (ratingKey?: string | null): boolean =>
+      !ratingKey || !visibleRatingKeys.has(ratingKey);
+
+    const isAvailable = (status: MediaStatus): boolean =>
+      status === MediaStatus.AVAILABLE ||
+      status === MediaStatus.PARTIALLY_AVAILABLE;
+
+    for (const item of media) {
+      const hidden = isHidden(item.ratingKey);
+      const hidden4k = isHidden(item.ratingKey4k);
+
+      if (isAvailable(item.status) && hidden) {
+        item.status = MediaStatus.UNKNOWN;
+      }
+
+      if (isAvailable(item.status4k) && hidden4k) {
+        item.status4k = MediaStatus.UNKNOWN;
+      }
+
+      // Seasons carry their own status, which the UI displays independently of
+      // the show's, so they have to be downgraded as well. Plex restricts
+      // access at show level, hence the show's own visibility is used.
+      for (const season of item.seasons ?? []) {
+        if (isAvailable(season.status) && hidden) {
+          season.status = MediaStatus.UNKNOWN;
+        }
+
+        if (isAvailable(season.status4k) && hidden4k) {
+          season.status4k = MediaStatus.UNKNOWN;
+        }
+      }
+    }
+
+    return media;
+  }
+
   public static async getMedia(
     id: number,
-    mediaType: MediaType
+    mediaType: MediaType,
+    // Passing the requesting user hides availability of media they have no
+    // access to on the media server.
+    user?: User
   ): Promise<Media | undefined> {
     const mediaRepository = getRepository(Media);
 
@@ -74,7 +146,17 @@ class Media {
         relations: { requests: true, issues: true },
       });
 
-      return media ?? undefined;
+      if (!media) {
+        return undefined;
+      }
+
+      if (!user) {
+        return media;
+      }
+
+      const [restricted] = await Media.applySharingRestrictions(user, [media]);
+
+      return restricted;
     } catch (e) {
       logger.error(e.message);
       return undefined;

--- a/server/lib/jellyfinsharing.test.ts
+++ b/server/lib/jellyfinsharing.test.ts
@@ -1,0 +1,63 @@
+import type { JellyfinUserResponse } from '@server/api/jellyfin';
+import { MediaServerType } from '@server/constants/server';
+import { parseTagRestriction } from '@server/lib/jellyfinsharing';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+type Policy = JellyfinUserResponse['Policy'];
+
+const policy = (fields: Partial<Policy>): Policy =>
+  ({ IsAdministrator: false, ...fields }) as Policy;
+
+describe('parseTagRestriction', () => {
+  describe('Jellyfin', () => {
+    const parse = (fields: Partial<Policy>) =>
+      parseTagRestriction(policy(fields), MediaServerType.JELLYFIN);
+
+    it('reads the two lists independently', () => {
+      assert.deepEqual(
+        parse({ AllowedTags: ['Family'], BlockedTags: ['Private'] }),
+        { allow: ['Family'], deny: ['Private'] }
+      );
+    });
+
+    it('returns an empty restriction when the policy carries no tag', () => {
+      assert.deepEqual(parse({}), { allow: [], deny: [] });
+    });
+
+    it('ignores the Emby inclusive flag', () => {
+      // The flag exists on Jellyfin policies too but has no meaning there, so
+      // reading it would silently turn a deny list into an allow list.
+      assert.deepEqual(
+        parse({ BlockedTags: ['Private'], IsTagBlockingModeInclusive: true }),
+        { allow: [], deny: ['Private'] }
+      );
+    });
+  });
+
+  describe('Emby', () => {
+    const parse = (fields: Partial<Policy>) =>
+      parseTagRestriction(policy(fields), MediaServerType.EMBY);
+
+    it('treats the single list as a deny list by default', () => {
+      assert.deepEqual(
+        parse({ BlockedTags: ['Private'], IsTagBlockingModeInclusive: false }),
+        { allow: [], deny: ['Private'] }
+      );
+    });
+
+    it('turns the same list into an allow list in inclusive mode', () => {
+      assert.deepEqual(
+        parse({ BlockedTags: ['Family'], IsTagBlockingModeInclusive: true }),
+        { allow: ['Family'], deny: [] }
+      );
+    });
+
+    it('ignores AllowedTags, which Emby does not use', () => {
+      assert.deepEqual(parse({ AllowedTags: ['Family'] }), {
+        allow: [],
+        deny: [],
+      });
+    });
+  });
+});

--- a/server/lib/jellyfinsharing.ts
+++ b/server/lib/jellyfinsharing.ts
@@ -1,9 +1,15 @@
+import type {
+  JellyfinLibraryItem,
+  JellyfinUserResponse,
+} from '@server/api/jellyfin';
 import JellyfinAPI from '@server/api/jellyfin';
 import { MediaServerType } from '@server/constants/server';
 import { UserType } from '@server/constants/user';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import { getSettings } from '@server/lib/settings';
+import type { TagRestriction } from '@server/lib/tagrestrictions';
+import { isAllowedByTagRestriction } from '@server/lib/tagrestrictions';
 import logger from '@server/logger';
 import { getHostname } from '@server/utils/getHostname';
 
@@ -29,6 +35,62 @@ import { getHostname } from '@server/utils/getHostname';
  * Returns `null` when the user reaches every enabled library, which callers
  * must treat as "no filtering".
  */
+/**
+ * Normalises the tag restrictions of a user policy, whose shape differs between
+ * the two servers. Both behaviours were established against real servers:
+ * Jellyfin applies `AllowedTags` and `BlockedTags` independently, while Emby
+ * keeps a single list in `BlockedTags` that `IsTagBlockingModeInclusive` turns
+ * from a deny list into an allow list.
+ */
+export const parseTagRestriction = (
+  policy: JellyfinUserResponse['Policy'],
+  serverType: MediaServerType
+): TagRestriction => {
+  const blocked = policy.BlockedTags ?? [];
+
+  if (serverType === MediaServerType.EMBY) {
+    return policy.IsTagBlockingModeInclusive
+      ? { allow: [...blocked], deny: [] }
+      : { allow: [], deny: [...blocked] };
+  }
+
+  return { allow: [...(policy.AllowedTags ?? [])], deny: [...blocked] };
+};
+
+/** Jellyfin reports item tags as `Tags`, Emby as `TagItems`. */
+const getItemTags = (item: JellyfinLibraryItem): string[] =>
+  item.Tags ?? item.TagItems?.map((tag) => tag.Name) ?? [];
+
+/**
+ * Builds the test telling whether a configured library is shared with the user.
+ *
+ * Emby's policy references libraries by their guid while the id stored in the
+ * settings is the numeric one it returns elsewhere, so a policy entry has to be
+ * matched against either identifier. Getting this wrong is not a partial
+ * failure: no library matches and the whole library reads as unavailable.
+ */
+const buildLibraryMatcher = async (
+  client: JellyfinAPI,
+  policy: JellyfinUserResponse['Policy']
+): Promise<(library: { id: string }) => boolean> => {
+  const allowedFolders = new Set(policy.EnabledFolders ?? []);
+  const guidById = new Map(
+    (await client.getLibraries())
+      .filter((library) => library.guid)
+      .map((library) => [library.key, library.guid as string])
+  );
+
+  return (library) => {
+    if (allowedFolders.has(library.id)) {
+      return true;
+    }
+
+    const guid = guidById.get(library.id);
+
+    return !!guid && allowedFolders.has(guid);
+  };
+};
+
 export const resolveVisibleJellyfinItemIds = async (
   user: User
 ): Promise<Set<string> | null> => {
@@ -68,28 +130,56 @@ export const resolveVisibleJellyfinItemIds = async (
 
   // Without a policy there is nothing to enforce; leave availability untouched
   // rather than risk hiding a library the user can actually reach.
-  if (!policy || policy.EnableAllFolders !== false) {
+  if (!policy) {
     return null;
   }
 
-  const allowedLibraryIds = new Set(policy.EnabledFolders ?? []);
+  const tagRestriction = parseTagRestriction(
+    policy,
+    settings.main.mediaServerType
+  );
+  const hasTagRestrictions =
+    tagRestriction.allow.length > 0 || tagRestriction.deny.length > 0;
+  const reachesEveryLibrary = policy.EnableAllFolders !== false;
+
+  if (reachesEveryLibrary && !hasTagRestrictions) {
+    return null;
+  }
+
   const enabled = settings.jellyfin.libraries.filter(
     (library) => library.enabled
   );
+  const isLibraryAllowed = reachesEveryLibrary
+    ? () => true
+    : await buildLibraryMatcher(client, policy);
 
-  if (enabled.every((library) => allowedLibraryIds.has(library.id))) {
+  if (enabled.every(isLibraryAllowed) && !hasTagRestrictions) {
     return null;
   }
 
   const visible = new Set<string>();
 
   for (const library of enabled) {
-    if (!allowedLibraryIds.has(library.id)) {
+    if (!isLibraryAllowed(library)) {
       // Library not shared with this user: nothing from it is visible.
       continue;
     }
 
-    for (const item of await client.getLibraryContents(library.id)) {
+    // Tags are only requested when they can change the outcome, since both
+    // servers return a long list of metadata keywords under the same field.
+    const items = await client.getLibraryContents(
+      library.id,
+      hasTagRestrictions ? { fields: 'Tags,TagItems' } : {}
+    );
+
+    for (const item of items) {
+      if (
+        hasTagRestrictions &&
+        !isAllowedByTagRestriction(tagRestriction, getItemTags(item))
+      ) {
+        continue;
+      }
+
       visible.add(item.Id);
     }
   }
@@ -98,8 +188,9 @@ export const resolveVisibleJellyfinItemIds = async (
     label: 'Media Server Sharing',
     userId: user.id,
     allowedLibraries: enabled
-      .filter((library) => allowedLibraryIds.has(library.id))
+      .filter(isLibraryAllowed)
       .map((library) => library.name),
+    tagRestriction: hasTagRestrictions ? tagRestriction : undefined,
     visibleItems: visible.size,
   });
 

--- a/server/lib/jellyfinsharing.ts
+++ b/server/lib/jellyfinsharing.ts
@@ -10,11 +10,16 @@ import { getHostname } from '@server/utils/getHostname';
 /**
  * Builds the set of Jellyfin or Emby item ids visible to a user.
  *
- * Unlike Plex, access is granted per library only, there is no label based
- * restriction, and the allowed libraries are taken from the user's policy:
- * `EnableAllFolders` means unrestricted, otherwise `EnabledFolders` lists the
- * library ids the user may browse. Both servers report those fields on the user
- * list, so a single request covers every user.
+ * The allowed libraries are taken from the user's policy: `EnableAllFolders`
+ * means unrestricted, otherwise `EnabledFolders` lists the library ids the user
+ * may browse. Both servers report those fields on the user list, so a single
+ * request covers every user.
+ *
+ * Only that library dimension is handled here. Both servers carry a second,
+ * tag based mechanism which is the direct analogue of Plex labels, and which
+ * they do enforce: Jellyfin exposes `AllowedTags` and `BlockedTags` on the
+ * policy, Emby `IncludeTags`, `BlockedTags` and `IsTagBlockingModeInclusive`.
+ * A user restricted that way is still reported as having access here.
  *
  * Items are then listed with the owner's credentials, since neither server
  * honours a `userId` filter when queried with an administrator token: Jellyfin

--- a/server/lib/jellyfinsharing.ts
+++ b/server/lib/jellyfinsharing.ts
@@ -1,0 +1,102 @@
+import JellyfinAPI from '@server/api/jellyfin';
+import { MediaServerType } from '@server/constants/server';
+import { UserType } from '@server/constants/user';
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import { getHostname } from '@server/utils/getHostname';
+
+/**
+ * Builds the set of Jellyfin or Emby item ids visible to a user.
+ *
+ * Unlike Plex, access is granted per library only, there is no label based
+ * restriction, and the allowed libraries are taken from the user's policy:
+ * `EnableAllFolders` means unrestricted, otherwise `EnabledFolders` lists the
+ * library ids the user may browse. Both servers report those fields on the user
+ * list, so a single request covers every user.
+ *
+ * Items are then listed with the owner's credentials, since neither server
+ * honours a `userId` filter when queried with an administrator token: Jellyfin
+ * answers 401 for a forbidden library, and Emby returns an empty list even for
+ * an allowed one.
+ *
+ * Returns `null` when the user reaches every enabled library, which callers
+ * must treat as "no filtering".
+ */
+export const resolveVisibleJellyfinItemIds = async (
+  user: User
+): Promise<Set<string> | null> => {
+  const settings = getSettings();
+
+  if (
+    (settings.main.mediaServerType !== MediaServerType.JELLYFIN &&
+      settings.main.mediaServerType !== MediaServerType.EMBY) ||
+    user.userType === UserType.PLEX ||
+    !user.jellyfinUserId
+  ) {
+    return null;
+  }
+
+  const userRepository = getRepository(User);
+  const admin = await userRepository.findOne({
+    select: { id: true, jellyfinDeviceId: true, jellyfinUserId: true },
+    where: { id: 1 },
+  });
+
+  // The owner always reaches the whole library.
+  if (!admin || user.id === admin.id) {
+    return null;
+  }
+
+  const client = new JellyfinAPI(
+    getHostname(),
+    settings.jellyfin.apiKey,
+    admin.jellyfinDeviceId
+  );
+  client.setUserId(admin.jellyfinUserId ?? '');
+
+  const { users } = await client.getUsers();
+  const policy = users.find(
+    (candidate) => candidate.Id === user.jellyfinUserId
+  )?.Policy;
+
+  // Without a policy there is nothing to enforce; leave availability untouched
+  // rather than risk hiding a library the user can actually reach.
+  if (!policy || policy.EnableAllFolders !== false) {
+    return null;
+  }
+
+  const allowedLibraryIds = new Set(policy.EnabledFolders ?? []);
+  const enabled = settings.jellyfin.libraries.filter(
+    (library) => library.enabled
+  );
+
+  if (enabled.every((library) => allowedLibraryIds.has(library.id))) {
+    return null;
+  }
+
+  const visible = new Set<string>();
+
+  for (const library of enabled) {
+    if (!allowedLibraryIds.has(library.id)) {
+      // Library not shared with this user: nothing from it is visible.
+      continue;
+    }
+
+    for (const item of await client.getLibraryContents(library.id)) {
+      visible.add(item.Id);
+    }
+  }
+
+  logger.debug('Resolved media server library restrictions for user', {
+    label: 'Media Server Sharing',
+    userId: user.id,
+    allowedLibraries: enabled
+      .filter((library) => allowedLibraryIds.has(library.id))
+      .map((library) => library.name),
+    visibleItems: visible.size,
+  });
+
+  return visible;
+};

--- a/server/lib/librarysharing.test.ts
+++ b/server/lib/librarysharing.test.ts
@@ -1,0 +1,70 @@
+import { MediaServerType } from '@server/constants/server';
+import type Media from '@server/entity/Media';
+import { getMediaServerItemIds } from '@server/lib/librarysharing';
+import { getSettings } from '@server/lib/settings';
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+const asMedia = (fields: Partial<Media>): Media => fields as Media;
+
+const withMediaServer = (type: MediaServerType) => {
+  getSettings().main.mediaServerType = type;
+};
+
+describe('getMediaServerItemIds', () => {
+  const initialType = getSettings().main.mediaServerType;
+
+  afterEach(() => {
+    getSettings().main.mediaServerType = initialType;
+  });
+
+  it('returns Plex rating keys when the server is Plex', () => {
+    withMediaServer(MediaServerType.PLEX);
+
+    assert.deepEqual(
+      getMediaServerItemIds(
+        asMedia({
+          ratingKey: '51',
+          ratingKey4k: '52',
+          jellyfinMediaId: 'abc',
+          jellyfinMediaId4k: 'def',
+        })
+      ),
+      { id: '51', id4k: '52' }
+    );
+  });
+
+  it('returns Jellyfin item ids when the server is Jellyfin', () => {
+    withMediaServer(MediaServerType.JELLYFIN);
+
+    assert.deepEqual(
+      getMediaServerItemIds(
+        asMedia({
+          ratingKey: '51',
+          ratingKey4k: '52',
+          jellyfinMediaId: 'abc',
+          jellyfinMediaId4k: 'def',
+        })
+      ),
+      { id: 'abc', id4k: 'def' }
+    );
+  });
+
+  it('reuses the Jellyfin columns for Emby', () => {
+    withMediaServer(MediaServerType.EMBY);
+
+    assert.deepEqual(
+      getMediaServerItemIds(asMedia({ jellyfinMediaId: 'abc' })),
+      { id: 'abc', id4k: undefined }
+    );
+  });
+
+  it('tolerates media that carries no identifier yet', () => {
+    withMediaServer(MediaServerType.PLEX);
+
+    assert.deepEqual(getMediaServerItemIds(asMedia({})), {
+      id: undefined,
+      id4k: undefined,
+    });
+  });
+});

--- a/server/lib/librarysharing.ts
+++ b/server/lib/librarysharing.ts
@@ -1,8 +1,12 @@
+import { MediaType } from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import type Media from '@server/entity/Media';
 import type { User } from '@server/entity/User';
 import { resolveVisibleJellyfinItemIds } from '@server/lib/jellyfinsharing';
-import { resolveVisiblePlexRatingKeys } from '@server/lib/plexsharing';
+import {
+  grantLabelAccess,
+  resolveVisiblePlexRatingKeys,
+} from '@server/lib/plexsharing';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 
@@ -104,4 +108,45 @@ export const getMediaServerItemIds = (
   }
 
   return { id: media.jellyfinMediaId, id4k: media.jellyfinMediaId4k };
+};
+
+/**
+ * Grants the requester access to media that has just become available, when the
+ * owner opted into it.
+ *
+ * Both routes a request can take end up here: the library already held the
+ * media, or a download landed and the scanner made it available. Granting from
+ * only one of them leaves the requester without access on the other, which is
+ * the more common case since most requests are downloaded rather than already
+ * present.
+ *
+ * Never throws: a failed grant must not hold up the request it belongs to.
+ */
+export const grantLibraryAccessForRequest = async (
+  user: User | null | undefined,
+  ratingKey: string | null | undefined,
+  mediaType: MediaType,
+  requestId: number
+): Promise<void> => {
+  if (!getSettings().plex.grantLabelOnApproval || !user || !ratingKey) {
+    return;
+  }
+
+  try {
+    const granted = await grantLabelAccess(user, {
+      ratingKey,
+      type: mediaType === MediaType.MOVIE ? 'movie' : 'show',
+    });
+
+    if (granted) {
+      // The user's visible set just changed, so drop the cached copy.
+      clearLibrarySharingCache(user.id);
+    }
+  } catch (e) {
+    logger.error('Failed to grant media server library access for request', {
+      label: 'Media Request',
+      requestId,
+      errorMessage: e instanceof Error ? e.message : String(e),
+    });
+  }
 };

--- a/server/lib/librarysharing.ts
+++ b/server/lib/librarysharing.ts
@@ -25,13 +25,21 @@ interface CacheEntry {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const cache = new Map<number, CacheEntry>();
 
+/**
+ * Resolution takes several requests, so concurrent callers for the same user
+ * share the one in flight instead of each starting their own.
+ */
+const inFlight = new Map<number, Promise<VisibleMediaIds>>();
+
 export const clearLibrarySharingCache = (userId?: number): void => {
   if (userId === undefined) {
     cache.clear();
+    inFlight.clear();
     return;
   }
 
   cache.delete(userId);
+  inFlight.delete(userId);
 };
 
 const resolve = async (user: User): Promise<VisibleMediaIds> => {
@@ -55,19 +63,33 @@ export const getVisibleMediaIds = async (
     return cached.ids;
   }
 
-  try {
-    const ids = await resolve(user);
-    cache.set(user.id, { ids, expiresAt: Date.now() + CACHE_TTL_MS });
-    return ids;
-  } catch (e) {
-    logger.error('Failed to resolve media server sharing restrictions', {
-      label: 'Media Server Sharing',
-      userId: user.id,
-      errorMessage: e.message,
-    });
-    // Fail open: a transient media server error must not hide the whole library.
-    return null;
+  const pending = inFlight.get(user.id);
+
+  if (pending) {
+    return pending;
   }
+
+  const resolution = resolve(user)
+    .then((ids) => {
+      cache.set(user.id, { ids, expiresAt: Date.now() + CACHE_TTL_MS });
+      return ids;
+    })
+    .catch((e) => {
+      logger.error('Failed to resolve media server sharing restrictions', {
+        label: 'Media Server Sharing',
+        userId: user.id,
+        errorMessage: e.message,
+      });
+      // Fail open: a transient error must not hide the whole library.
+      return null;
+    })
+    .finally(() => {
+      inFlight.delete(user.id);
+    });
+
+  inFlight.set(user.id, resolution);
+
+  return resolution;
 };
 
 /**

--- a/server/lib/librarysharing.ts
+++ b/server/lib/librarysharing.ts
@@ -1,0 +1,85 @@
+import { MediaServerType } from '@server/constants/server';
+import type Media from '@server/entity/Media';
+import type { User } from '@server/entity/User';
+import { resolveVisibleJellyfinItemIds } from '@server/lib/jellyfinsharing';
+import { resolveVisiblePlexRatingKeys } from '@server/lib/plexsharing';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+
+/**
+ * The set of media server item ids a restricted user is allowed to see, or
+ * `null` when the user is unrestricted and availability needs no filtering.
+ */
+export type VisibleMediaIds = Set<string> | null;
+
+interface CacheEntry {
+  expiresAt: number;
+  ids: VisibleMediaIds;
+}
+
+/**
+ * Resolving the visible ids costs a handful of media server requests, so the
+ * result is cached per user. Sharing rules change rarely, and a stale entry
+ * only delays a restriction by a few minutes.
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<number, CacheEntry>();
+
+export const clearLibrarySharingCache = (userId?: number): void => {
+  if (userId === undefined) {
+    cache.clear();
+    return;
+  }
+
+  cache.delete(userId);
+};
+
+const resolve = async (user: User): Promise<VisibleMediaIds> => {
+  switch (getSettings().main.mediaServerType) {
+    case MediaServerType.PLEX:
+      return resolveVisiblePlexRatingKeys(user);
+    case MediaServerType.JELLYFIN:
+    case MediaServerType.EMBY:
+      return resolveVisibleJellyfinItemIds(user);
+    default:
+      return null;
+  }
+};
+
+export const getVisibleMediaIds = async (
+  user: User
+): Promise<VisibleMediaIds> => {
+  const cached = cache.get(user.id);
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.ids;
+  }
+
+  try {
+    const ids = await resolve(user);
+    cache.set(user.id, { ids, expiresAt: Date.now() + CACHE_TTL_MS });
+    return ids;
+  } catch (e) {
+    logger.error('Failed to resolve media server sharing restrictions', {
+      label: 'Media Server Sharing',
+      userId: user.id,
+      errorMessage: e.message,
+    });
+    // Fail open: a transient media server error must not hide the whole library.
+    return null;
+  }
+};
+
+/**
+ * Returns the identifiers a media item carries on the configured media server,
+ * for the regular and the 4K version.
+ */
+export const getMediaServerItemIds = (
+  media: Media
+): { id?: string | null; id4k?: string | null } => {
+  if (getSettings().main.mediaServerType === MediaServerType.PLEX) {
+    return { id: media.ratingKey, id4k: media.ratingKey4k };
+  }
+
+  return { id: media.jellyfinMediaId, id4k: media.jellyfinMediaId4k };
+};

--- a/server/lib/plexsharing.test.ts
+++ b/server/lib/plexsharing.test.ts
@@ -1,0 +1,63 @@
+import { pickGrantLabel } from '@server/lib/plexsharing';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const sharedWith = (counts: Record<string, number>): Map<string, number> =>
+  new Map(Object.entries(counts));
+
+describe('pickGrantLabel', () => {
+  it('prefers the label no other user is allowed to see', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['Famille', 'Nico', 'cedric2605'],
+        ['cedric2605'],
+        sharedWith({ famille: 2, nico: 1 })
+      ),
+      { label: 'cedric2605', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('breaks ties between exclusive labels on the user name', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['brunocarrer', 'nikaii', 'cedric2605'],
+        ['cedric2605'],
+        sharedWith({})
+      ),
+      { label: 'cedric2605', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('falls back to the least shared label when none is exclusive', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['Famille', 'Nico'],
+        ['cedric2605'],
+        sharedWith({ famille: 2, nico: 1 })
+      ),
+      { label: 'Nico', alsoVisibleTo: 1 }
+    );
+  });
+
+  it('keeps the allow list order when nothing else separates the labels', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['Nico', 'Famille'],
+        [],
+        sharedWith({ nico: 1, famille: 1 })
+      ),
+      { label: 'Nico', alsoVisibleTo: 1 }
+    );
+  });
+
+  it('matches the user name case-insensitively', () => {
+    assert.deepEqual(
+      pickGrantLabel(['Famille', 'Cedric2605'], ['cedric2605'], sharedWith({})),
+      { label: 'Cedric2605', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('returns null when there is no candidate', () => {
+    assert.equal(pickGrantLabel([], ['cedric2605'], sharedWith({})), null);
+  });
+});

--- a/server/lib/plexsharing.test.ts
+++ b/server/lib/plexsharing.test.ts
@@ -6,7 +6,7 @@ const sharedWith = (counts: Record<string, number>): Map<string, number> =>
   new Map(Object.entries(counts));
 
 describe('pickGrantLabel', () => {
-  it('prefers the label no other user is allowed to see', () => {
+  it('grants the label named after the user', () => {
     assert.deepEqual(
       pickGrantLabel(
         ['Family', 'Household', 'alice'],
@@ -17,39 +17,65 @@ describe('pickGrantLabel', () => {
     );
   });
 
-  it('breaks ties between exclusive labels on the user name', () => {
-    assert.deepEqual(
-      pickGrantLabel(['bob', 'carol', 'alice'], ['alice'], sharedWith({})),
-      { label: 'alice', alsoVisibleTo: 0 }
-    );
-  });
-
-  it('falls back to the least shared label when none is exclusive', () => {
-    assert.deepEqual(
+  it('grants nothing when no label is named after the user', () => {
+    assert.equal(
       pickGrantLabel(
         ['Family', 'Household'],
         ['alice'],
         sharedWith({ family: 2, household: 1 })
       ),
-      { label: 'Household', alsoVisibleTo: 1 }
+      null
     );
   });
 
-  it('keeps the allow list order when nothing else separates the labels', () => {
-    assert.deepEqual(
-      pickGrantLabel(
-        ['Household', 'Family'],
-        [],
-        sharedWith({ household: 1, family: 1 })
-      ),
-      { label: 'Household', alsoVisibleTo: 1 }
-    );
+  it('grants nothing when the user has no name to match', () => {
+    assert.equal(pickGrantLabel(['Family', 'alice'], [], sharedWith({})), null);
   });
 
   it('matches the user name case-insensitively', () => {
     assert.deepEqual(
       pickGrantLabel(['Family', 'Alice'], ['alice'], sharedWith({})),
       { label: 'Alice', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('matches any of the names the user is known by', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['Family', 'alice'],
+        ['alice.plex', 'alice'],
+        sharedWith({})
+      ),
+      { label: 'alice', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('reports the other users a matching label is also visible to', () => {
+    assert.deepEqual(
+      pickGrantLabel(['alice'], ['alice'], sharedWith({ alice: 2 })),
+      { label: 'alice', alsoVisibleTo: 2 }
+    );
+  });
+
+  it('prefers the least shared match when several names apply', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['alice', 'Family', 'alice-plex'],
+        ['alice', 'alice-plex'],
+        sharedWith({ alice: 2, 'alice-plex': 0 })
+      ),
+      { label: 'alice-plex', alsoVisibleTo: 0 }
+    );
+  });
+
+  it('keeps the allow list order when nothing else separates the matches', () => {
+    assert.deepEqual(
+      pickGrantLabel(
+        ['alice-plex', 'alice'],
+        ['alice', 'alice-plex'],
+        sharedWith({ alice: 1, 'alice-plex': 1 })
+      ),
+      { label: 'alice-plex', alsoVisibleTo: 1 }
     );
   });
 

--- a/server/lib/plexsharing.test.ts
+++ b/server/lib/plexsharing.test.ts
@@ -9,55 +9,51 @@ describe('pickGrantLabel', () => {
   it('prefers the label no other user is allowed to see', () => {
     assert.deepEqual(
       pickGrantLabel(
-        ['Famille', 'Nico', 'cedric2605'],
-        ['cedric2605'],
-        sharedWith({ famille: 2, nico: 1 })
+        ['Family', 'Household', 'alice'],
+        ['alice'],
+        sharedWith({ family: 2, household: 1 })
       ),
-      { label: 'cedric2605', alsoVisibleTo: 0 }
+      { label: 'alice', alsoVisibleTo: 0 }
     );
   });
 
   it('breaks ties between exclusive labels on the user name', () => {
     assert.deepEqual(
-      pickGrantLabel(
-        ['brunocarrer', 'nikaii', 'cedric2605'],
-        ['cedric2605'],
-        sharedWith({})
-      ),
-      { label: 'cedric2605', alsoVisibleTo: 0 }
+      pickGrantLabel(['bob', 'carol', 'alice'], ['alice'], sharedWith({})),
+      { label: 'alice', alsoVisibleTo: 0 }
     );
   });
 
   it('falls back to the least shared label when none is exclusive', () => {
     assert.deepEqual(
       pickGrantLabel(
-        ['Famille', 'Nico'],
-        ['cedric2605'],
-        sharedWith({ famille: 2, nico: 1 })
+        ['Family', 'Household'],
+        ['alice'],
+        sharedWith({ family: 2, household: 1 })
       ),
-      { label: 'Nico', alsoVisibleTo: 1 }
+      { label: 'Household', alsoVisibleTo: 1 }
     );
   });
 
   it('keeps the allow list order when nothing else separates the labels', () => {
     assert.deepEqual(
       pickGrantLabel(
-        ['Nico', 'Famille'],
+        ['Household', 'Family'],
         [],
-        sharedWith({ nico: 1, famille: 1 })
+        sharedWith({ household: 1, family: 1 })
       ),
-      { label: 'Nico', alsoVisibleTo: 1 }
+      { label: 'Household', alsoVisibleTo: 1 }
     );
   });
 
   it('matches the user name case-insensitively', () => {
     assert.deepEqual(
-      pickGrantLabel(['Famille', 'Cedric2605'], ['cedric2605'], sharedWith({})),
-      { label: 'Cedric2605', alsoVisibleTo: 0 }
+      pickGrantLabel(['Family', 'Alice'], ['alice'], sharedWith({})),
+      { label: 'Alice', alsoVisibleTo: 0 }
     );
   });
 
   it('returns null when there is no candidate', () => {
-    assert.equal(pickGrantLabel([], ['cedric2605'], sharedWith({})), null);
+    assert.equal(pickGrantLabel([], ['alice'], sharedWith({})), null);
   });
 });

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -13,6 +13,12 @@ import logger from '@server/logger';
  */
 export type PlexVisibleRatingKeys = Set<string> | null;
 
+/** Identifies a single item in the Plex library. */
+export interface PlexItemRef {
+  ratingKey: string;
+  type: 'movie' | 'show';
+}
+
 interface CacheEntry {
   expiresAt: number;
   ratingKeys: PlexVisibleRatingKeys;
@@ -158,6 +164,67 @@ const getSectionRatingKeys = async (
   } while (offset < totalSize);
 
   return ratingKeys;
+};
+
+/**
+ * Grants a restricted user access to an item already present in the library, by
+ * adding one of the labels they are allowed to see.
+ *
+ * Returns the label that was applied, or `null` when nothing had to be done:
+ * the user is unrestricted, already has access, or has no allow list to draw a
+ * label from (a deny-only restriction cannot be satisfied this way).
+ */
+export const grantLabelAccess = async (
+  user: User,
+  { ratingKey, type }: PlexItemRef
+): Promise<string | null> => {
+  const settings = getSettings();
+
+  if (
+    settings.main.mediaServerType !== MediaServerType.PLEX ||
+    user.userType !== UserType.PLEX ||
+    !user.plexId ||
+    user.id === 1
+  ) {
+    return null;
+  }
+
+  const adminToken = await getAdminPlexToken();
+
+  if (!adminToken) {
+    return null;
+  }
+
+  const rules = await new PlexTvAPI(adminToken).getUserSharingRules(
+    user.plexId
+  );
+
+  if (!rules) {
+    return null;
+  }
+
+  const filter = type === 'show' ? rules.tv : rules.movies;
+  const label = filter.allow.find(
+    (candidate) => !filter.deny.includes(candidate)
+  );
+
+  if (!label) {
+    return null;
+  }
+
+  await new PlexAPI({ plexToken: adminToken }).addLabel(ratingKey, type, label);
+
+  // The user's visible set just changed, so drop the cached copy.
+  clearPlexSharingCache(user.id);
+
+  logger.info('Granted Plex library access by adding a label', {
+    label: 'Plex Sharing',
+    userId: user.id,
+    ratingKey,
+    plexLabel: label,
+  });
+
+  return label;
 };
 
 export const getVisibleRatingKeys = async (

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -19,28 +19,6 @@ export interface PlexItemRef {
   type: 'movie' | 'show';
 }
 
-interface CacheEntry {
-  expiresAt: number;
-  ratingKeys: PlexVisibleRatingKeys;
-}
-
-/**
- * Resolving the visible rating keys costs a handful of Plex requests, so the
- * result is cached per user. Sharing rules and labels change rarely, and a
- * stale entry only delays a restriction by a few minutes.
- */
-const CACHE_TTL_MS = 5 * 60 * 1000;
-const cache = new Map<number, CacheEntry>();
-
-export const clearPlexSharingCache = (userId?: number): void => {
-  if (userId === undefined) {
-    cache.clear();
-    return;
-  }
-
-  cache.delete(userId);
-};
-
 const getAdminPlexToken = async (): Promise<string | null> => {
   const userRepository = getRepository(User);
   const admin = await userRepository.findOne({
@@ -59,7 +37,7 @@ const getAdminPlexToken = async (): Promise<string | null> => {
  * "show everything", so unrestricted setups keep their current behaviour and
  * pay no extra cost.
  */
-const resolveVisibleRatingKeys = async (
+export const resolveVisiblePlexRatingKeys = async (
   user: User
 ): Promise<PlexVisibleRatingKeys> => {
   const settings = getSettings();
@@ -214,9 +192,6 @@ export const grantLabelAccess = async (
 
   await new PlexAPI({ plexToken: adminToken }).addLabel(ratingKey, type, label);
 
-  // The user's visible set just changed, so drop the cached copy.
-  clearPlexSharingCache(user.id);
-
   logger.info('Granted Plex library access by adding a label', {
     label: 'Plex Sharing',
     userId: user.id,
@@ -225,31 +200,4 @@ export const grantLabelAccess = async (
   });
 
   return label;
-};
-
-export const getVisibleRatingKeys = async (
-  user: User
-): Promise<PlexVisibleRatingKeys> => {
-  const cached = cache.get(user.id);
-
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.ratingKeys;
-  }
-
-  try {
-    const ratingKeys = await resolveVisibleRatingKeys(user);
-    cache.set(user.id, {
-      ratingKeys,
-      expiresAt: Date.now() + CACHE_TTL_MS,
-    });
-    return ratingKeys;
-  } catch (e) {
-    logger.error('Failed to resolve Plex sharing restrictions', {
-      label: 'Plex Sharing',
-      userId: user.id,
-      errorMessage: e.message,
-    });
-    // Fail open: a transient Plex error must not hide the whole library.
-    return null;
-  }
 };

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -168,6 +168,12 @@ export const resolveVisiblePlexRatingKeys = async (
     }
   }
 
+  logger.debug('Resolved Plex library restrictions for user', {
+    label: 'Plex Sharing',
+    userId: user.id,
+    visibleItems: visible.size,
+  });
+
   return visible;
 };
 

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -26,21 +26,24 @@ export interface PlexItemRef {
  *
  * A label is a shared bucket rather than a per-user permission: applying one
  * that other restricted users are also allowed to see hands them the item too.
- * So the label the fewest other users can see wins, and a label named after the
- * user breaks ties, since naming a label after its user is the usual
- * convention. Ordering is otherwise stable, to keep the choice predictable.
+ * Only a label named after the user is therefore ever applied, since that is the
+ * usual convention for a label meant for a single person, and nothing is granted
+ * when the user has no such label: a shared bucket is the owner's to hand out,
+ * not Seerr's.
  *
  * `sharedWithCount` maps a lowercased label to the number of *other* restricted
  * users allowed to see it. Unrestricted users are not counted: they already see
- * the item whatever label it carries.
+ * the item whatever label it carries. It no longer drives the choice, only the
+ * least shared of several name matches and the count reported to the owner,
+ * since even a label named after the user may be allowed to others.
  */
 export const pickGrantLabel = (
   candidates: string[],
-  preferredNames: string[],
+  userNames: string[],
   sharedWithCount: Map<string, number>
 ): { label: string; alsoVisibleTo: number } | null => {
   const names = new Set(
-    preferredNames.filter(Boolean).map((name) => name.toLowerCase())
+    userNames.filter(Boolean).map((name) => name.toLowerCase())
   );
 
   const ranked = candidates
@@ -48,14 +51,10 @@ export const pickGrantLabel = (
       label,
       index,
       alsoVisibleTo: sharedWithCount.get(label.toLowerCase()) ?? 0,
-      matchesName: names.has(label.toLowerCase()),
     }))
-    .sort(
-      (a, b) =>
-        a.alsoVisibleTo - b.alsoVisibleTo ||
-        Number(b.matchesName) - Number(a.matchesName) ||
-        a.index - b.index
-    );
+    .filter(({ label }) => names.has(label.toLowerCase()))
+    // Ordering is stable, to keep the choice predictable.
+    .sort((a, b) => a.alsoVisibleTo - b.alsoVisibleTo || a.index - b.index);
 
   const best = ranked[0];
 
@@ -205,8 +204,9 @@ const getSectionRatingKeys = async (
  * adding one of the labels they are allowed to see.
  *
  * Returns the label that was applied, or `null` when nothing had to be done:
- * the user is unrestricted, already has access, or has no allow list to draw a
- * label from (a deny-only restriction cannot be satisfied this way).
+ * the user is unrestricted, already has access, has no allow list to draw a
+ * label from (a deny-only restriction cannot be satisfied this way), or is
+ * allowed no label named after them.
  */
 export const grantLabelAccess = async (
   user: User,
@@ -253,7 +253,7 @@ export const grantLabelAccess = async (
   );
 
   // How many other restricted users each candidate label would also expose the
-  // item to, so the most exclusive one can be preferred.
+  // item to, which is reported to the owner along with the granted label.
   const sharedWithCount = new Map<string, number>();
 
   for (const [plexUserId, otherRules] of rulesByPlexUserId) {
@@ -282,6 +282,18 @@ export const grantLabelAccess = async (
   );
 
   if (!picked) {
+    // Worth surfacing: the owner enabled the grant and nothing happened, which
+    // from the outside is indistinguishable from a failure.
+    logger.info(
+      'No Plex label named after the user to grant, leaving the item untouched',
+      {
+        label: 'Plex Sharing',
+        userId: user.id,
+        ratingKey,
+        allowedLabels: candidates,
+      }
+    );
+
     return null;
   }
 

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -1,4 +1,5 @@
 import PlexAPI from '@server/api/plexapi';
+import type { PlexUserSharingRules } from '@server/api/plextv';
 import PlexTvAPI from '@server/api/plextv';
 import { MediaServerType } from '@server/constants/server';
 import { UserType } from '@server/constants/user';
@@ -18,6 +19,48 @@ export interface PlexItemRef {
   ratingKey: string;
   type: 'movie' | 'show';
 }
+
+/**
+ * Picks which of the labels a user is allowed to see should be applied to grant
+ * them access to an item.
+ *
+ * A label is a shared bucket rather than a per-user permission: applying one
+ * that other restricted users are also allowed to see hands them the item too.
+ * So the label the fewest other users can see wins, and a label named after the
+ * user breaks ties, since naming a label after its user is the usual
+ * convention. Ordering is otherwise stable, to keep the choice predictable.
+ *
+ * `sharedWithCount` maps a lowercased label to the number of *other* restricted
+ * users allowed to see it. Unrestricted users are not counted: they already see
+ * the item whatever label it carries.
+ */
+export const pickGrantLabel = (
+  candidates: string[],
+  preferredNames: string[],
+  sharedWithCount: Map<string, number>
+): { label: string; alsoVisibleTo: number } | null => {
+  const names = new Set(
+    preferredNames.filter(Boolean).map((name) => name.toLowerCase())
+  );
+
+  const ranked = candidates
+    .map((label, index) => ({
+      label,
+      index,
+      alsoVisibleTo: sharedWithCount.get(label.toLowerCase()) ?? 0,
+      matchesName: names.has(label.toLowerCase()),
+    }))
+    .sort(
+      (a, b) =>
+        a.alsoVisibleTo - b.alsoVisibleTo ||
+        Number(b.matchesName) - Number(a.matchesName) ||
+        a.index - b.index
+    );
+
+  const best = ranked[0];
+
+  return best ? { label: best.label, alsoVisibleTo: best.alsoVisibleTo } : null;
+};
 
 const getAdminPlexToken = async (): Promise<string | null> => {
   const userRepository = getRepository(User);
@@ -180,15 +223,17 @@ export const grantLabelAccess = async (
     return null;
   }
 
-  const rules = await new PlexTvAPI(adminToken).getUserSharingRules(
-    user.plexId
-  );
+  const plexTvClient = new PlexTvAPI(adminToken);
+  const rulesByPlexUserId = await plexTvClient.getAllUserSharingRules();
+  const rules = rulesByPlexUserId.get(user.plexId);
 
   if (!rules) {
     return null;
   }
 
-  const filter = type === 'show' ? rules.tv : rules.movies;
+  const filterOf = (candidate: PlexUserSharingRules) =>
+    type === 'show' ? candidate.tv : candidate.movies;
+  const filter = filterOf(rules);
 
   if (filter.allowNothing) {
     return null;
@@ -197,22 +242,58 @@ export const grantLabelAccess = async (
   // Case-insensitive, to match how the filter is evaluated: granting a label
   // that the deny list then rejects would achieve nothing.
   const denied = new Set(filter.deny.map((entry) => entry.toLowerCase()));
-  const label = filter.allow.find(
+  const candidates = filter.allow.filter(
     (candidate) => !denied.has(candidate.toLowerCase())
   );
 
-  if (!label) {
+  // How many other restricted users each candidate label would also expose the
+  // item to, so the most exclusive one can be preferred.
+  const sharedWithCount = new Map<string, number>();
+
+  for (const [plexUserId, otherRules] of rulesByPlexUserId) {
+    if (plexUserId === user.plexId) {
+      continue;
+    }
+
+    const otherFilter = filterOf(otherRules);
+    const otherDenied = new Set(
+      otherFilter.deny.map((entry) => entry.toLowerCase())
+    );
+
+    for (const allowed of otherFilter.allow) {
+      const key = allowed.toLowerCase();
+
+      if (!otherDenied.has(key)) {
+        sharedWithCount.set(key, (sharedWithCount.get(key) ?? 0) + 1);
+      }
+    }
+  }
+
+  const picked = pickGrantLabel(
+    candidates,
+    [user.plexUsername, user.username].filter((name): name is string => !!name),
+    sharedWithCount
+  );
+
+  if (!picked) {
     return null;
   }
 
-  await new PlexAPI({ plexToken: adminToken }).addLabel(ratingKey, type, label);
+  await new PlexAPI({ plexToken: adminToken }).addLabel(
+    ratingKey,
+    type,
+    picked.label
+  );
 
   logger.info('Granted Plex library access by adding a label', {
     label: 'Plex Sharing',
     userId: user.id,
     ratingKey,
-    plexLabel: label,
+    plexLabel: picked.label,
+    // Worth surfacing: no label is exclusive to a single user in every setup,
+    // so the owner should know when granting access widens it to others.
+    alsoVisibleToOtherUsers: picked.alsoVisibleTo,
   });
 
-  return label;
+  return picked.label;
 };

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -1,0 +1,188 @@
+import PlexAPI from '@server/api/plexapi';
+import PlexTvAPI from '@server/api/plextv';
+import { MediaServerType } from '@server/constants/server';
+import { UserType } from '@server/constants/user';
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+
+/**
+ * The set of Plex rating keys a restricted user is allowed to see, or `null`
+ * when the user is unrestricted and availability needs no filtering.
+ */
+export type PlexVisibleRatingKeys = Set<string> | null;
+
+interface CacheEntry {
+  expiresAt: number;
+  ratingKeys: PlexVisibleRatingKeys;
+}
+
+/**
+ * Resolving the visible rating keys costs a handful of Plex requests, so the
+ * result is cached per user. Sharing rules and labels change rarely, and a
+ * stale entry only delays a restriction by a few minutes.
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<number, CacheEntry>();
+
+export const clearPlexSharingCache = (userId?: number): void => {
+  if (userId === undefined) {
+    cache.clear();
+    return;
+  }
+
+  cache.delete(userId);
+};
+
+const getAdminPlexToken = async (): Promise<string | null> => {
+  const userRepository = getRepository(User);
+  const admin = await userRepository.findOne({
+    select: { id: true, plexToken: true },
+    where: { id: 1 },
+  });
+
+  return admin?.plexToken ?? null;
+};
+
+/**
+ * Builds the set of rating keys visible to a user, honouring both the shared
+ * library selection and the label restrictions configured in Plex.
+ *
+ * Returns `null` when the user is unrestricted, which callers must treat as
+ * "show everything", so unrestricted setups keep their current behaviour and
+ * pay no extra cost.
+ */
+const resolveVisibleRatingKeys = async (
+  user: User
+): Promise<PlexVisibleRatingKeys> => {
+  const settings = getSettings();
+
+  if (
+    settings.main.mediaServerType !== MediaServerType.PLEX ||
+    user.userType !== UserType.PLEX ||
+    !user.plexId
+  ) {
+    return null;
+  }
+
+  // The owner always sees the whole library.
+  if (user.id === 1) {
+    return null;
+  }
+
+  const adminToken = await getAdminPlexToken();
+
+  if (!adminToken) {
+    return null;
+  }
+
+  const rules = await new PlexTvAPI(adminToken).getUserSharingRules(
+    user.plexId
+  );
+
+  if (!rules) {
+    return null;
+  }
+
+  const plexClient = new PlexAPI({ plexToken: adminToken });
+  const libraries = settings.plex.libraries.filter(
+    (library) => library.enabled
+  );
+  const visible = new Set<string>();
+
+  for (const library of libraries) {
+    if (!rules.allLibraries && !rules.sharedSectionKeys.includes(library.id)) {
+      // Library not shared with this user: nothing from it is visible.
+      continue;
+    }
+
+    const filter = library.type === 'show' ? rules.tv : rules.movies;
+    const allowed = new Set<string>();
+
+    if (filter.allow.length) {
+      for (const label of filter.allow) {
+        for (const ratingKey of await plexClient.getRatingKeysByLabel(
+          library.id,
+          label
+        )) {
+          allowed.add(ratingKey);
+        }
+      }
+    } else {
+      // The library is shared without an allow list, so everything in it is
+      // visible unless a deny label excludes it.
+      for (const ratingKey of await getSectionRatingKeys(
+        plexClient,
+        library.id
+      )) {
+        allowed.add(ratingKey);
+      }
+    }
+
+    for (const label of filter.deny) {
+      for (const ratingKey of await plexClient.getRatingKeysByLabel(
+        library.id,
+        label
+      )) {
+        allowed.delete(ratingKey);
+      }
+    }
+
+    for (const ratingKey of allowed) {
+      visible.add(ratingKey);
+    }
+  }
+
+  return visible;
+};
+
+/** Lists every rating key of a library section, paging through the results. */
+const getSectionRatingKeys = async (
+  plexClient: PlexAPI,
+  sectionId: string
+): Promise<string[]> => {
+  const ratingKeys: string[] = [];
+  const size = 500;
+  let offset = 0;
+  let totalSize = 0;
+
+  do {
+    const { totalSize: total, items } = await plexClient.getLibraryContents(
+      sectionId,
+      { offset, size }
+    );
+    totalSize = total;
+    ratingKeys.push(...items.map((item) => item.ratingKey));
+    offset += size;
+  } while (offset < totalSize);
+
+  return ratingKeys;
+};
+
+export const getVisibleRatingKeys = async (
+  user: User
+): Promise<PlexVisibleRatingKeys> => {
+  const cached = cache.get(user.id);
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.ratingKeys;
+  }
+
+  try {
+    const ratingKeys = await resolveVisibleRatingKeys(user);
+    cache.set(user.id, {
+      ratingKeys,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    });
+    return ratingKeys;
+  } catch (e) {
+    logger.error('Failed to resolve Plex sharing restrictions', {
+      label: 'Plex Sharing',
+      userId: user.id,
+      errorMessage: e.message,
+    });
+    // Fail open: a transient Plex error must not hide the whole library.
+    return null;
+  }
+};

--- a/server/lib/plexsharing.ts
+++ b/server/lib/plexsharing.ts
@@ -82,6 +82,13 @@ export const resolveVisiblePlexRatingKeys = async (
     }
 
     const filter = library.type === 'show' ? rules.tv : rules.movies;
+
+    if (filter.allowNothing) {
+      // The restrictions cannot be satisfied, so skip the library entirely
+      // rather than listing items only to discard them.
+      continue;
+    }
+
     const allowed = new Set<string>();
 
     if (filter.allow.length) {
@@ -182,8 +189,16 @@ export const grantLabelAccess = async (
   }
 
   const filter = type === 'show' ? rules.tv : rules.movies;
+
+  if (filter.allowNothing) {
+    return null;
+  }
+
+  // Case-insensitive, to match how the filter is evaluated: granting a label
+  // that the deny list then rejects would achieve nothing.
+  const denied = new Set(filter.deny.map((entry) => entry.toLowerCase()));
   const label = filter.allow.find(
-    (candidate) => !filter.deny.includes(candidate)
+    (candidate) => !denied.has(candidate.toLowerCase())
   );
 
   if (!label) {

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -44,8 +44,9 @@ export interface PlexSettings {
   webAppUrl?: string;
   /**
    * When a user restricted by Plex labels requests media that already exists in
-   * the library, automatically add one of their allowed labels to it so they
-   * gain access, instead of leaving the request for the owner to handle.
+   * the library, automatically add the label named after them to it so they gain
+   * access, instead of leaving the request for the owner to handle. Nothing is
+   * added when they are allowed no such label.
    *
    * Disabled by default: granting library access is the owner's decision.
    */

--- a/server/lib/settings/index.ts
+++ b/server/lib/settings/index.ts
@@ -42,6 +42,14 @@ export interface PlexSettings {
   useSsl?: boolean;
   libraries: Library[];
   webAppUrl?: string;
+  /**
+   * When a user restricted by Plex labels requests media that already exists in
+   * the library, automatically add one of their allowed labels to it so they
+   * gain access, instead of leaving the request for the owner to handle.
+   *
+   * Disabled by default: granting library access is the owner's decision.
+   */
+  grantLabelOnApproval?: boolean;
 }
 
 export interface JellyfinSettings {

--- a/server/lib/tagrestrictions.test.ts
+++ b/server/lib/tagrestrictions.test.ts
@@ -1,0 +1,62 @@
+import { isAllowedByTagRestriction } from '@server/lib/tagrestrictions';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('isAllowedByTagRestriction', () => {
+  it('allows everything when no restriction applies', () => {
+    assert.equal(
+      isAllowedByTagRestriction({ allow: [], deny: [] }, ['anything']),
+      true
+    );
+    assert.equal(isAllowedByTagRestriction({ allow: [], deny: [] }, []), true);
+  });
+
+  it('denies an item carrying a denied tag', () => {
+    assert.equal(
+      isAllowedByTagRestriction({ allow: [], deny: ['Private'] }, ['Private']),
+      false
+    );
+    assert.equal(
+      isAllowedByTagRestriction({ allow: [], deny: ['Private'] }, ['Family']),
+      true
+    );
+  });
+
+  it('requires one of the allowed tags when an allow list applies', () => {
+    const restriction = { allow: ['Family'], deny: [] };
+
+    assert.equal(isAllowedByTagRestriction(restriction, ['Family']), true);
+    assert.equal(isAllowedByTagRestriction(restriction, ['Other']), false);
+    assert.equal(isAllowedByTagRestriction(restriction, []), false);
+  });
+
+  it('lets a denied tag win over an allowed one', () => {
+    // Matches what both Plex and Jellyfin do when the same tag is on both
+    // lists: nothing carrying it is visible, and nothing without it satisfies
+    // the allow list either.
+    const restriction = { allow: ['Shared'], deny: ['Shared'] };
+
+    assert.equal(isAllowedByTagRestriction(restriction, ['Shared']), false);
+    assert.equal(isAllowedByTagRestriction(restriction, ['Other']), false);
+  });
+
+  it('compares tags case-insensitively', () => {
+    assert.equal(
+      isAllowedByTagRestriction({ allow: ['family'], deny: [] }, ['Family']),
+      true
+    );
+    assert.equal(
+      isAllowedByTagRestriction({ allow: [], deny: ['PRIVATE'] }, ['private']),
+      false
+    );
+  });
+
+  it('shows nothing when the restriction is unsatisfiable', () => {
+    assert.equal(
+      isAllowedByTagRestriction({ allow: [], deny: [], allowNothing: true }, [
+        'Family',
+      ]),
+      false
+    );
+  });
+});

--- a/server/lib/tagrestrictions.ts
+++ b/server/lib/tagrestrictions.ts
@@ -1,0 +1,50 @@
+/**
+ * A restriction expressed as the labels or tags a user may and may not see.
+ *
+ * Every media server exposes the same idea under a different name: Plex calls
+ * them labels and encodes them in the sharing filter, Jellyfin splits them into
+ * `AllowedTags` and `BlockedTags`, Emby keeps a single list whose polarity is
+ * flipped by a flag. They are normalised into this shape so the matching rule
+ * lives in one place rather than once per server.
+ */
+export interface TagRestriction {
+  allow: string[];
+  deny: string[];
+  /**
+   * Set when the combined restrictions cannot be satisfied by any tag, so
+   * nothing is visible and the media server need not be queried at all.
+   */
+  allowNothing?: boolean;
+}
+
+export const EMPTY_TAG_RESTRICTION: TagRestriction = { allow: [], deny: [] };
+
+/**
+ * Evaluates a restriction against the tags carried by an item. Items without
+ * tags are only visible when no allow list applies.
+ *
+ * A deny entry wins over an allow entry, which is what both Plex and Jellyfin
+ * do: a user allowed and denied the same tag sees nothing carrying it.
+ */
+export const isAllowedByTagRestriction = (
+  restriction: TagRestriction,
+  tags: string[]
+): boolean => {
+  if (restriction.allowNothing) {
+    return false;
+  }
+
+  const normalized = tags.map((tag) => tag.toLowerCase());
+
+  if (restriction.deny.some((tag) => normalized.includes(tag.toLowerCase()))) {
+    return false;
+  }
+
+  if (!restriction.allow.length) {
+    return true;
+  }
+
+  return restriction.allow.some((tag) =>
+    normalized.includes(tag.toLowerCase())
+  );
+};

--- a/server/lib/watchlistsync.ts
+++ b/server/lib/watchlistsync.ts
@@ -70,7 +70,10 @@ class WatchlistSync {
       response.items.map((i) => ({
         tmdbId: i.tmdbId,
         mediaType: i.type === 'show' ? MediaType.TV : MediaType.MOVIE,
-      }))
+      })),
+      // Sync decides what already exists in the library, so it must see the
+      // real status rather than one downgraded by sharing restrictions.
+      { applySharingRestrictions: false }
     );
 
     const watchlistTmdbIds = response.items.map((i) => i.tmdbId);

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -77,27 +77,49 @@ mediaRoutes.get('/', async (req, res, next) => {
   }
 
   try {
-    const [media, mediaCount] = await mediaRepository.findAndCount({
-      order: sortFilter,
-      where: whereClause,
-      take: pageSize,
-      skip,
-    });
+    const mediaCount = await mediaRepository.count({ where: whereClause });
 
     // This endpoint feeds the "Recently Added" slider, so availability has to
-    // be reported from the requesting user's point of view.
-    const restricted = req.user
-      ? await Media.applySharingRestrictions(req.user, media)
-      : media;
+    // be reported from the requesting user's point of view. The requested
+    // filter is then applied a second time: an item hidden from that user is no
+    // longer in the state the caller asked for, and without this pass the
+    // slider shows a restricted user exactly the titles the media server hides
+    // from them, merely flagged unavailable.
+    //
+    // Dropping them would leave a short page, so the library is walked further
+    // until the page is full. The walk is bounded, because a user who can see
+    // very little must not turn this endpoint into a full table scan; such a
+    // user gets a short page rather than an expensive one.
+    const results: Media[] = [];
+    const maxRowsScanned = pageSize * 10;
+    let offset = skip;
+    let rowsScanned = 0;
 
-    // The caller asked for media in a given availability state, so an item the
-    // downgrade just took out of that state has no place in the answer. Without
-    // this, a restricted user is shown, as recently added, the titles the media
-    // server hides from them, merely flagged unavailable. Only the page shrinks,
-    // the total stays the library's, which no caller paginates on.
-    const results = acceptedStatuses
-      ? restricted.filter((item) => acceptedStatuses.includes(item.status))
-      : restricted;
+    while (results.length < pageSize && rowsScanned < maxRowsScanned) {
+      const batch = await mediaRepository.find({
+        order: sortFilter,
+        where: whereClause,
+        take: pageSize,
+        skip: offset,
+      });
+
+      if (!batch.length) {
+        break;
+      }
+
+      offset += batch.length;
+      rowsScanned += batch.length;
+
+      const restricted = req.user
+        ? await Media.applySharingRestrictions(req.user, batch)
+        : batch;
+
+      results.push(
+        ...(acceptedStatuses
+          ? restricted.filter((item) => acceptedStatuses.includes(item.status))
+          : restricted)
+      );
+    }
 
     return res.status(200).json({
       pageInfo: {
@@ -106,7 +128,7 @@ mediaRoutes.get('/', async (req, res, next) => {
         results: mediaCount,
         page: Math.ceil(skip / pageSize) + 1,
       },
-      results,
+      results: results.slice(0, pageSize),
     } as MediaResultsResponse);
   } catch (e) {
     next({ status: 500, message: e.message });

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -81,6 +81,13 @@ mediaRoutes.get('/', async (req, res, next) => {
       take: pageSize,
       skip,
     });
+
+    // This endpoint feeds the "Recently Added" slider, so availability has to
+    // be reported from the requesting user's point of view.
+    const results = req.user
+      ? await Media.applySharingRestrictions(req.user, media)
+      : media;
+
     return res.status(200).json({
       pageInfo: {
         pages: Math.ceil(mediaCount / pageSize),
@@ -88,7 +95,7 @@ mediaRoutes.get('/', async (req, res, next) => {
         results: mediaCount,
         page: Math.ceil(skip / pageSize) + 1,
       },
-      results: media,
+      results,
     } as MediaResultsResponse);
   } catch (e) {
     next({ status: 500, message: e.message });

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -27,28 +27,30 @@ mediaRoutes.get('/', async (req, res, next) => {
   const pageSize = req.query.take ? Number(req.query.take) : 20;
   const skip = req.query.skip ? Number(req.query.skip) : 0;
 
-  let statusFilter = undefined;
+  let acceptedStatuses: MediaStatus[] | undefined;
 
   switch (req.query.filter) {
     case 'available':
-      statusFilter = MediaStatus.AVAILABLE;
+      acceptedStatuses = [MediaStatus.AVAILABLE];
       break;
     case 'partial':
-      statusFilter = MediaStatus.PARTIALLY_AVAILABLE;
+      acceptedStatuses = [MediaStatus.PARTIALLY_AVAILABLE];
       break;
     case 'allavailable':
-      statusFilter = In([
+      acceptedStatuses = [
         MediaStatus.AVAILABLE,
         MediaStatus.PARTIALLY_AVAILABLE,
-      ]);
+      ];
       break;
     case 'processing':
-      statusFilter = MediaStatus.PROCESSING;
+      acceptedStatuses = [MediaStatus.PROCESSING];
       break;
     case 'pending':
-      statusFilter = MediaStatus.PENDING;
+      acceptedStatuses = [MediaStatus.PENDING];
       break;
   }
+
+  const statusFilter = acceptedStatuses ? In(acceptedStatuses) : undefined;
 
   let sortFilter: FindOneOptions<Media>['order'] = {
     id: 'DESC',
@@ -84,9 +86,18 @@ mediaRoutes.get('/', async (req, res, next) => {
 
     // This endpoint feeds the "Recently Added" slider, so availability has to
     // be reported from the requesting user's point of view.
-    const results = req.user
+    const restricted = req.user
       ? await Media.applySharingRestrictions(req.user, media)
       : media;
+
+    // The caller asked for media in a given availability state, so an item the
+    // downgrade just took out of that state has no place in the answer. Without
+    // this, a restricted user is shown, as recently added, the titles the media
+    // server hides from them, merely flagged unavailable. Only the page shrinks,
+    // the total stays the library's, which no caller paginates on.
+    const results = acceptedStatuses
+      ? restricted.filter((item) => acceptedStatuses.includes(item.status))
+      : restricted;
 
     return res.status(200).json({
       pageInfo: {

--- a/server/routes/movie.ts
+++ b/server/routes/movie.ts
@@ -22,7 +22,7 @@ movieRoutes.get('/:id', async (req, res, next) => {
       language: (req.query.language as string) ?? req.locale,
     });
 
-    const media = await Media.getMedia(tmdbMovie.id, MediaType.MOVIE);
+    const media = await Media.getMedia(tmdbMovie.id, MediaType.MOVIE, req.user);
 
     const onUserWatchlist = await getRepository(Watchlist).exist({
       where: {

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -29,6 +29,31 @@ import { Router } from 'express';
 
 const requestRoutes = Router();
 
+/**
+ * Applies the requesting user's media server restrictions to the media carried
+ * by requests.
+ *
+ * Requests load their media eagerly, which bypasses the filtering done by the
+ * `Media` finders, so it has to be applied here as well. Without this the
+ * requests list reports media hidden from the user as available, and hands them
+ * a deep link they cannot open.
+ */
+const hideRestrictedMedia = async (
+  user: User | undefined,
+  requests: MediaRequest[]
+): Promise<void> => {
+  if (!user) {
+    return;
+  }
+
+  await Media.applySharingRestrictions(
+    user,
+    requests
+      .map((request) => request.media)
+      .filter((media): media is Media => !!media)
+  );
+};
+
 requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
   '/',
   async (req, res, next) => {
@@ -180,6 +205,8 @@ requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
         .take(pageSize)
         .skip(skip)
         .getManyAndCount();
+
+      await hideRestrictedMedia(req.user, requests);
 
       const settings = getSettings();
 
@@ -446,6 +473,8 @@ requestRoutes.get('/:requestId', async (req, res, next) => {
         message: 'You do not have permission to view this request.',
       });
     }
+
+    await hideRestrictedMedia(req.user, [request]);
 
     return res.status(200).json(request);
   } catch (e) {

--- a/server/routes/tv.ts
+++ b/server/routes/tv.ts
@@ -30,7 +30,7 @@ tvRoutes.get('/:id', async (req, res, next) => {
       tvId: Number(req.params.id),
       language: (req.query.language as string) ?? req.locale,
     });
-    const media = await Media.getMedia(tv.id, MediaType.TV);
+    const media = await Media.getMedia(tv.id, MediaType.TV, req.user);
 
     const onUserWatchlist = await getRepository(Watchlist).exist({
       where: {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -18,6 +18,7 @@ import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import notificationManager, { Notification } from '@server/lib/notifications';
+import { grantLabelAccess } from '@server/lib/plexsharing';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { withNestedTransaction } from '@server/utils/nestedTransaction';
@@ -181,6 +182,55 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
   }
 
+  /**
+   * Media hidden from a user by Plex sharing restrictions is reported as
+   * unavailable to them, so they are able to request something the library
+   * already holds. Such a request must never be sent to Radarr or Sonarr, or
+   * the file would be downloaded a second time.
+   *
+   * Returns `true` when the caller has to stop, and grants library access right
+   * away when the owner opted into it.
+   */
+  private async isAlreadyInLibrary(entity: MediaRequest): Promise<boolean> {
+    const status = entity.is4k ? entity.media.status4k : entity.media.status;
+    const ratingKey = entity.is4k
+      ? entity.media.ratingKey4k
+      : entity.media.ratingKey;
+
+    if (status !== MediaStatus.AVAILABLE || !ratingKey) {
+      return false;
+    }
+
+    const settings = getSettings();
+
+    logger.info(
+      'Request targets media already present in the library, skipping download',
+      {
+        label: 'Media Request',
+        requestId: entity.id,
+        mediaId: entity.media.id,
+        grantLabelOnApproval: !!settings.plex.grantLabelOnApproval,
+      }
+    );
+
+    if (settings.plex.grantLabelOnApproval && entity.requestedBy) {
+      try {
+        await grantLabelAccess(entity.requestedBy, {
+          ratingKey,
+          type: entity.type === MediaType.MOVIE ? 'movie' : 'show',
+        });
+      } catch (e) {
+        logger.error('Failed to grant Plex library access for request', {
+          label: 'Media Request',
+          requestId: entity.id,
+          errorMessage: e.message,
+        });
+      }
+    }
+
+    return true;
+  }
+
   public async sendToRadarr(
     entity: MediaRequest,
     manager: EntityManager
@@ -189,6 +239,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.MOVIE
     ) {
+      if (await this.isAlreadyInLibrary(entity)) {
+        return;
+      }
+
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
@@ -488,6 +542,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.TV
     ) {
+      if (await this.isAlreadyInLibrary(entity)) {
+        return;
+      }
+
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -236,6 +236,43 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
+
+        // Media already in the library never needs a download client, so this
+        // is settled before any server is looked up. Doing it later leaves the
+        // request approved forever on an instance without a default one, and
+        // makes the tag handling below call the server for nothing.
+        const media = await mediaRepository.findOne({
+          where: { id: entity.media.id },
+        });
+
+        if (!media) {
+          logger.error('Media data not found', {
+            label: 'Media Request',
+            requestId: entity.id,
+            mediaId: entity.media.id,
+          });
+          return;
+        }
+
+        if (
+          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        ) {
+          logger.warn('Media already exists, marking request as COMPLETED', {
+            label: 'Media Request',
+            requestId: entity.id,
+            mediaId: entity.media.id,
+          });
+
+          // The requester may only be seeing this as unavailable because the
+          // media server hides it from them, so optionally grant them access.
+          await this.grantLibraryAccessIfEnabled(entity, media);
+
+          const requestRepository = manager.getRepository(MediaRequest);
+          entity.status = MediaRequestStatus.COMPLETED;
+          await requestRepository.save(entity);
+          return;
+        }
+
         if (settings.radarr.length === 0 && !settings.radarr[0]) {
           logger.info(
             'No Radarr server configured, skipping request processing',
@@ -326,38 +363,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             mediaId: entity.media.id,
             tagIds: tags,
           });
-        }
-
-        const media = await mediaRepository.findOne({
-          where: { id: entity.media.id },
-        });
-
-        if (!media) {
-          logger.error('Media data not found', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-          return;
-        }
-
-        if (
-          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        ) {
-          logger.warn('Media already exists, marking request as COMPLETED', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-
-          // The requester may only be seeing this as unavailable because the
-          // media server hides it from them, so optionally grant them access.
-          await this.grantLibraryAccessIfEnabled(entity, media);
-
-          const requestRepository = manager.getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.COMPLETED;
-          await requestRepository.save(entity);
-          return;
         }
 
         const tmdb = new TheMovieDb();
@@ -451,7 +456,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           })
           .catch(async () => {
             try {
-              const requestRepository = getRepository(MediaRequest);
+              const requestRepository = manager.getRepository(MediaRequest);
 
               if (entity.status !== MediaRequestStatus.FAILED) {
                 entity.status = MediaRequestStatus.FAILED;
@@ -539,6 +544,38 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
+
+        // Same as for movies: settled before any server is looked up.
+        const media = await mediaRepository.findOne({
+          where: { id: entity.media.id },
+        });
+
+        if (!media) {
+          throw new Error('Media data not found');
+        }
+
+        if (
+          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        ) {
+          logger.warn('Media already exists, marking request as COMPLETED', {
+            label: 'Media Request',
+            requestId: entity.id,
+            mediaId: entity.media.id,
+          });
+
+          // The requester may only be seeing this as unavailable because the
+          // media server hides it from them, so optionally grant them access.
+          await this.grantLibraryAccessIfEnabled(entity, media);
+
+          const requestRepository = manager.getRepository(MediaRequest);
+          entity.status = MediaRequestStatus.COMPLETED;
+          entity.seasons.forEach((season) => {
+            season.status = MediaRequestStatus.COMPLETED;
+          });
+          await requestRepository.save(entity);
+          return;
+        }
+
         if (settings.sonarr.length === 0 && !settings.sonarr[0]) {
           logger.warn(
             'No Sonarr server configured, skipping request processing',
@@ -586,36 +623,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
               mediaId: entity.media.id,
             }
           );
-          return;
-        }
-
-        const media = await mediaRepository.findOne({
-          where: { id: entity.media.id },
-        });
-
-        if (!media) {
-          throw new Error('Media data not found');
-        }
-
-        if (
-          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        ) {
-          logger.warn('Media already exists, marking request as COMPLETED', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-
-          // The requester may only be seeing this as unavailable because the
-          // media server hides it from them, so optionally grant them access.
-          await this.grantLibraryAccessIfEnabled(entity, media);
-
-          const requestRepository = manager.getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.COMPLETED;
-          entity.seasons.forEach((season) => {
-            season.status = MediaRequestStatus.COMPLETED;
-          });
-          await requestRepository.save(entity);
           return;
         }
 
@@ -803,7 +810,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           })
           .catch(async () => {
             try {
-              const requestRepository = getRepository(MediaRequest);
+              const requestRepository = manager.getRepository(MediaRequest);
 
               if (entity.status !== MediaRequestStatus.FAILED) {
                 entity.status = MediaRequestStatus.FAILED;

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -184,57 +184,45 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
   }
 
   /**
-   * Media hidden from a user by Plex sharing restrictions is reported as
-   * unavailable to them, so they are able to request something the library
-   * already holds. Such a request must never be sent to Radarr or Sonarr, or
-   * the file would be downloaded a second time.
+   * Grants the requester access to media the library already holds, when the
+   * owner opted into it.
    *
-   * Returns `true` when the caller has to stop, and grants library access right
-   * away when the owner opted into it.
+   * A restricted user only sees such media as unavailable because the media
+   * server hides it from them, so the request is legitimate even though nothing
+   * has to be downloaded. Plex only, since it relies on labels.
    */
-  private async isAlreadyInLibrary(entity: MediaRequest): Promise<boolean> {
-    const status = entity.is4k ? entity.media.status4k : entity.media.status;
-    const ratingKey = entity.is4k
-      ? entity.media.ratingKey4k
-      : entity.media.ratingKey;
+  private async grantLibraryAccessIfEnabled(
+    entity: MediaRequest,
+    media: Media
+  ): Promise<void> {
+    const settings = getSettings();
+    const ratingKey = entity.is4k ? media.ratingKey4k : media.ratingKey;
 
-    if (status !== MediaStatus.AVAILABLE || !ratingKey) {
-      return false;
+    if (
+      !settings.plex.grantLabelOnApproval ||
+      !ratingKey ||
+      !entity.requestedBy
+    ) {
+      return;
     }
 
-    const settings = getSettings();
+    try {
+      const granted = await grantLabelAccess(entity.requestedBy, {
+        ratingKey,
+        type: entity.type === MediaType.MOVIE ? 'movie' : 'show',
+      });
 
-    logger.info(
-      'Request targets media already present in the library, skipping download',
-      {
+      if (granted) {
+        // The user's visible set just changed, so drop the cached copy.
+        clearLibrarySharingCache(entity.requestedBy.id);
+      }
+    } catch (e) {
+      logger.error('Failed to grant media server library access for request', {
         label: 'Media Request',
         requestId: entity.id,
-        mediaId: entity.media.id,
-        grantLabelOnApproval: !!settings.plex.grantLabelOnApproval,
-      }
-    );
-
-    if (settings.plex.grantLabelOnApproval && entity.requestedBy) {
-      try {
-        const granted = await grantLabelAccess(entity.requestedBy, {
-          ratingKey,
-          type: entity.type === MediaType.MOVIE ? 'movie' : 'show',
-        });
-
-        if (granted) {
-          // The user's visible set just changed, so drop the cached copy.
-          clearLibrarySharingCache(entity.requestedBy.id);
-        }
-      } catch (e) {
-        logger.error('Failed to grant Plex library access for request', {
-          label: 'Media Request',
-          requestId: entity.id,
-          errorMessage: e.message,
-        });
-      }
+        errorMessage: e.message,
+      });
     }
-
-    return true;
   }
 
   public async sendToRadarr(
@@ -245,10 +233,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.MOVIE
     ) {
-      if (await this.isAlreadyInLibrary(entity)) {
-        return;
-      }
-
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
@@ -365,6 +349,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             requestId: entity.id,
             mediaId: entity.media.id,
           });
+
+          // The requester may only be seeing this as unavailable because the
+          // media server hides it from them, so optionally grant them access.
+          await this.grantLibraryAccessIfEnabled(entity, media);
 
           const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;
@@ -548,10 +536,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.TV
     ) {
-      if (await this.isAlreadyInLibrary(entity)) {
-        return;
-      }
-
       try {
         const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
@@ -621,6 +605,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             requestId: entity.id,
             mediaId: entity.media.id,
           });
+
+          // The requester may only be seeing this as unavailable because the
+          // media server hides it from them, so optionally grant them access.
+          await this.grantLibraryAccessIfEnabled(entity, media);
 
           const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -17,9 +17,8 @@ import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
-import { clearLibrarySharingCache } from '@server/lib/librarysharing';
+import { grantLibraryAccessForRequest } from '@server/lib/librarysharing';
 import notificationManager, { Notification } from '@server/lib/notifications';
-import { grantLabelAccess } from '@server/lib/plexsharing';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { withNestedTransaction } from '@server/utils/nestedTransaction';
@@ -183,48 +182,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
   }
 
-  /**
-   * Grants the requester access to media the library already holds, when the
-   * owner opted into it.
-   *
-   * A restricted user only sees such media as unavailable because the media
-   * server hides it from them, so the request is legitimate even though nothing
-   * has to be downloaded. Plex only, since it relies on labels.
-   */
-  private async grantLibraryAccessIfEnabled(
-    entity: MediaRequest,
-    media: Media
-  ): Promise<void> {
-    const settings = getSettings();
-    const ratingKey = entity.is4k ? media.ratingKey4k : media.ratingKey;
-
-    if (
-      !settings.plex.grantLabelOnApproval ||
-      !ratingKey ||
-      !entity.requestedBy
-    ) {
-      return;
-    }
-
-    try {
-      const granted = await grantLabelAccess(entity.requestedBy, {
-        ratingKey,
-        type: entity.type === MediaType.MOVIE ? 'movie' : 'show',
-      });
-
-      if (granted) {
-        // The user's visible set just changed, so drop the cached copy.
-        clearLibrarySharingCache(entity.requestedBy.id);
-      }
-    } catch (e) {
-      logger.error('Failed to grant media server library access for request', {
-        label: 'Media Request',
-        requestId: entity.id,
-        errorMessage: e.message,
-      });
-    }
-  }
-
   public async sendToRadarr(
     entity: MediaRequest,
     manager: EntityManager
@@ -265,7 +222,12 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
 
           // The requester may only be seeing this as unavailable because the
           // media server hides it from them, so optionally grant them access.
-          await this.grantLibraryAccessIfEnabled(entity, media);
+          await grantLibraryAccessForRequest(
+            entity.requestedBy,
+            entity.is4k ? media.ratingKey4k : media.ratingKey,
+            entity.type,
+            entity.id
+          );
 
           const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;
@@ -565,7 +527,12 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
 
           // The requester may only be seeing this as unavailable because the
           // media server hides it from them, so optionally grant them access.
-          await this.grantLibraryAccessIfEnabled(entity, media);
+          await grantLibraryAccessForRequest(
+            entity.requestedBy,
+            entity.is4k ? media.ratingKey4k : media.ratingKey,
+            entity.type,
+            entity.id
+          );
 
           const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -17,6 +17,7 @@ import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
+import { clearLibrarySharingCache } from '@server/lib/librarysharing';
 import notificationManager, { Notification } from '@server/lib/notifications';
 import { grantLabelAccess } from '@server/lib/plexsharing';
 import { getSettings } from '@server/lib/settings';
@@ -215,10 +216,15 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
 
     if (settings.plex.grantLabelOnApproval && entity.requestedBy) {
       try {
-        await grantLabelAccess(entity.requestedBy, {
+        const granted = await grantLabelAccess(entity.requestedBy, {
           ratingKey,
           type: entity.type === MediaType.MOVIE ? 'movie' : 'show',
         });
+
+        if (granted) {
+          // The user's visible set just changed, so drop the cached copy.
+          clearLibrarySharingCache(entity.requestedBy.id);
+        }
       } catch (e) {
         logger.error('Failed to grant Plex library access for request', {
           label: 'Media Request',

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -7,6 +7,7 @@ import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
+import { grantLibraryAccessForRequest } from '@server/lib/librarysharing';
 import logger from '@server/logger';
 import { withNestedTransaction } from '@server/utils/nestedTransaction';
 import type {
@@ -131,6 +132,29 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
       }
 
       await requestRepository.save(completedRequests);
+
+      // The other half of the grant done when the library already held the
+      // media: most requests are downloaded rather than already present, and
+      // without this a restricted user still cannot see what they requested.
+      // The rating key is read from the entity being saved, since the scanner
+      // sets it in the same write that makes the media available.
+      // A request also completes when the media is marked deleted, and the
+      // rating key survives that for as long as a request is still active, so
+      // that case is skipped rather than left to fail against Plex.
+      if ((is4k ? event.status4k : event.status) !== MediaStatus.DELETED) {
+        const ratingKey = is4k
+          ? (event.ratingKey4k ?? databaseEvent.ratingKey4k)
+          : (event.ratingKey ?? databaseEvent.ratingKey);
+
+        for (const request of completedRequests) {
+          await grantLibraryAccessForRequest(
+            request.requestedBy,
+            ratingKey,
+            request.type,
+            request.id
+          );
+        }
+      }
     }
   }
 

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -133,28 +133,50 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
 
       await requestRepository.save(completedRequests);
 
-      // The other half of the grant done when the library already held the
-      // media: most requests are downloaded rather than already present, and
-      // without this a restricted user still cannot see what they requested.
-      // The rating key is read from the entity being saved, since the scanner
-      // sets it in the same write that makes the media available.
-      // A request also completes when the media is marked deleted, and the
-      // rating key survives that for as long as a request is still active, so
-      // that case is skipped rather than left to fail against Plex.
-      if ((is4k ? event.status4k : event.status) !== MediaStatus.DELETED) {
-        const ratingKey = is4k
-          ? (event.ratingKey4k ?? databaseEvent.ratingKey4k)
-          : (event.ratingKey ?? databaseEvent.ratingKey);
+      return completedRequests;
+    }
 
-        for (const request of completedRequests) {
-          await grantLibraryAccessForRequest(
-            request.requestedBy,
-            ratingKey,
-            request.type,
-            request.id
-          );
-        }
-      }
+    return [];
+  }
+
+  /**
+   * Grants the requester access to the media their request was just completed
+   * by, when the owner opted into it.
+   *
+   * The other half of the grant done when the library already held the media:
+   * most requests are downloaded rather than already present, and without this
+   * a restricted user still cannot see what they requested.
+   *
+   * Deliberately run outside the transaction that completed the requests, since
+   * granting talks to plex.tv and to the media server, which must not happen
+   * with a write lock held.
+   */
+  private async grantLibraryAccessForCompleted(
+    completedRequests: MediaRequest[],
+    event: Media,
+    databaseEvent: Media,
+    is4k: boolean
+  ): Promise<void> {
+    // A request also completes when the media is marked deleted, and the rating
+    // key survives that for as long as a request is still active, so that case
+    // is skipped rather than left to fail against Plex.
+    if ((is4k ? event.status4k : event.status) === MediaStatus.DELETED) {
+      return;
+    }
+
+    // Read from the entity being saved, since the scanner sets the rating key
+    // in the same write that makes the media available.
+    const ratingKey = is4k
+      ? (event.ratingKey4k ?? databaseEvent.ratingKey4k)
+      : (event.ratingKey ?? databaseEvent.ratingKey);
+
+    for (const request of completedRequests) {
+      await grantLibraryAccessForRequest(
+        request.requestedBy,
+        ratingKey,
+        request.type,
+        request.id
+      );
     }
   }
 
@@ -254,14 +276,23 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(false))) &&
         validStatuses.includes(event.entity.status)
       ) {
-        await withNestedTransaction(event.manager, async (manager) => {
-          await this.updateRelatedMediaRequest(
-            manager,
-            event.entity as Media,
-            event.databaseEntity as Media,
-            false
-          );
-        });
+        const completedRequests = await withNestedTransaction(
+          event.manager,
+          async (manager) =>
+            this.updateRelatedMediaRequest(
+              manager,
+              event.entity as Media,
+              event.databaseEntity as Media,
+              false
+            )
+        );
+
+        await this.grantLibraryAccessForCompleted(
+          completedRequests,
+          event.entity as Media,
+          event.databaseEntity as Media,
+          false
+        );
       }
     } catch (e) {
       logger.error(
@@ -282,14 +313,23 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(true))) &&
         validStatuses.includes(event.entity.status4k)
       ) {
-        await withNestedTransaction(event.manager, async (manager) => {
-          await this.updateRelatedMediaRequest(
-            manager,
-            event.entity as Media,
-            event.databaseEntity as Media,
-            true
-          );
-        });
+        const completedRequests = await withNestedTransaction(
+          event.manager,
+          async (manager) =>
+            this.updateRelatedMediaRequest(
+              manager,
+              event.entity as Media,
+              event.databaseEntity as Media,
+              true
+            )
+        );
+
+        await this.grantLibraryAccessForCompleted(
+          completedRequests,
+          event.entity as Media,
+          event.databaseEntity as Media,
+          true
+        );
       }
     } catch (e) {
       logger.error(

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -72,7 +72,7 @@ const messages = defineMessages('components.Settings', {
     'Optionally direct users to the web app on your server instead of https://app.plex.tv/desktop',
   grantLabelOnApproval: 'Grant Library Access on Approval',
   grantLabelOnApprovalTip:
-    'When a user restricted by labels requests media already in your library, add one of their allowed labels to it instead of leaving the request for you to handle manually',
+    'When a user restricted by labels requests media already in your library, grant them access by adding the label the fewest other users can see, instead of leaving the request for you to handle manually',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
     'Optionally configure the settings for your Tautulli server. Seerr fetches watch history data for your Plex media from Tautulli.',

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -70,6 +70,9 @@ const messages = defineMessages('components.Settings', {
   webAppUrl: '<WebAppLink>Web App</WebAppLink> URL',
   webAppUrlTip:
     'Optionally direct users to the web app on your server instead of https://app.plex.tv/desktop',
+  grantLabelOnApproval: 'Grant Library Access on Approval',
+  grantLabelOnApprovalTip:
+    'When a user restricted by labels requests media already in your library, add one of their allowed labels to it instead of leaving the request for you to handle manually',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
     'Optionally configure the settings for your Tautulli server. Seerr fetches watch history data for your Plex media from Tautulli.',
@@ -386,6 +389,7 @@ const SettingsPlex = ({ isSetupSettings }: SettingsPlexProps) => {
           useSsl: data?.useSsl,
           selectedPreset: undefined,
           webAppUrl: data?.webAppUrl,
+          grantLabelOnApproval: data?.grantLabelOnApproval ?? false,
         }}
         validationSchema={PlexSettingsSchema}
         validateOnMount={true}
@@ -407,6 +411,7 @@ const SettingsPlex = ({ isSetupSettings }: SettingsPlexProps) => {
               port: Number(values.port),
               useSsl: values.useSsl,
               webAppUrl: values.webAppUrl,
+              grantLabelOnApproval: values.grantLabelOnApproval,
             } as PlexSettings);
 
             syncLibraries();
@@ -610,6 +615,31 @@ const SettingsPlex = ({ isSetupSettings }: SettingsPlexProps) => {
                     typeof errors.webAppUrl === 'string' && (
                       <div className="error">{errors.webAppUrl}</div>
                     )}
+                </div>
+              </div>
+              <div className="form-row">
+                <label
+                  htmlFor="grantLabelOnApproval"
+                  className="checkbox-label"
+                >
+                  {intl.formatMessage(messages.grantLabelOnApproval)}
+                  <SettingsBadge badgeType="advanced" className="ml-2" />
+                  <span className="label-tip">
+                    {intl.formatMessage(messages.grantLabelOnApprovalTip)}
+                  </span>
+                </label>
+                <div className="form-input-area">
+                  <Field
+                    type="checkbox"
+                    id="grantLabelOnApproval"
+                    name="grantLabelOnApproval"
+                    onChange={() => {
+                      setFieldValue(
+                        'grantLabelOnApproval',
+                        !values.grantLabelOnApproval
+                      );
+                    }}
+                  />
                 </div>
               </div>
               <div className="actions">

--- a/src/components/Settings/SettingsPlex.tsx
+++ b/src/components/Settings/SettingsPlex.tsx
@@ -72,7 +72,7 @@ const messages = defineMessages('components.Settings', {
     'Optionally direct users to the web app on your server instead of https://app.plex.tv/desktop',
   grantLabelOnApproval: 'Grant Library Access on Approval',
   grantLabelOnApprovalTip:
-    'When a user restricted by labels requests media already in your library, grant them access by adding the label the fewest other users can see, instead of leaving the request for you to handle manually',
+    'When a user restricted by labels requests media already in your library, grant them access by adding the label named after them, instead of leaving the request for you to handle manually. Nothing is added when they are allowed no such label',
   tautulliSettings: 'Tautulli Settings',
   tautulliSettingsDescription:
     'Optionally configure the settings for your Tautulli server. Seerr fetches watch history data for your Plex media from Tautulli.',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1204,6 +1204,8 @@
   "components.Settings.failed": "Does not work",
   "components.Settings.failedToSaveMetadataSettings": "Failed to save metadata provider settings",
   "components.Settings.general": "General",
+  "components.Settings.grantLabelOnApproval": "Grant Library Access on Approval",
+  "components.Settings.grantLabelOnApprovalTip": "When a user restricted by labels requests media already in your library, add one of their allowed labels to it instead of leaving the request for you to handle manually",
   "components.Settings.hostname": "Hostname or IP Address",
   "components.Settings.importBlocklistedTagsTip": "Import blocklisted tag configuration",
   "components.Settings.invalidKeyword": "{keywordId} is not a TMDB keyword.",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1205,7 +1205,7 @@
   "components.Settings.failedToSaveMetadataSettings": "Failed to save metadata provider settings",
   "components.Settings.general": "General",
   "components.Settings.grantLabelOnApproval": "Grant Library Access on Approval",
-  "components.Settings.grantLabelOnApprovalTip": "When a user restricted by labels requests media already in your library, add one of their allowed labels to it instead of leaving the request for you to handle manually",
+  "components.Settings.grantLabelOnApprovalTip": "When a user restricted by labels requests media already in your library, grant them access by adding the label the fewest other users can see, instead of leaving the request for you to handle manually",
   "components.Settings.hostname": "Hostname or IP Address",
   "components.Settings.importBlocklistedTagsTip": "Import blocklisted tag configuration",
   "components.Settings.invalidKeyword": "{keywordId} is not a TMDB keyword.",

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1205,7 +1205,7 @@
   "components.Settings.failedToSaveMetadataSettings": "Failed to save metadata provider settings",
   "components.Settings.general": "General",
   "components.Settings.grantLabelOnApproval": "Grant Library Access on Approval",
-  "components.Settings.grantLabelOnApprovalTip": "When a user restricted by labels requests media already in your library, grant them access by adding the label the fewest other users can see, instead of leaving the request for you to handle manually",
+  "components.Settings.grantLabelOnApprovalTip": "When a user restricted by labels requests media already in your library, grant them access by adding the label named after them, instead of leaving the request for you to handle manually. Nothing is added when they are allowed no such label",
   "components.Settings.hostname": "Hostname or IP Address",
   "components.Settings.importBlocklistedTagsTip": "Import blocklisted tag configuration",
   "components.Settings.invalidKeyword": "{keywordId} is not a TMDB keyword.",


### PR DESCRIPTION
## Description

Media servers let the owner restrict a shared user to specific libraries, and Plex additionally to items carrying specific labels (*Library → Restrictions → "Allow only labels"*). Seerr computed availability for the whole library regardless of who was asking, so a restricted user was shown titles as **Available** and then could not play them. In a multi-user setup that is a constant source of "why doesn't this work" questions, and it also leaks what other users have been adding.

This resolves the sharing rules of the requesting user and reports availability from their point of view, for **Plex, Jellyfin and Emby**.

- Fixes #180

### How it works

A dispatcher picks the resolver from the configured media server type and owns a five minute per-user cache, with concurrent resolutions for the same user sharing a single in-flight promise. Each resolver returns the set of item ids the user may see, or `null` when the user is unrestricted, in which case nothing is filtered and no request is made at all.

**Plex.** Sharing rules come from plex.tv `shared_servers`, which returns the label filters (`filterAll`, `filterMovies`, `filterTelevision`) **and** the shared sections in a single call, unlike `/api/users` which only reports a library count. Both `label=` and negated `label!=` restrictions are handled, and a server wide `filterAll` is combined with the per type one. Plex never returns labels in bulk library listings, whatever fields are requested, but it does support filtering *by* label, so the set is resolved with **one request per allowed label** rather than one per item. On my library that is 3 requests for a user restricted to 2 labels, against 760 if metadata had to be fetched item by item.

**Jellyfin and Emby.** The allowed libraries come from the user's policy: `EnableAllFolders` means unrestricted, otherwise `EnabledFolders` lists the library ids. Both servers report those fields on the user list, so a single request covers every user. Items are then listed with the owner's credentials rather than through a `userId` filter, because neither server honours that filter when queried with an administrator token: Jellyfin answers 401 for a forbidden library, and Emby returns an empty list even for an allowed one. Reading the policy is the only behaviour both agree on.

Availability is compared against `ratingKey` for Plex and `jellyfinMediaId` for Jellyfin and Emby, which already share the same columns.

**Tag restrictions.** Both servers carry a second mechanism next to the library selection, the direct analogue of Plex labels, and both enforce it. They express it differently, which was established against real servers rather than taken from the documentation: Jellyfin applies `AllowedTags` and `BlockedTags` independently, a denied tag winning over an allowed one, while Emby keeps a single list in `BlockedTags` whose polarity `IsTagBlockingModeInclusive` flips, and ignores its own `IncludeTags` entirely. Both are normalised into the same allow/deny shape already used for Plex labels, so the matching rule lives in one place rather than once per server. Tags are only requested when they can change the outcome, since both servers return a long list of metadata keywords under that same field.

**Library identifiers.** Emby's policy references libraries by their guid while the identifier stored in the settings is the numeric one it returns elsewhere, so a policy entry is matched against either. Jellyfin is unaffected, its library id already being the guid.

### What the user sees

Availability is **downgraded to `UNKNOWN` rather than the item being hidden**, so a restricted user can still request the title, instead of it silently disappearing.

One place makes an exception, because there the downgrade would otherwise contradict the caller. The `media` list endpoint filters by availability in SQL before the per-user view is applied, so an item hidden from that user stayed in an "available" listing merely flagged unavailable, and the Recently Added slider showed a restricted user exactly the titles the media server hides from them. The requested filter is therefore honoured again after the downgrade, and the library is walked further until the page is full, so the client gets a complete page already scoped to the user and needs to know nothing about the restrictions. The walk is bounded to ten pages worth of rows: a user who can see very little gets a short page rather than a full table scan. The reported total stays the library's, which no caller paginates on today.

Filtering is applied in `Media.getRelatedMedia` and `Media.getMedia`, which between them cover Discover, search, collections, people and the detail pages, plus the `media` route that feeds the "Recently Added" slider. Season statuses are downgraded as well, since the UI displays them independently of the show's. Background jobs opt out through a flag, so watchlist sync keeps seeing the library's real state and does not create duplicate requests.

### Granting access to what was requested

Being told a title is unavailable and then having no way to obtain it is the frustrating half of the problem, so the owner can optionally let Seerr grant access, through a new setting that is **disabled by default**:

- **off (default)**: nothing is written to the media server and granting library access stays a manual decision
- **on**: once the requested media is in the library, the label named after the requester is added to it, so they immediately gain access

This one is Plex specific, since it relies on labels.

**Both routes a request can take are covered**, which is the part I got wrong at first. A request either finds the media already in the library, in which case Seerr completes it without sending anything to Radarr or Sonarr, or it is downloaded and the scanner makes it available later. Granting only in the first case — where an earlier revision of this PR wired it — meant the setting did nothing for almost every request: a freshly imported file carries no label at all, so a label restricted user cannot see what they just waited for any more than before. The grant therefore also runs when a request is completed because the media became available, next to the existing completion logic in `MediaSubscriber`, and is deliberately performed **outside the transaction** that completes the requests, since it talks to plex.tv and to the media server. Media marked deleted is skipped, since it keeps its rating key for as long as a request is still active.

**Which label gets applied.** A label is a shared bucket, not a per-user permission, so applying one that other restricted users are also allowed to see hands them the item too. Only a label **named after the requester** is applied, matched case insensitively against their Plex username and their Seerr username, and **nothing is granted when they are allowed no such label** — handing out a shared bucket like `Famille` is the owner's decision, not Seerr's. The number of other restricted users the granted label is also visible to is logged, since even a nominative label may have been shared, and the case where nothing was applied is logged too, so an owner who enabled the setting is not left wondering why nothing happened. This answers my own open question 3 below with the most conservative of the options listed there; say the word if you would rather have another.

**The grant is one way.** Deleting the request afterwards does not take the label back, and neither does declining it later. Seerr cannot tell a label it applied itself from one the owner set by hand, so removing it on request deletion would risk destroying the owner's own tagging. Revoking access stays a manual action in Plex, see open question 4. Note that removing the label there takes up to the cache TTL to be reflected, see open question 1.

### Performance

Unrestricted users return early before any request to the media server, so existing setups pay nothing. Resolution fails open: a transient error must never hide the whole library.

Granting is the one place that costs something per request rather than per user: each grant reads every user's sharing rules from plex.tv to know which labels are exclusive, then writes the label. That is fine for the one request that triggered it, but a sync that completes a batch of requests at once pays it per request. Happy to batch it behind the same cache as the resolver if you would rather not have that.

## How Has This Been Tested?

Verified against real servers rather than from the documentation, which is how the Jellyfin and Emby divergence described above was found.

**Plex 1.43**, on my own server: 8 shared users, 3 of them restricted by label, ~760 movies and ~85 shows.

- a movie carrying an allowed label stays available for the restricted user, while a movie carrying none of their labels reports unavailable and stays available for the owner
- a hidden show reports unavailable, seasons included
- the "Recently Added" list reports per user availability
- requesting hidden media completes without reaching Radarr, and the label is applied when the setting is on
- the resolved visible set was compared against an independent count taken straight from Plex, using per-label queries: 717 movies + 62 shows + 10 concerts, matching exactly
- the requests list and the single request route report availability per user, which they did not at first: requests load their media eagerly and so bypassed the filtering done in the finders
- a restricted user is not handed a play deep link, which is built from the media server id independently of status
- label writes were checked to merge rather than replace: the item's existing labels are read back first, so the write adds to them and is a no-op when the label is already there

**Jellyfin 10.11** and **Emby 4.9**, on throwaway servers with two movie libraries and a user restricted to one of them:

- media in a forbidden library reports unavailable for that user and available for the owner
- granting access to that library makes it available again
- a user with `EnableAllFolders` and no tag restriction returns early, with no enumeration at all
- a user restricted by tag alone, reaching every library, is filtered rather than skipped: of five movies, the one carrying the denied tag reports unavailable and the other four stay available
- both tag polarities were exercised on each server and checked against what the server itself serves that user: as a deny list, two of a three movie library remain; in Emby's inclusive mode, only the tagged one does
- the Emby guid mismatch was caught this way: with the policy written as Emby itself writes it, no library matched and every title reported unavailable, including the library Emby grants. That case now resolves to the right single library
- the two behaviours listed above for Plex were re-checked here rather than assumed, since neither is Plex specific: the play link is written into the same `mediaUrl` field for all three server types, and the requests list bypasses the finders whatever the server is. On Jellyfin, with the user restricted to `LibA`, the two `LibB` movies report unavailable with no play link while the three `LibA` ones report available with one; on Emby, with the user restricted to `LibB`, the mirror image holds. The requests list agrees with the detail page for that user on both, and the owner keeps full availability throughout.

**Automated**

- 41 unit tests: the Plex restriction parser (url encoded values, encoded separators, malformed escapes, comma separated lists, negation, non label clauses), the label matcher (allow, deny, unsatisfiable, case insensitivity), the grant label selection (name match, case insensitivity, several known names, nothing granted without a match, exclusivity reporting, stable ordering), the tag matcher shared by the three servers (allow, deny, deny winning over allow, case insensitivity, unsatisfiable), the per server tag policy normalisation including Emby's polarity flag and the fields each server ignores, and the identifier selection per server type
- `pnpm test`: 194/194
- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `prettier` and `commitlint` all clean
- rebased on `develop`, including the subscriber transaction plumbing added since this branch opened

Note on coverage: the grant is wired into two subscriber paths, and neither subscriber has automated tests in this repo. The already-present route was exercised on the Plex server described above; the download route is newer and has not been through a full download-to-label round on a real server yet.

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

**AI disclosure.** An AI assistant was used as a coding aid. Every change was reviewed and exercised against the real Plex, Jellyfin and Emby servers described above, and the review round on this PR led to real corrections rather than being waved through: the redundant guard was removed once I confirmed Seerr already handled that case, an allow list intersection that failed open was fixed, and one suggested change was rejected because it broke Plex's own encoding of the label separator, which the tests caught.

No documentation change is included, and no database migration is required: nothing is persisted, the resolved visibility lives in an in-memory cache. Tell me if you would rather see the new setting documented somewhere specific.

## Open questions for reviewers

1. **Cache invalidation.** The five minute TTL means a restriction changed on the media server takes up to five minutes to apply. `clearLibrarySharingCache()` is exported and called after a label grant, but nothing calls it on a settings change or a user sync. Would you rather hook it somewhere specific, or resolve the rules on login and store them on the user?
2. **Whether the grant setting belongs here at all.** It makes a request flow write to the media server, which is a side effect Seerr does not otherwise have, and it only works on Plex: on Jellyfin and Emby access is granted per library, so there is no equivalent and the setting is asymmetric between server types. It is off by default, and dropping it would leave this PR purely read only, with granting access staying a manual step in Plex. I went with the setting because being told a title is unavailable and then having no way to obtain it is the frustrating half of the problem, but I am genuinely unsure it is the right call for Seerr.
3. **Which label to grant — decided, but tell me if you disagree.** Only a label named after the requester is applied, and nothing at all when there is none. The alternatives I considered were applying every allowed label, or preferring the label the fewest other users can see, which is what an earlier revision of this PR did: both hand the item to whoever else is allowed that label, which is why I dropped them. The cost of the conservative rule is that the setting does nothing for a user who has no nominative label, and there is no UI telling the owner that, only a log line.

   There is also the question of what the label should *represent*, which I think matters more than the picking rule. A label named after the requester is only one convention: a shared one standing for a household or an audience may be closer to what an owner actually wants, and the two answer different needs. That leads to a choice I deliberately have not made. As it stands the grant can only use a label the owner already created in Plex **and** already allowed that user to see, so Seerr never invents anything. Creating a label on the fly when a request comes in would lift that constraint, but it would mean writing new taxonomy into someone else's library, and on its own it would not even work: a brand new label is not in the user's allow list until the owner puts it there, so the grant would still not grant anything. A dedicated setting where the owner names the label to use would be a third option. Which of these is in scope? I would rather be told before building any of them.
4. **Whether deleting a request should take the label back.** It does not today: the grant is one way, and declining or deleting the request afterwards leaves the label in place. The reason is that Seerr cannot tell a label it applied from one the owner set by hand, so removing it blindly risks destroying the owner's own tagging. Doing it properly would mean recording what was granted, which is precisely what this PR avoids today, since nothing is persisted and no migration is needed. Three answers seem defensible: leave revocation manual as it is now, persist the granted label so it can be taken back exactly and accept the migration, or treat the grant as deliberately permanent and say so in the setting's description. Which would you want?
5. **Placement of the filter.** Doing it inside the entity keeps the diff small and covers every caller, but if you prefer it in a middleware or in the response mappers, say so and I will move it.
6. **Requesting media that is hidden and already requested.** The duplicate request check keys on tmdb id alone, so if one restricted user has a pending request for media hidden from them, a second restricted user requesting the same title gets a 409 they can do nothing about. The check predates this PR, but the case only becomes reachable with it, since both users would previously have been told the media was available. Tell me if you would rather I let the request through when the media is hidden from the requester.
