### PR TITLE
fix: keep library settings when renamed on media server

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -148,7 +148,7 @@ class PlexAPI extends ExternalAPI {
         .filter((library) => library.agent !== 'com.plexapp.agents.none')
         .map((library) => {
           const existing = settings.plex.libraries.find(
-            (l) => l.id === library.key && l.name === library.title
+            (l) => l.id === library.key
           );
 
           return {

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -420,7 +420,7 @@ settingsRoutes.post('/jellyfin/library/sync', async (_req, res, next) => {
 
   const newLibraries: Library[] = libraries.map((library) => {
     const existing = settings.jellyfin.libraries.find(
-      (l) => l.id === library.key && l.name === library.title
+      (l) => l.id === library.key
     );
 
     return {
@@ -428,6 +428,7 @@ settingsRoutes.post('/jellyfin/library/sync', async (_req, res, next) => {
       name: library.title,
       enabled: existing?.enabled ?? false,
       type: library.type,
+      lastScan: existing?.lastScan,
     };
   });
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Two ways library sync loses state.
 
`existing` was resolved with a compound match on id **and** name, so renaming a library on the media server made the lookup miss and `enabled: existing?.enabled ?? false` silently turned it off. Plex section keys and Jellyfin item GUIDs are stable across renames, so matching on id alone is enough.
 
The Jellyfin mapping also never carried `lastScan`, unlike `PlexAPI.syncLibraries()`. That one is inert today, `lastScan` is only read by the Plex scanner, for its recently-added scan window, but for symmetrical purposes and if the Jellyfin scanner ever grows an incremental path.

> [!note] 
> Found while reviewing #3321 and stacked on it because that PR moves the Jellyfin sync block into its new route.

## How Has This Been Tested?

{no need)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Library settings now remain associated with the correct Plex or Jellyfin library even after its name changes.
  * Enabled/disabled status is preserved during library synchronization.
  * Jellyfin libraries now retain their previous scan history when synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->