### PR TITLE
fix(tv): prevent phantom specials from blocking season request

### DIFF
--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -306,7 +306,14 @@ class BaseScanner<T> {
         ) ?? []
       ).length;
 
-      for (const season of seasons) {
+      for (const rawSeason of seasons) {
+        // Files can't promote a season the provider reports as empty.
+        // Zeroing the counts leaves any existing status for availabilitySync to judge.
+        const season =
+          rawSeason.totalEpisodes > 0
+            ? rawSeason
+            : { ...rawSeason, episodes: 0, episodes4k: 0 };
+
         const existingSeason = media?.seasons.find(
           (es) => es.seasonNumber === season.seasonNumber
         );

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -418,7 +418,7 @@ const TvRequestModal = ({
             : hasPermission(Permission.MANAGE_REQUESTS)
               ? intl.formatMessage(messages.approve)
               : intl.formatMessage(messages.edit)
-          : getAllRequestedSeasons().length >= getAllSeasons().length
+          : unrequestedSeasons.length === 0
             ? intl.formatMessage(messages.alreadyrequested)
             : !settings.currentSettings.partialRequestsEnabled
               ? intl.formatMessage(
@@ -441,7 +441,7 @@ const TvRequestModal = ({
               unrequestedSeasons.length > quota.tv.limit &&
               !requestOverrides?.ignoreQuota
             ? true
-            : getAllRequestedSeasons().length >= getAllSeasons().length ||
+            : unrequestedSeasons.length === 0 ||
               (settings.currentSettings.partialRequestsEnabled &&
                 selectedSeasons.length === 0)
       }

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -309,19 +309,26 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     return [...requestedSeasons, ...availableSeasons];
   };
 
-  const showHasSpecials = data.seasons.some(
-    (season) =>
-      season.seasonNumber === 0 &&
-      settings.currentSettings.enableSpecialEpisodes
-  );
+  // Mirrors the season list the request modal offers, so the two agree.
+  const requestableSeasons = data.seasons
+    .filter(
+      (season) =>
+        season.episodeCount !== 0 &&
+        (settings.currentSettings.enableSpecialEpisodes ||
+          season.seasonNumber !== 0)
+    )
+    .map((season) => season.seasonNumber);
 
-  const isComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(false).length;
+  const isSeasonSetComplete = (is4k: boolean) => {
+    const requested = getAllRequestedSeasons(is4k);
+    return requestableSeasons.every((seasonNumber) =>
+      requested.includes(seasonNumber)
+    );
+  };
 
-  const is4kComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(true).length;
+  const isComplete = isSeasonSetComplete(false);
+
+  const is4kComplete = isSeasonSetComplete(true);
 
   const streamingRegion = user?.settings?.streamingRegion
     ? user.settings.streamingRegion


### PR DESCRIPTION
## Description

Adding a Specials folder in Plex for a show whose TMDB specials entry has no episodes made the rest of the series unrequestable. The scanner sees one file against zero expected episodes and writes a season 0 row as PARTIALLY_AVAILABLE, which flips the whole series to Partially Available because the PARTIALLY_AVAILABLE branch of the rollup does not exclude specials the way the AVAILABLE branch does.

`TvRequestModal` decided whether a show was fully requested by comparing how many seasons are requested or available against how many seasons it offers. That season 0 counts toward the first number but is dropped from the second by the `episodeCount !== 0` filter, so a show with one real season looked fully requested: the button read "Already Requested" and was disabled while the season row still said "Not Requested" and its toggle still worked. `TvDetails` counted seasons too but added one for specials, so it still rendered "Request More" and users could open a modal whose button was already dead. Shows whose specials entry has at least one episode were never affected.

Both now check whether any offered season is still unrequested instead of comparing counts, and `TvDetails` reads the same filtered season list the modal renders. On the server, `processShow` zeroes the episode counts for a season the provider reports as empty so files can no longer promote it. **This PR does not deliberately add downgrading an existing status to `processShow`**: one scanner only sees one source, and demoting there would reintroduce the race the AVAILABLE stickiness already guards against. **Existing records keep their season 0 row and can be fixed with Clear Data followed by a rescan.**


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- ~~Did not test myself, waiting to be~~ Tested by original reporter on discord and confirmed to be working (`preview-phantom-specials` for testing).

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Empty seasons are no longer incorrectly treated as available when they report no episodes.
  - TV request buttons now accurately reflect whether any seasons remain requestable.
  - Season completion status now excludes empty seasons and handles specials correctly for standard and 4K requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->