### PR TITLE
fix(sonarr): decouple anime root folder routing from seriesType

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -573,37 +573,37 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           throw new Error('TVDB ID not found');
         }
 
+        const isAnime = series.keywords.results.some(
+          (keyword) => keyword.id === ANIME_KEYWORD_ID
+        );
+
+        // seriesType only controls how Sonarr parses/numbers episodes
+        // it is sent in the addSeries payload and must not gate anime routing
         let seriesType: SonarrSeries['seriesType'] = 'standard';
 
-        // Change series type to anime if the anime keyword is present on tmdb
-        if (
-          series.keywords.results.some(
-            (keyword) => keyword.id === ANIME_KEYWORD_ID
-          )
-        ) {
+        if (isAnime) {
           seriesType = sonarrSettings.animeSeriesType ?? 'anime';
         }
 
         let rootFolder =
-          seriesType === 'anime' && sonarrSettings.activeAnimeDirectory
+          isAnime && sonarrSettings.activeAnimeDirectory
             ? sonarrSettings.activeAnimeDirectory
             : sonarrSettings.activeDirectory;
         let qualityProfile =
-          seriesType === 'anime' && sonarrSettings.activeAnimeProfileId
+          isAnime && sonarrSettings.activeAnimeProfileId
             ? sonarrSettings.activeAnimeProfileId
             : sonarrSettings.activeProfileId;
         let languageProfile =
-          seriesType === 'anime' && sonarrSettings.activeAnimeLanguageProfileId
+          isAnime && sonarrSettings.activeAnimeLanguageProfileId
             ? sonarrSettings.activeAnimeLanguageProfileId
             : sonarrSettings.activeLanguageProfileId;
-        let tags =
-          seriesType === 'anime'
-            ? sonarrSettings.animeTags
-              ? [...sonarrSettings.animeTags]
-              : []
-            : sonarrSettings.tags
-              ? [...sonarrSettings.tags]
-              : [];
+        let tags = isAnime
+          ? sonarrSettings.animeTags
+            ? [...sonarrSettings.animeTags]
+            : []
+          : sonarrSettings.tags
+            ? [...sonarrSettings.tags]
+            : [];
 
         if (
           entity.rootFolder &&

--- a/src/components/Settings/SonarrModal/index.tsx
+++ b/src/components/Settings/SonarrModal/index.tsx
@@ -248,7 +248,7 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
           activeLanguageProfileId: sonarr?.activeLanguageProfileId,
           rootFolder: sonarr?.activeDirectory,
           seriesType: sonarr?.seriesType,
-          animeSeriesType: sonarr?.animeSeriesType,
+          animeSeriesType: sonarr?.animeSeriesType ?? 'anime',
           activeAnimeProfileId: sonarr?.activeAnimeProfileId,
           activeAnimeLanguageProfileId: sonarr?.activeAnimeLanguageProfileId,
           activeAnimeRootFolder: sonarr?.activeAnimeDirectory,
@@ -791,8 +791,8 @@ const SonarrModal = ({ onClose, sonarr, onSave }: SonarrModalProps) => {
                         name="animeSeriesType"
                         disabled={!isValidated || isTesting}
                       >
-                        <option value="standard">Standard</option>
                         <option value="anime">Anime</option>
+                        <option value="standard">Standard</option>
                       </Field>
                     </div>
                   </div>


### PR DESCRIPTION
## Description
Auto-approved requests were landing in the series root folder instead of the anime one when Sonarr's Anime Series Type was set to Standard. rootFolder/qualityProfile/languageProfile/tags were gated on `seriesType`, which only exists to control episode numbering.

The frontend already resolves anime overrides from the TMDB keyword alone, so approving through the modal writes a correct override first and never hits this. Auto-approve skips the modal and falls through to the broken default.

This PR gates the anime-specific selections on an independentisAnime check instead. Also defaults new Sonarr services toAnime Series Type, since an unset value already behaved as anime via a fallback the form didn't reflect.

- Fixes #3244

## How Has This Been Tested?

- Manually tested with a user with auto approval perms

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sonarr anime request handling by applying anime-specific folders, quality profiles, language profiles, and tags based on the request’s anime classification.
  * Prevented the series type setting from incorrectly affecting anime routing.

* **Improvements**
  * Sonarr settings now default the anime series type to “Anime” when no value is configured.
  * Reordered series type options to show “Anime” first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->