### PR TITLE
feat(RequestList): add user filter to the requests page

### DIFF
--- a/src/components/RequestList/index.tsx
+++ b/src/components/RequestList/index.tsx
@@ -17,8 +17,10 @@ import {
   ChevronRightIcon,
   CircleStackIcon,
   FunnelIcon,
+  UsersIcon,
 } from '@heroicons/react/24/solid';
 import type { RequestResultsResponse } from '@server/interfaces/api/requestInterfaces';
+import type { UserResultsResponse } from '@server/interfaces/api/userInterfaces';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -28,6 +30,7 @@ import useSWR from 'swr';
 const messages = defineMessages('components.RequestList', {
   requests: 'Requests',
   showallrequests: 'Show All Requests',
+  allusers: 'All Users',
   sortAdded: 'Most Recent',
   sortModified: 'Last Modified',
   sortDirection: 'Toggle Sort Direction',
@@ -66,10 +69,29 @@ const RequestList = () => {
   const [currentSortDirection, setCurrentSortDirection] =
     useState<SortDirection>('desc');
   const [currentPageSize, setCurrentPageSize] = useState<number>(10);
+  const [currentRequestedBy, setCurrentRequestedBy] = useState<number | 'all'>(
+    'all'
+  );
 
   const page = router.query.page ? Number(router.query.page) : 1;
   const pageIndex = page - 1;
   const updateQueryParams = useUpdateQueryParams({ page: page.toString() });
+
+  // The profile and per-user pages are already scoped to a single user, so the
+  // user filter only applies on the main /requests page.
+  const canFilterByUser =
+    !router.pathname.startsWith('/profile') &&
+    !router.query.userId &&
+    hasPermission([Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW], {
+      type: 'or',
+    });
+
+  const { data: userData } = useSWR<UserResultsResponse>(
+    canFilterByUser ? '/api/v1/user?take=1000&sort=displayname' : null
+  );
+
+  // Hide the filter when there is only a single user to choose from
+  const showUserFilter = canFilterByUser && (userData?.results.length ?? 0) > 1;
 
   const {
     data,
@@ -83,7 +105,9 @@ const RequestList = () => {
         ? `&requestedBy=${currentUser?.id}`
         : router.query.userId
           ? `&requestedBy=${router.query.userId}`
-          : ''
+          : currentRequestedBy !== 'all'
+            ? `&requestedBy=${currentRequestedBy}`
+            : ''
     }`
   );
 
@@ -166,6 +190,40 @@ const RequestList = () => {
           {intl.formatMessage(messages.requests)}
         </Header>
         <div className="mt-2 flex flex-grow flex-col sm:flex-row lg:flex-grow-0">
+          {showUserFilter && (
+            <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
+              <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
+                <UsersIcon className="h-6 w-6" />
+              </span>
+              <select
+                id="requestedBy"
+                name="requestedBy"
+                onChange={(e) => {
+                  setCurrentRequestedBy(
+                    e.target.value === 'all' ? 'all' : Number(e.target.value)
+                  );
+                  router.push({
+                    pathname: router.pathname,
+                    query: {},
+                  });
+                }}
+                value={currentRequestedBy}
+                className="rounded-r-only"
+              >
+                <option value="all">
+                  {intl.formatMessage(messages.allusers)}
+                </option>
+                {userData?.results.map((filterUser) => (
+                  <option
+                    value={filterUser.id}
+                    key={`request-user-filter-${filterUser.id}`}
+                  >
+                    {filterUser.displayName}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="mb-2 flex flex-grow sm:mb-0 sm:mr-2 lg:flex-grow-0">
             <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-gray-800 px-3 text-sm text-gray-100">
               <CircleStackIcon className="h-6 w-6" />
@@ -327,13 +385,15 @@ const RequestList = () => {
             {intl.formatMessage(globalMessages.noresults)}
           </span>
           {(currentFilter !== Filter.ALL ||
-            currentMediaType !== Filter.ALL) && (
+            currentMediaType !== Filter.ALL ||
+            currentRequestedBy !== 'all') && (
             <div className="mt-4">
               <Button
                 buttonType="primary"
                 onClick={() => {
                   setCurrentFilter(Filter.ALL);
                   setCurrentMediaType(Filter.ALL);
+                  setCurrentRequestedBy('all');
                 }}
               >
                 {intl.formatMessage(messages.showallrequests)}

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -537,6 +537,7 @@
   "components.RequestList.RequestItem.tmdbid": "TMDB ID",
   "components.RequestList.RequestItem.tvdbid": "TheTVDB ID",
   "components.RequestList.RequestItem.unknowntitle": "Unknown Title",
+  "components.RequestList.allusers": "All Users",
   "components.RequestList.requests": "Requests",
   "components.RequestList.showallrequests": "Show All Requests",
   "components.RequestList.sortAdded": "Most Recent",


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

Adds a user filter to the global requests page (`/requests`). You could already filter by a given user if you navigated directly to their individual page (`/users/3/requests?filter=all`), but thats annoying.

Note this only shows on the global page, and only if theres more than one user.. and only if you have relevant permissions to view others requests.

I tried to find an existing issue but couldnt. Its possible I missed one, I was a bit surprised no one had previously mentioned it?

## How Has This Been Tested?

Deployed in my homelab and verified. Ran CI scripts (`pnpm format:check && pnpm test && pnpm build`)

## Screenshots / Logs (if applicable)

Desktop layout
<img width="1043" height="88" alt="Screenshot 2026-08-08 at 5 49 35 PM" src="https://github.com/user-attachments/assets/4e467f33-b382-49df-a8cd-c65383e16cb8" />

Desktop expanded
<img width="1026" height="117" alt="Screenshot 2026-08-08 at 5 50 17 PM" src="https://github.com/user-attachments/assets/cc878d6d-f17f-4e13-aaeb-9ea1622d44df" />

Mobile layout
<img width="415" height="286" alt="Screenshot 2026-08-08 at 5 49 45 PM" src="https://github.com/user-attachments/assets/fe0a50d2-b934-49bd-8bc5-3d91801563c7" />

Mobile expanded
<img width="410" height="265" alt="Screenshot 2026-08-08 at 5 50 25 PM" src="https://github.com/user-attachments/assets/64145f0b-369c-4fa2-a36a-96ab503b4d11" />

## AI Disclosure

I basically just one-shot it with Claude, and tweaked to add the 'single user' edge case.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [X] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] (N/A) I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] (N/A) Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a user filter to the request list for authorized users.
  - Users can filter requests by requester or select “All Users.”
  - The filter is hidden when unavailable or not applicable, such as on individual profile pages.
  - Selecting “Show all requests” clears the active user filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->