### PR TITLE
fix(sonarr): apply configured series type to non-anime requests

### DIFF
--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -579,7 +579,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
 
         // seriesType only controls how Sonarr parses/numbers episodes
         // it is sent in the addSeries payload and must not gate anime routing
-        let seriesType: SonarrSeries['seriesType'] = 'standard';
+        let seriesType: SonarrSeries['seriesType'] =
+          sonarrSettings.seriesType ?? 'standard';
 
         if (isAnime) {
           seriesType = sonarrSettings.animeSeriesType ?? 'anime';


### PR DESCRIPTION
## Description

The **Series Type** selector in the Sonarr settings modal has never done anything. `sonarrSettings.seriesType` is written by the UI and stored, but is read nowhere on the server and `seriesType` in `sendToSonarr` was hardcoded to
`'standard'`. A server configured as `Daily` therefore sent every non-anime request as `standard`, changing Sonarr's episode numbering and search behavior.

This dates to https://github.com/sct/overseerr/pull/3628, which added the Standard/Daily selector bound to the now-repurposed `seriesType` field without adding a read for it.

`seriesType` is now initialized from the configured value and overridden only for anime.

## How Has This Been Tested?

(no need)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)