### PR TITLE
fix(discover): fix tv title sorting and validate sortBy per media type

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -39,26 +39,38 @@ interface SingleSearchOptions extends SearchOptions {
   year?: number;
 }
 
-export const SortOptionsIterable = [
+const CommonSortOptionsIterable = [
   'popularity.desc',
   'popularity.asc',
+  'vote_average.desc',
+  'vote_average.asc',
+  'vote_count.desc',
+  'vote_count.asc',
+] as const;
+
+export const MovieSortOptionsIterable = [
+  ...CommonSortOptionsIterable,
   'release_date.desc',
   'release_date.asc',
   'revenue.desc',
   'revenue.asc',
   'primary_release_date.desc',
   'primary_release_date.asc',
-  'original_title.asc',
   'original_title.desc',
-  'vote_average.desc',
-  'vote_average.asc',
-  'vote_count.desc',
-  'vote_count.asc',
-  'first_air_date.desc',
-  'first_air_date.asc',
+  'original_title.asc',
 ] as const;
 
-export type SortOptions = (typeof SortOptionsIterable)[number];
+export const TvSortOptionsIterable = [
+  ...CommonSortOptionsIterable,
+  'first_air_date.desc',
+  'first_air_date.asc',
+  'original_name.desc',
+  'original_name.asc',
+] as const;
+
+export type MovieSortOptions = (typeof MovieSortOptionsIterable)[number];
+export type TvSortOptions = (typeof TvSortOptionsIterable)[number];
+export type SortOptions = MovieSortOptions | TvSortOptions;
 
 export interface TmdbCertificationResponse {
   certifications: {
@@ -88,7 +100,7 @@ interface DiscoverMovieOptions {
   studio?: string;
   keywords?: string;
   excludeKeywords?: string;
-  sortBy?: SortOptions;
+  sortBy?: MovieSortOptions;
   watchRegion?: string;
   watchProviders?: string;
   certification?: string;
@@ -114,7 +126,7 @@ interface DiscoverTvOptions {
   network?: number;
   keywords?: string;
   excludeKeywords?: string;
-  sortBy?: SortOptions;
+  sortBy?: TvSortOptions;
   watchRegion?: string;
   watchProviders?: string;
   withStatus?: string; // Returning Series: 0 Planned: 1 In Production: 2 Ended: 3 Cancelled: 4 Pilot: 5

--- a/server/job/blocklistedTagsProcessor.ts
+++ b/server/job/blocklistedTagsProcessor.ts
@@ -1,5 +1,7 @@
-import type { SortOptions } from '@server/api/themoviedb';
-import { SortOptionsIterable } from '@server/api/themoviedb';
+import {
+  MovieSortOptionsIterable,
+  TvSortOptionsIterable,
+} from '@server/api/themoviedb';
 import type {
   TmdbSearchMovieResponse,
   TmdbSearchTvResponse,
@@ -80,68 +82,40 @@ class BlocklistedTagProcessor implements RunnableScanner<StatusBase> {
 
     // The maximum number of queries we're expected to execute
     this.total =
-      2 * blocklistedTagsArr.length * pageLimit * SortOptionsIterable.length;
+      blocklistedTagsArr.length *
+      pageLimit *
+      (MovieSortOptionsIterable.length + TvSortOptionsIterable.length);
 
-    for (const type of [MediaType.MOVIE, MediaType.TV]) {
-      const getDiscover =
-        type === MediaType.MOVIE ? tmdb.getDiscoverMovies : tmdb.getDiscoverTv;
+    for (const tag of blocklistedTagsArr) {
+      const keywordDetails = await tmdb.getKeywordDetails({
+        keywordId: Number(tag),
+      });
 
-      // Iterate for each tag
-      for (const tag of blocklistedTagsArr) {
-        const keywordDetails = await tmdb.getKeywordDetails({
-          keywordId: Number(tag),
+      if (keywordDetails === null) {
+        logger.warn('Skipping invalid keyword in blocklisted tags', {
+          label: 'Blocklisted Tags Processor',
+          keywordId: tag,
         });
-
-        if (keywordDetails === null) {
-          logger.warn('Skipping invalid keyword in blocklisted tags', {
-            label: 'Blocklisted Tags Processor',
-            keywordId: tag,
-          });
-          invalidKeywords.add(tag);
-          continue;
-        }
-
-        let queryMax = pageLimit * SortOptionsIterable.length;
-        let fixedSortMode = false; // Set to true when the page limit allows for getting every page of tag
-
-        for (let query = 0; query < queryMax; query++) {
-          const page: number = fixedSortMode
-            ? query + 1
-            : (query % pageLimit) + 1;
-          const sortBy: SortOptions | undefined = fixedSortMode
-            ? undefined
-            : SortOptionsIterable[query % SortOptionsIterable.length];
-
-          if (!this.running) {
-            throw new AbortTransaction();
-          }
-
-          try {
-            const response = await getDiscover({
-              page,
-              sortBy,
-              keywords: tag,
-            });
-
-            await this.processResults(response, tag, type, em);
-            await new Promise((res) => setTimeout(res, TMDB_API_DELAY_MS));
-
-            this.progress++;
-            if (page === 1 && response.total_pages <= queryMax) {
-              // We will finish the tag with less queries than expected, move progress accordingly
-              this.progress += queryMax - response.total_pages;
-              fixedSortMode = true;
-              queryMax = response.total_pages;
-            }
-          } catch (error) {
-            logger.error('Error processing keyword in blocklisted tags', {
-              label: 'Blocklisted Tags Processor',
-              keywordId: tag,
-              errorMessage: error.message,
-            });
-          }
-        }
+        invalidKeywords.add(tag);
+        continue;
       }
+
+      await this.processTagForType(
+        MediaType.MOVIE,
+        tag,
+        em,
+        tmdb.getDiscoverMovies,
+        MovieSortOptionsIterable,
+        pageLimit
+      );
+      await this.processTagForType(
+        MediaType.TV,
+        tag,
+        em,
+        tmdb.getDiscoverTv,
+        TvSortOptionsIterable,
+        pageLimit
+      );
     }
 
     if (invalidKeywords.size > 0) {
@@ -158,6 +132,55 @@ class BlocklistedTagProcessor implements RunnableScanner<StatusBase> {
           label: 'Blocklisted Tags Processor',
           removedKeywords: Array.from(invalidKeywords),
           newBlocklistedTags: cleanedTags,
+        });
+      }
+    }
+  }
+
+  private async processTagForType<S extends string>(
+    type: MediaType,
+    tag: string,
+    em: EntityManager,
+    getDiscover: (options: {
+      page: number;
+      sortBy?: S;
+      keywords: string;
+    }) => Promise<TmdbSearchMovieResponse | TmdbSearchTvResponse>,
+    sortOptions: readonly S[],
+    pageLimit: number
+  ): Promise<void> {
+    let queryMax = pageLimit * sortOptions.length;
+    let fixedSortMode = false;
+
+    for (let query = 0; query < queryMax; query++) {
+      const page: number = fixedSortMode
+        ? query + 1
+        : Math.floor(query / sortOptions.length) + 1;
+      const sortBy: S | undefined = fixedSortMode
+        ? undefined
+        : sortOptions[query % sortOptions.length];
+
+      if (!this.running) {
+        throw new AbortTransaction();
+      }
+
+      try {
+        const response = await getDiscover({ page, sortBy, keywords: tag });
+
+        await this.processResults(response, tag, type, em);
+        await new Promise((res) => setTimeout(res, TMDB_API_DELAY_MS));
+
+        this.progress++;
+        if (page === 1 && response.total_pages <= queryMax) {
+          this.progress += queryMax - response.total_pages;
+          fixedSortMode = true;
+          queryMax = response.total_pages;
+        }
+      } catch (error) {
+        logger.error('Error processing keyword in blocklisted tags', {
+          label: 'Blocklisted Tags Processor',
+          keywordId: tag,
+          errorMessage: error.message,
         });
       }
     }

--- a/server/job/blocklistedTagsProcessor.ts
+++ b/server/job/blocklistedTagsProcessor.ts
@@ -175,6 +175,8 @@ class BlocklistedTagProcessor implements RunnableScanner<StatusBase> {
           this.progress += queryMax - response.total_pages;
           fixedSortMode = true;
           queryMax = response.total_pages;
+          // restart the counter so sequential paging resumes at page 2 even if earlier queries failed
+          query = 0;
         }
       } catch (error) {
         logger.error('Error processing keyword in blocklisted tags', {

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -1,6 +1,8 @@
 import PlexTvAPI from '@server/api/plextv';
-import type { SortOptions } from '@server/api/themoviedb';
-import TheMovieDb from '@server/api/themoviedb';
+import TheMovieDb, {
+  MovieSortOptionsIterable,
+  TvSortOptionsIterable,
+} from '@server/api/themoviedb';
 import type { TmdbKeyword } from '@server/api/themoviedb/interfaces';
 import { MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
@@ -62,7 +64,6 @@ const discoverRoutes = Router();
 
 const QueryFilterOptions = z.object({
   page: z.coerce.string().optional(),
-  sortBy: z.coerce.string().optional(),
   primaryReleaseDateGte: z.coerce.string().optional(),
   primaryReleaseDateLte: z.coerce.string().optional(),
   firstAirDateGte: z.coerce.string().optional(),
@@ -90,21 +91,28 @@ const QueryFilterOptions = z.object({
 });
 
 export type FilterOptions = z.infer<typeof QueryFilterOptions>;
-const ApiQuerySchema = QueryFilterOptions.omit({
+const MovieApiQuerySchema = QueryFilterOptions.omit({
   certificationMode: true,
+}).extend({
+  sortBy: z.enum(MovieSortOptionsIterable).optional().catch(undefined),
+});
+const TvApiQuerySchema = QueryFilterOptions.omit({
+  certificationMode: true,
+}).extend({
+  sortBy: z.enum(TvSortOptionsIterable).optional().catch(undefined),
 });
 
 discoverRoutes.get('/movies', async (req, res, next) => {
   const tmdb = createTmdbWithRegionLanguage(req.user);
 
   try {
-    const query = ApiQuerySchema.parse(req.query);
+    const query = MovieApiQuerySchema.parse(req.query);
     const keywords = query.keywords;
     const excludeKeywords = query.excludeKeywords;
 
     const data = await tmdb.getDiscoverMovies({
       page: Number(query.page),
-      sortBy: query.sortBy as SortOptions,
+      sortBy: query.sortBy,
       language: req.locale ?? query.language,
       originalLanguage: query.language,
       genre: query.genre,
@@ -406,12 +414,12 @@ discoverRoutes.get('/tv', async (req, res, next) => {
   const tmdb = createTmdbWithRegionLanguage(req.user);
 
   try {
-    const query = ApiQuerySchema.parse(req.query);
+    const query = TvApiQuerySchema.parse(req.query);
     const keywords = query.keywords;
     const excludeKeywords = query.excludeKeywords;
     const data = await tmdb.getDiscoverTv({
       page: Number(query.page),
-      sortBy: query.sortBy as SortOptions,
+      sortBy: query.sortBy,
       language: req.locale ?? query.language,
       genre: query.genre,
       network: query.network ? Number(query.network) : undefined,

--- a/src/components/Discover/DiscoverMovies/index.tsx
+++ b/src/components/Discover/DiscoverMovies/index.tsx
@@ -13,7 +13,7 @@ import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
 import defineMessages from '@app/utils/defineMessages';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
-import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
+import type { MovieSortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { MovieResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
 import { useState } from 'react';

--- a/src/components/Discover/DiscoverTv/index.tsx
+++ b/src/components/Discover/DiscoverTv/index.tsx
@@ -13,7 +13,7 @@ import { useUpdateQueryParams } from '@app/hooks/useUpdateQueryParams';
 import ErrorPage from '@app/pages/_error';
 import defineMessages from '@app/utils/defineMessages';
 import { BarsArrowDownIcon, FunnelIcon } from '@heroicons/react/24/solid';
-import type { SortOptions as TMDBSortOptions } from '@server/api/themoviedb';
+import type { TvSortOptions as TMDBSortOptions } from '@server/api/themoviedb';
 import type { TvResult } from '@server/models/Search';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
@@ -40,8 +40,8 @@ const SortOptions: Record<string, TMDBSortOptions> = {
   FirstAirDateDesc: 'first_air_date.desc',
   TmdbRatingAsc: 'vote_average.asc',
   TmdbRatingDesc: 'vote_average.desc',
-  TitleAsc: 'original_title.asc',
-  TitleDesc: 'original_title.desc',
+  TitleAsc: 'original_name.asc',
+  TitleDesc: 'original_name.desc',
 } as const;
 
 const DiscoverTv = () => {


### PR DESCRIPTION
## Description

The TV discover page's title sort sent `sort_by=original_title.*` to `/discover/tv`, which is a movie-only value. TMDB silently ignores invalid `sort_by` parameters and returns its default popularity order, so sorting series by title did nothing. Sort options are now split per media type and validated at the route (previously any string was cast and forwarded unchecked), and TV title sorting uses `original_name.*`.

> [!note] 
> **Known limitation (upstream)**
> - The `title`/`name` were deliberately not adopted as when I verified against the live TMDB API, their sort orderings are identical to the `original_*` variants, as in `sort_by=name.desc` and `sort_by=original_name.desc` return matching ID sequences on `/discover/tv`, as do `title.desc` and `original_title.desc` on `/discover/movie`. Therefore, switching movies to `title` would change nothing while widening the scope. Thus, this PR keeps Movie's `original_title.*`, and similarly adopts `original_name.*` for TV as the value for sorting.
> - TMDB orders title sorts by the original-language title in code-point order. The `language` parameter affects display strings only. Non-Latin-script titles therefore cluster together in title sorts regardless of their displayed names, no TMDB sort option orders by the localized title, and this cannot be corrected client-side because pagination is server-side. Consistent with earlier reports: [title vs original_title exact match](https://www.themoviedb.org/talk/58cc119fc3a3682889012eb5), [staff confirmation that results are not sorted by translated titles](https://www.themoviedb.org/talk/5439df560e0a2649a10016b5).

Invalid sortBy values, including the original_title.* the UI previously emitted for TV are now ignored and fall back to TMDB's default order rather than erroring. 

Lastly, the blocklisted tags job now iterates only valid, distinct sort values per media type (previously TV queries and movie queries per tag used cross-type values that silently degraded into duplicate popularity-ordered pages so now this should make fewer requests per tag with strictly better coverage, and keyword details are fetched once per tag instead of once per media type).

- Fixes #3304

## How Has This Been Tested?

- Tested against the live TMDB API: sort-order equivalence of the localized and original title fields on both discover endpoints, and that the `language` parameter affects ordering. 
```
curl -s 'curl -s 'https://api.themoviedb.org/3/discover/tv?api_key=KEY&language=en-US&sort_by=name.desc&page=5' | jq -c '[.results[].id]'
curl -s 'https://api.themoviedb.org/3/discover/tv?api_key=KEY&language=en-US&sort_by=original_name.desc&page=5' | jq -c '[.results[].id]'
# both: [197074,65237,251479,288693,297953,126991,320346,291393,94222,89150,102899,92061,154589,92114,313440,210107,321696,68814,203164,57433]
# movie pair (title.desc vs original_title.desc) likewise identical
```
- Tested title asc/desc on Discover Movies and Discover Series in a dev instance, confirmed sorting now works for `/tv`.

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Movie and TV discovery now offer media-specific sorting options.
  * TV title sorting now uses the correct original-name ordering.
* **Bug Fixes**
  * Improved discovery query validation ensures only supported sort options are accepted for movies versus TV.
  * Blocklisted-tag processing now unifies paging for movies and TV, with more accurate totals, consistent progress updates, and improved cancellation behavior.
  * Discovery processing now handles incomplete result pages more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->