### PR TITLE
fix(ui): keep user list action buttons sized with a single user

### DIFF
--- a/src/components/UserList/index.tsx
+++ b/src/components/UserList/index.tsx
@@ -750,12 +750,12 @@ const UserList = () => {
             >
               {intl.formatMessage(messages.created)}
             </SortableColumnHeader>
-            <Table.TH className="w-1/12 whitespace-nowrap text-right">
+            <Table.TH className="w-1/12 min-w-[12rem] whitespace-nowrap text-right">
               {(data.results ?? []).length > 1 && (
                 <div className="flex justify-end">
                   <Button
                     buttonType="warning"
-                    className="w-full sm:min-w-[12rem]"
+                    className="w-full"
                     onClick={() => setShowBulkEditModal(true)}
                     disabled={selectedUsers.length === 0}
                   >
@@ -874,33 +874,32 @@ const UserList = () => {
                   day: 'numeric',
                 })}
               </Table.TD>
-              <Table.TD
-                alignText="right"
-                className="grid grid-cols-1 gap-1 sm:grid-cols-2 sm:gap-2"
-              >
-                <Button
-                  buttonType="warning"
-                  disabled={user.id === 1 && currentUser?.id !== 1}
-                  onClick={() =>
-                    router.push(
-                      '/users/[userId]/settings',
-                      `/users/${user.id}/settings`
-                    )
-                  }
-                >
-                  {intl.formatMessage(globalMessages.edit)}
-                </Button>
-                <Button
-                  buttonType="danger"
-                  disabled={
-                    user.id === 1 ||
-                    (currentUser?.id !== 1 &&
-                      hasPermission(Permission.ADMIN, user.permissions))
-                  }
-                  onClick={() => setDeleteModal({ isOpen: true, user })}
-                >
-                  {intl.formatMessage(globalMessages.delete)}
-                </Button>
+              <Table.TD alignText="right">
+                <div className="grid grid-cols-1 gap-1 sm:grid-cols-2 sm:gap-2">
+                  <Button
+                    buttonType="warning"
+                    disabled={user.id === 1 && currentUser?.id !== 1}
+                    onClick={() =>
+                      router.push(
+                        '/users/[userId]/settings',
+                        `/users/${user.id}/settings`
+                      )
+                    }
+                  >
+                    {intl.formatMessage(globalMessages.edit)}
+                  </Button>
+                  <Button
+                    buttonType="danger"
+                    disabled={
+                      user.id === 1 ||
+                      (currentUser?.id !== 1 &&
+                        hasPermission(Permission.ADMIN, user.permissions))
+                    }
+                    onClick={() => setDeleteModal({ isOpen: true, user })}
+                  >
+                    {intl.formatMessage(globalMessages.delete)}
+                  </Button>
+                </div>
               </Table.TD>
             </tr>
           ))}


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On the Users page, the Edit/Delete action column only got a usable minimum width from the Bulk Edit button.
That button is hidden when there is exactly one user, so the column collapsed and the Edit/Delete buttons laid out incorrectly.

- Fixes #3309 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Opened Users page with exactly one user and confirmed Edit/Delete retain proper width and layout.
- Opened Users page with multiple users and confirmed Bulk Edit still appears and Edit/Delete layout is unchanged.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved alignment and spacing for the user list’s “Created” column and bulk-edit controls.
  * Refined the layout of edit and delete actions within user rows.
  * Preserved existing button behavior and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->