### PR TITLE
feat(notifications): add embed poster option for Gotify

### DIFF
--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -104,7 +104,7 @@ class GotifyAgent
     }
 
     if (embedPoster && payload.image) {
-      message += `\n\n![${payload.subject}](${payload.image})  `;
+      message += `\n\n![](${payload.image})  `;
     }
 
     if (applicationUrl && payload.media) {
@@ -119,6 +119,13 @@ class GotifyAgent
         'client::display': {
           contentType: 'text/markdown',
         },
+        ...(embedPoster && payload.image
+          ? {
+              'client::notification': {
+                bigImageUrl: payload.image,
+              },
+            }
+          : {}),
       },
       title,
       message,

--- a/server/lib/notifications/agents/gotify.ts
+++ b/server/lib/notifications/agents/gotify.ts
@@ -52,6 +52,7 @@ class GotifyAgent
     const settings = this.getSettings();
     const intl = getIntl(settings.options.locale);
     const { applicationUrl, applicationTitle } = getSettings().main;
+    const embedPoster = settings.embedPoster;
     const priority = settings.options.priority ?? 1;
 
     const title = payload.event
@@ -100,6 +101,10 @@ class GotifyAgent
 
     for (const extra of payload.extra ?? []) {
       message += `\n\n**${extra.name}**\n${extra.value}  `;
+    }
+
+    if (embedPoster && payload.image) {
+      message += `\n\n![${payload.subject}](${payload.image})  `;
     }
 
     if (applicationUrl && payload.media) {

--- a/src/components/Settings/Notifications/NotificationsGotify/index.tsx
+++ b/src/components/Settings/Notifications/NotificationsGotify/index.tsx
@@ -18,6 +18,7 @@ const messages = defineMessages(
   'components.Settings.Notifications.NotificationsGotify',
   {
     agentenabled: 'Enable Agent',
+    embedPoster: 'Embed Poster',
     url: 'Server URL',
     token: 'Application Token',
     priority: 'Priority',
@@ -92,6 +93,7 @@ const NotificationsGotify = () => {
     <Formik
       initialValues={{
         enabled: data?.enabled,
+        embedPoster: data?.embedPoster,
         types: data?.types,
         url: data?.options.url,
         token: data?.options.token,
@@ -103,6 +105,7 @@ const NotificationsGotify = () => {
         try {
           await axios.post('/api/v1/settings/notifications/gotify', {
             enabled: values.enabled,
+            embedPoster: values.embedPoster,
             types: values.types,
             options: {
               url: values.url,
@@ -188,6 +191,14 @@ const NotificationsGotify = () => {
               </label>
               <div className="form-input-area">
                 <Field type="checkbox" id="enabled" name="enabled" />
+              </div>
+            </div>
+            <div className="form-row">
+              <label htmlFor="embedPoster" className="checkbox-label">
+                {intl.formatMessage(messages.embedPoster)}
+              </label>
+              <div className="form-input-area">
+                <Field type="checkbox" id="embedPoster" name="embedPoster" />
               </div>
             </div>
             <div className="form-row">

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -641,6 +641,7 @@
   "components.Selector.showmore": "Show More",
   "components.Selector.starttyping": "Starting typing to search.",
   "components.Settings.Notifications.NotificationsGotify.agentenabled": "Enable Agent",
+  "components.Settings.Notifications.NotificationsGotify.embedPoster": "Embed Poster",
   "components.Settings.Notifications.NotificationsGotify.gotifysettingsfailed": "Gotify notification settings failed to save.",
   "components.Settings.Notifications.NotificationsGotify.gotifysettingssaved": "Gotify notification settings saved successfully!",
   "components.Settings.Notifications.NotificationsGotify.priority": "Priority",


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

* Adds the option to embed poster in Gotify notifications
* Improves parity with ntfy
* Fixes #3215 

## How Has This Been Tested?

* Ran a local instance of Gotify (v3.0.0) on Windows 11 amd64
* Configured seerr to send notifications to Gotify and tested sending and receiving them in Gotify
* Tested for different notification types
* Ran all existing automated tests

## Screenshots / Logs (if applicable)
<img width="711" height="688" alt="image" src="https://github.com/user-attachments/assets/685c9cfe-cbb2-4d73-8db0-42f9d408018a" />
<img width="426" height="752" alt="image" src="https://github.com/user-attachments/assets/2a75cb69-34f2-4e96-8da7-68d9bc07aa8e" />


## AI Use
Used AI to locate the notification agent files, however all code written by me.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Embed Poster” option to Gotify notification settings.
  * When enabled, notifications include the request’s image as a Markdown poster and notification image when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->