### PR TITLE
chore: exclude .pnpm-store from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 .gitconfig
 .github
 .gitignore
+.pnpm-store
 .husky
 .next
 .prettierignore


### PR DESCRIPTION
## Description

On local builds the .pnpm-store directory is not excluded from the build context. Since it's never referenced by the Dockerfile RUN --mount=type=cache uses its own in-container store path, and it gets shipped to the daemon on every build for no benefit. Adding .pnpm-store to .dockerignore cuts build context size by over 1gb with no change to build output.

- Fixes N/A

## How Has This Been Tested?

Local Docker build was run successfully with image output size reduced by 1.2gb


## Screenshots / Logs (if applicable)
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)