### PR TITLE
fix(request): render anime notice alert in a div instead of a p

### DIFF
--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -486,12 +486,12 @@ const TvRequestModal = ({
         ) &&
         getAllRequestedSeasons().length < getAllSeasons().length &&
         !editRequest && (
-          <p className="mt-6">
+          <div className="mt-6">
             <Alert
               title={intl.formatMessage(messages.requestadmin)}
               type="info"
             />
-          </p>
+          </div>
         )}
       {(quota?.tv.limit ?? 0) > 0 && (
         <QuotaDisplay


### PR DESCRIPTION
## Description

The anime-request notice in `TvRequestModal` wrapped `Alert` in a `<p>`, but Alert's root element is a `div`, and a `div` isn't valid content for a `p` tag. This caused "In HTML, `<div>` cannot be a descendant of `<p>`" hydration errors whenever the notice rendered.

`MovieRequestModal` has the identical `Aler`t in the identical spot, already wrapped in a `div` and this brings `TvRequestModal` in line with that.

## How Has This Been Tested?

(no)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the structure of the admin approval notice while preserving its existing styling and alert content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->