### PR TITLE
feat: add support for custom plex metadata provider guid scheme in scanner

### DIFF
--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -28,7 +28,7 @@ const tvdbRegex = new RegExp(/tvdb:\/\/([0-9]+)/);
 const tmdbShowRegex = new RegExp(/themoviedb:\/\/([0-9]+)/);
 const plexRegex = new RegExp(/plex:\/\//);
 const plexCustomProviderRegex = new RegExp(
-  /tv\.plex\.agents\.custom\.[a-zA-Z0-9]+:\/\//
+  /tv\.plex\.agents\.custom(\.[a-zA-Z0-9]+)+:\/\//
 );
 // Hama agent uses ASS naming, see details here:
 // https://github.com/ZeroQI/Absolute-Series-Scanner/blob/master/README.md#forcing-the-movieseries-id

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -27,7 +27,9 @@ const tmdbRegex = new RegExp(/tmdb:\/\/([0-9]+)/);
 const tvdbRegex = new RegExp(/tvdb:\/\/([0-9]+)/);
 const tmdbShowRegex = new RegExp(/themoviedb:\/\/([0-9]+)/);
 const plexRegex = new RegExp(/plex:\/\//);
-const plexCustomProviderRegex = new RegExp(/tv\.plex\.agents\.custom\..*:\/\//);
+const plexCustomProviderRegex = new RegExp(
+  /tv\.plex\.agents\.custom\.[a-zA-Z0-9]+:\/\//
+);
 // Hama agent uses ASS naming, see details here:
 // https://github.com/ZeroQI/Absolute-Series-Scanner/blob/master/README.md#forcing-the-movieseries-id
 const hamaTvdbRegex = new RegExp(/hama:\/\/tvdb[0-9]?-([0-9]+)/);

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -27,6 +27,7 @@ const tmdbRegex = new RegExp(/tmdb:\/\/([0-9]+)/);
 const tvdbRegex = new RegExp(/tvdb:\/\/([0-9]+)/);
 const tmdbShowRegex = new RegExp(/themoviedb:\/\/([0-9]+)/);
 const plexRegex = new RegExp(/plex:\/\//);
+const plexCustomProviderRegex = new RegExp(/tv\.plex\.agents\.custom\..*:\/\//);
 // Hama agent uses ASS naming, see details here:
 // https://github.com/ZeroQI/Absolute-Series-Scanner/blob/master/README.md#forcing-the-movieseries-id
 const hamaTvdbRegex = new RegExp(/hama:\/\/tvdb[0-9]?-([0-9]+)/);
@@ -382,7 +383,7 @@ class PlexScanner
   private async getMediaIds(plexitem: PlexLibraryItem): Promise<MediaIds> {
     let mediaIds: Partial<MediaIds> = {};
     // Check if item is using new plex movie/tv agent
-    if (plexitem.guid.match(plexRegex)) {
+    if (plexitem.guid.match(plexRegex) || plexitem.guid.match(plexCustomProviderRegex)) {
       const guidCache = cacheManager.getCache('plexguid');
 
       const cachedGuids = guidCache.data.get<MediaIds>(plexitem.ratingKey);

--- a/server/lib/scanners/plex/index.ts
+++ b/server/lib/scanners/plex/index.ts
@@ -383,7 +383,10 @@ class PlexScanner
   private async getMediaIds(plexitem: PlexLibraryItem): Promise<MediaIds> {
     let mediaIds: Partial<MediaIds> = {};
     // Check if item is using new plex movie/tv agent
-    if (plexitem.guid.match(plexRegex) || plexitem.guid.match(plexCustomProviderRegex)) {
+    if (
+      plexitem.guid.match(plexRegex) ||
+      plexitem.guid.match(plexCustomProviderRegex)
+    ) {
       const guidCache = cacheManager.getCache('plexguid');
 
       const cachedGuids = guidCache.data.get<MediaIds>(plexitem.ratingKey);


### PR DESCRIPTION
## Description

Modern custom plex metadata providers are supposed to use a new "guid" scheme (i hate that they call it a guid when its not) that is different than what is reported by legacy plex metadata agents. The new guid scheme follows this format: `tv.plex.agents.custom.<provider-name>://`. This is specified in plex's developer documentation here: https://developer.plex.tv/pms/#section/API-Info/Metadata-Response (scroll down the the section titled "Guid construction" I've included a screenshot:
<img width="631" height="362" alt="image" src="https://github.com/user-attachments/assets/ce9b8bd8-488f-40f6-bf98-072204891d43" />

Currently seerr only accepts metadata agents with the legacy guid scheme that begins with `plex://`, which causes seerr to not detect metadata from certain modern plex metadata providers, such as [ShokoRelay](https://github.com/natyusha/ShokoRelay). Without this change, seerr is unable to detect TMDB links to any of the shows or movies in my plex libraries that use ShokoRelay as their metadata provider.

AI Disclosure: No AI was used in the creation of this code or pull request.

## How Has This Been Tested?

To test this, I copied the config from my seerr instance deployed in my homelab to my local seerr git repo and launched the docker container locally with docker compose. It was already connected to my local plex server, and running a manual library scan worked locally with this change. After that, I ran `pnpm build` and `pnpm test` which both passed with no errors.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex media recognition by supporting custom TV Plex agent GUIDs as Plex movie/TV agent identifiers.
  * Ensured GUID-to-ID extraction and lookup works for both standard and custom Plex GUID formats, improving media matching consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->