### PR TITLE
fix(subscriber): keep request status updates on the owning save's connection

### DIFF
--- a/docs/extending-seerr/database-config.mdx
+++ b/docs/extending-seerr/database-config.mdx
@@ -36,6 +36,7 @@ DB_USER= # (required) Username used to connect to the database.
 DB_PASS= # (required) Password of the user used to connect to the database.
 DB_NAME="seerr" # (optional) The name of the database to connect to. The default is "seerr".
 DB_POOL_SIZE="10" # (optional) The number of connections to maintain in the connection pool. The default is "10".
+DB_CONNECT_TIMEOUT_MS="30000" # (optional) How long to wait for a free connection from the pool before erroring, in milliseconds. The default is "30000". Set to "0" to wait indefinitely.
 DB_LOG_QUERIES="false" # (optional) Whether to log the DB queries for debugging. The default is "false".
 ```
 
@@ -50,6 +51,7 @@ DB_USER= # (required) Username used to connect to the database.
 DB_PASS= # (optional) Password of the user used to connect to the database, depending on the server's authentication configuration.
 DB_NAME="seerr" # (optional) The name of the database to connect to. The default is "seerr".
 DB_POOL_SIZE="10" # (optional) The number of connections to maintain in the connection pool. The default is "10".
+DB_CONNECT_TIMEOUT_MS="30000" # (optional) How long to wait for a free connection from the pool before erroring, in milliseconds. The default is "30000". Set to "0" to wait indefinitely.
 DB_LOG_QUERIES="false" # (optional) Whether to log the DB queries for debugging. The default is "false".
 ```
 

--- a/server/datasource.ts
+++ b/server/datasource.ts
@@ -97,6 +97,8 @@ const postgresDevConfig: DataSourceOptions = {
   database: process.env.DB_NAME ?? 'seerr',
   ssl: buildSslConfig(),
   poolSize: intFromEnv('DB_POOL_SIZE'),
+  // Bounds pool acquisition waits so exhaustion surfaces as errors instead of a silent hang
+  connectTimeoutMS: intFromEnv('DB_CONNECT_TIMEOUT_MS', 30000),
   synchronize: false,
   migrationsRun: true,
   logging: boolFromEnv('DB_LOG_QUERIES'),
@@ -116,6 +118,8 @@ const postgresProdConfig: DataSourceOptions = {
   database: process.env.DB_NAME ?? 'seerr',
   ssl: buildSslConfig(),
   poolSize: intFromEnv('DB_POOL_SIZE'),
+  // Bounds pool acquisition waits so exhaustion surfaces as errors instead of a silent hang
+  connectTimeoutMS: intFromEnv('DB_CONNECT_TIMEOUT_MS', 30000),
   synchronize: false,
   migrationsRun: false,
   logging: boolFromEnv('DB_LOG_QUERIES'),

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -283,13 +283,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           });
         }
 
-        const tmdb = new TheMovieDb();
-        const radarr = new RadarrAPI({
-          apiKey: radarrSettings.apiKey,
-          url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
-        });
-        const movie = await tmdb.getMovie({ movieId: entity.media.tmdbId });
-
         const media = await mediaRepository.findOne({
           where: { id: entity.media.id },
         });
@@ -302,6 +295,28 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           });
           return;
         }
+
+        if (
+          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        ) {
+          logger.warn('Media already exists, marking request as COMPLETED', {
+            label: 'Media Request',
+            requestId: entity.id,
+            mediaId: entity.media.id,
+          });
+
+          const requestRepository = manager.getRepository(MediaRequest);
+          entity.status = MediaRequestStatus.COMPLETED;
+          await requestRepository.save(entity);
+          return;
+        }
+
+        const tmdb = new TheMovieDb();
+        const radarr = new RadarrAPI({
+          apiKey: radarrSettings.apiKey,
+          url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+        });
+        const movie = await tmdb.getMovie({ movieId: entity.media.tmdbId });
 
         if (radarrSettings.tagRequests) {
           const radarrTags = await radarr.getTags();
@@ -346,21 +361,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
               radarrServer: radarrSettings.hostname + ':' + radarrSettings.port,
             });
           }
-        }
-
-        if (
-          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        ) {
-          logger.warn('Media already exists, marking request as COMPLETED', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-
-          const requestRepository = manager.getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.COMPLETED;
-          await requestRepository.save(entity);
-          return;
         }
 
         const radarrMovieOptions: RadarrMovieOptions = {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -180,13 +180,16 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
   }
 
-  public async sendToRadarr(entity: MediaRequest): Promise<void> {
+  public async sendToRadarr(
+    entity: MediaRequest,
+    manager: EntityManager
+  ): Promise<void> {
     if (
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.MOVIE
     ) {
       try {
-        const mediaRepository = getRepository(Media);
+        const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
         if (settings.radarr.length === 0 && !settings.radarr[0]) {
           logger.info(
@@ -354,7 +357,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             mediaId: entity.media.id,
           });
 
-          const requestRepository = getRepository(MediaRequest);
+          const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;
           await requestRepository.save(entity);
           return;
@@ -377,6 +380,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         radarr
           .addMovie(radarrMovieOptions)
           .then(async (radarrMovie) => {
+            // Needs its own repository as this runs detached from the request transaction
+            const mediaRepository = getRepository(Media);
             // We grab media again here to make sure we have the latest version of it
             const media = await mediaRepository.findOne({
               where: { id: entity.media.id },
@@ -444,8 +449,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           mediaId: entity.media.id,
         });
       } catch (e) {
-        const requestRepository = getRepository(MediaRequest);
-        const mediaRepository = getRepository(Media);
+        const requestRepository = manager.getRepository(MediaRequest);
+        const mediaRepository = manager.getRepository(Media);
         const media = await mediaRepository.findOne({
           where: { id: entity.media.id },
         });
@@ -474,13 +479,16 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
   }
 
-  public async sendToSonarr(entity: MediaRequest): Promise<void> {
+  public async sendToSonarr(
+    entity: MediaRequest,
+    manager: EntityManager
+  ): Promise<void> {
     if (
       entity.status === MediaRequestStatus.APPROVED &&
       entity.type === MediaType.TV
     ) {
       try {
-        const mediaRepository = getRepository(Media);
+        const mediaRepository = manager.getRepository(Media);
         const settings = getSettings();
         if (settings.sonarr.length === 0 && !settings.sonarr[0]) {
           logger.warn(
@@ -549,7 +557,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             mediaId: entity.media.id,
           });
 
-          const requestRepository = getRepository(MediaRequest);
+          const requestRepository = manager.getRepository(MediaRequest);
           entity.status = MediaRequestStatus.COMPLETED;
           entity.seasons.forEach((season) => {
             season.status = MediaRequestStatus.COMPLETED;
@@ -567,7 +575,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         const tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
 
         if (!tvdbId) {
-          const requestRepository = getRepository(MediaRequest);
+          const requestRepository = manager.getRepository(MediaRequest);
           await mediaRepository.remove(media);
           await requestRepository.remove(entity);
           throw new Error('TVDB ID not found');
@@ -720,6 +728,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         sonarr
           .addSeries(sonarrSeriesOptions)
           .then(async (sonarrSeries) => {
+            // Needs its own repository as this runs detached from the request transaction
+            const mediaRepository = getRepository(Media);
             // We grab media again here to make sure we have the latest version of it
             const media = await mediaRepository.findOne({
               where: { id: entity.media.id },
@@ -788,8 +798,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           mediaId: entity.media.id,
         });
       } catch (e) {
-        const requestRepository = getRepository(MediaRequest);
-        const mediaRepository = getRepository(Media);
+        const requestRepository = manager.getRepository(MediaRequest);
+        const mediaRepository = manager.getRepository(Media);
         const media = await mediaRepository.findOne({
           where: { id: entity.media.id },
         });
@@ -818,8 +828,11 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
   }
 
-  public async updateParentStatus(entity: MediaRequest): Promise<void> {
-    const mediaRepository = getRepository(Media);
+  public async updateParentStatus(
+    manager: EntityManager,
+    entity: MediaRequest
+  ): Promise<void> {
+    const mediaRepository = manager.getRepository(Media);
     const media = await mediaRepository.findOne({
       where: { id: entity.media.id },
     });
@@ -833,8 +846,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     const statusKey = entity.is4k ? 'status4k' : 'status';
-    const seasonRequestRepository = getRepository(SeasonRequest);
-    const requestRepository = getRepository(MediaRequest);
+    const seasonRequestRepository = manager.getRepository(SeasonRequest);
+    const requestRepository = manager.getRepository(MediaRequest);
 
     if (
       entity.status === MediaRequestStatus.APPROVED &&
@@ -893,7 +906,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       media.mediaType === MediaType.TV &&
       entity.status === MediaRequestStatus.DECLINED
     ) {
-      const seasonRepository = getRepository(Season);
+      const seasonRepository = manager.getRepository(Season);
       const actualSeasons = await seasonRepository.find({
         where: { media: { id: media.id } },
       });
@@ -1010,8 +1023,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      await this.sendToRadarr(event.entity as MediaRequest);
-      await this.sendToSonarr(event.entity as MediaRequest);
+      await this.sendToRadarr(event.entity as MediaRequest, event.manager);
+      await this.sendToSonarr(event.entity as MediaRequest, event.manager);
     } catch (e) {
       logger.error('Error while sending to *arr in afterUpdate subscriber', {
         label: 'Media Request',
@@ -1021,7 +1034,10 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      await this.updateParentStatus(event.entity as MediaRequest);
+      // Savepoint on the save's own connection so failures don't abort the request save
+      await event.manager.transaction(async (manager) => {
+        await this.updateParentStatus(manager, event.entity as MediaRequest);
+      });
 
       if (event.entity.status === MediaRequestStatus.COMPLETED) {
         if (event.entity.media.mediaType === MediaType.MOVIE) {
@@ -1049,8 +1065,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      await this.sendToRadarr(event.entity as MediaRequest);
-      await this.sendToSonarr(event.entity as MediaRequest);
+      await this.sendToRadarr(event.entity as MediaRequest, event.manager);
+      await this.sendToSonarr(event.entity as MediaRequest, event.manager);
     } catch (e) {
       logger.error('Error while sending to *arr in afterInsert subscriber', {
         label: 'Media Request',
@@ -1060,7 +1076,9 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      await this.updateParentStatus(event.entity as MediaRequest);
+      await event.manager.transaction(async (manager) => {
+        await this.updateParentStatus(manager, event.entity as MediaRequest);
+      });
     } catch (e) {
       logger.error(
         'Error while updating parent status in afterInsert subscriber',

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -20,6 +20,7 @@ import SeasonRequest from '@server/entity/SeasonRequest';
 import notificationManager, { Notification } from '@server/lib/notifications';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import { withNestedTransaction } from '@server/utils/nestedTransaction';
 import { isEqual, truncate } from 'lodash';
 import type {
   EntityManager,
@@ -1034,8 +1035,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      // Savepoint on the save's own connection so failures don't abort the request save
-      await event.manager.transaction(async (manager) => {
+      await withNestedTransaction(event.manager, async (manager) => {
         await this.updateParentStatus(manager, event.entity as MediaRequest);
       });
 
@@ -1076,7 +1076,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
     }
 
     try {
-      await event.manager.transaction(async (manager) => {
+      await withNestedTransaction(event.manager, async (manager) => {
         await this.updateParentStatus(manager, event.entity as MediaRequest);
       });
     } catch (e) {

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -3,19 +3,26 @@ import {
   MediaStatus,
   MediaType,
 } from '@server/constants/media';
-import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import logger from '@server/logger';
-import type { EntitySubscriberInterface, UpdateEvent } from 'typeorm';
+import type {
+  EntityManager,
+  EntitySubscriberInterface,
+  UpdateEvent,
+} from 'typeorm';
 import { EventSubscriber, In } from 'typeorm';
 
 @EventSubscriber()
 export class MediaSubscriber implements EntitySubscriberInterface<Media> {
-  private async updateChildRequestStatus(event: Media, is4k: boolean) {
-    const requestRepository = getRepository(MediaRequest);
+  private async updateChildRequestStatus(
+    manager: EntityManager,
+    event: Media,
+    is4k: boolean
+  ) {
+    const requestRepository = manager.getRepository(MediaRequest);
 
     const requests = await requestRepository.find({
       where: { media: { id: event.id } },
@@ -33,12 +40,13 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
   }
 
   private async updateRelatedMediaRequest(
+    manager: EntityManager,
     event: Media,
     databaseEvent: Media,
     is4k: boolean
   ) {
-    const requestRepository = getRepository(MediaRequest);
-    const seasonRequestRepository = getRepository(SeasonRequest);
+    const requestRepository = manager.getRepository(MediaRequest);
+    const seasonRequestRepository = manager.getRepository(SeasonRequest);
 
     const relatedRequests = await requestRepository.find({
       relations: {
@@ -68,45 +76,48 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         ) {
           shouldComplete = true;
         } else if (event.mediaType === 'tv') {
-          const allSeasonResults = await Promise.all(
-            request.seasons.map(async (requestSeason) => {
-              const matchingSeason = event.seasons.find(
-                (mediaSeason) =>
-                  mediaSeason.seasonNumber === requestSeason.seasonNumber
-              );
-              const matchingOldSeason = databaseEvent.seasons.find(
-                (oldSeason) =>
-                  oldSeason.seasonNumber === requestSeason.seasonNumber
-              );
+          const allSeasonResults: boolean[] = [];
 
-              if (!matchingSeason) {
-                return false;
-              }
+          // Sequential on purpose as these saves share the transaction's connection
+          for (const requestSeason of request.seasons) {
+            const matchingSeason = event.seasons.find(
+              (mediaSeason) =>
+                mediaSeason.seasonNumber === requestSeason.seasonNumber
+            );
+            const matchingOldSeason = databaseEvent.seasons.find(
+              (oldSeason) =>
+                oldSeason.seasonNumber === requestSeason.seasonNumber
+            );
 
-              const currentSeasonStatus =
-                matchingSeason[request.is4k ? 'status4k' : 'status'];
-              const previousSeasonStatus =
-                matchingOldSeason?.[request.is4k ? 'status4k' : 'status'];
+            if (!matchingSeason) {
+              allSeasonResults.push(false);
+              continue;
+            }
 
-              const hasStatusChanged =
-                currentSeasonStatus !== previousSeasonStatus;
+            const currentSeasonStatus =
+              matchingSeason[request.is4k ? 'status4k' : 'status'];
+            const previousSeasonStatus =
+              matchingOldSeason?.[request.is4k ? 'status4k' : 'status'];
 
-              const shouldUpdate =
-                (hasStatusChanged ||
-                  requestSeason.status === MediaRequestStatus.COMPLETED) &&
-                (currentSeasonStatus === MediaStatus.AVAILABLE ||
-                  currentSeasonStatus === MediaStatus.DELETED);
+            const hasStatusChanged =
+              currentSeasonStatus !== previousSeasonStatus;
 
-              if (shouldUpdate) {
-                requestSeason.status = MediaRequestStatus.COMPLETED;
-                await seasonRequestRepository.save(requestSeason);
+            const shouldUpdate =
+              (hasStatusChanged ||
+                requestSeason.status === MediaRequestStatus.COMPLETED) &&
+              (currentSeasonStatus === MediaStatus.AVAILABLE ||
+                currentSeasonStatus === MediaStatus.DELETED);
 
-                return true;
-              }
+            if (shouldUpdate) {
+              requestSeason.status = MediaRequestStatus.COMPLETED;
+              await seasonRequestRepository.save(requestSeason);
 
-              return false;
-            })
-          );
+              allSeasonResults.push(true);
+              continue;
+            }
+
+            allSeasonResults.push(false);
+          }
 
           const allSeasonsReady = allSeasonResults.every((result) => result);
           shouldComplete = allSeasonsReady;
@@ -132,7 +143,14 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.entity.status === MediaStatus.AVAILABLE &&
         event.databaseEntity?.status === MediaStatus.PENDING
       ) {
-        await this.updateChildRequestStatus(event.entity as Media, false);
+        // Savepoint on the save's own connection so failures don't abort the media save
+        await event.manager.transaction(async (manager) => {
+          await this.updateChildRequestStatus(
+            manager,
+            event.entity as Media,
+            false
+          );
+        });
       }
     } catch (e) {
       logger.error(
@@ -151,7 +169,13 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.entity.status4k === MediaStatus.AVAILABLE &&
         event.databaseEntity?.status4k === MediaStatus.PENDING
       ) {
-        await this.updateChildRequestStatus(event.entity as Media, true);
+        await event.manager.transaction(async (manager) => {
+          await this.updateChildRequestStatus(
+            manager,
+            event.entity as Media,
+            true
+          );
+        });
       }
     } catch (e) {
       logger.error(
@@ -206,11 +230,14 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(false))) &&
         validStatuses.includes(event.entity.status)
       ) {
-        await this.updateRelatedMediaRequest(
-          event.entity as Media,
-          event.databaseEntity as Media,
-          false
-        );
+        await event.manager.transaction(async (manager) => {
+          await this.updateRelatedMediaRequest(
+            manager,
+            event.entity as Media,
+            event.databaseEntity as Media,
+            false
+          );
+        });
       }
     } catch (e) {
       logger.error(
@@ -231,11 +258,14 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(true))) &&
         validStatuses.includes(event.entity.status4k)
       ) {
-        await this.updateRelatedMediaRequest(
-          event.entity as Media,
-          event.databaseEntity as Media,
-          true
-        );
+        await event.manager.transaction(async (manager) => {
+          await this.updateRelatedMediaRequest(
+            manager,
+            event.entity as Media,
+            event.databaseEntity as Media,
+            true
+          );
+        });
       }
     } catch (e) {
       logger.error(

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -8,6 +8,7 @@ import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import logger from '@server/logger';
+import { withNestedTransaction } from '@server/utils/nestedTransaction';
 import type {
   EntityManager,
   EntitySubscriberInterface,
@@ -143,8 +144,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.entity.status === MediaStatus.AVAILABLE &&
         event.databaseEntity?.status === MediaStatus.PENDING
       ) {
-        // Savepoint on the save's own connection so failures don't abort the media save
-        await event.manager.transaction(async (manager) => {
+        await withNestedTransaction(event.manager, async (manager) => {
           await this.updateChildRequestStatus(
             manager,
             event.entity as Media,
@@ -169,7 +169,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
         event.entity.status4k === MediaStatus.AVAILABLE &&
         event.databaseEntity?.status4k === MediaStatus.PENDING
       ) {
-        await event.manager.transaction(async (manager) => {
+        await withNestedTransaction(event.manager, async (manager) => {
           await this.updateChildRequestStatus(
             manager,
             event.entity as Media,
@@ -230,7 +230,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(false))) &&
         validStatuses.includes(event.entity.status)
       ) {
-        await event.manager.transaction(async (manager) => {
+        await withNestedTransaction(event.manager, async (manager) => {
           await this.updateRelatedMediaRequest(
             manager,
             event.entity as Media,
@@ -258,7 +258,7 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
             seasonStatusCheck(true))) &&
         validStatuses.includes(event.entity.status4k)
       ) {
-        await event.manager.transaction(async (manager) => {
+        await withNestedTransaction(event.manager, async (manager) => {
           await this.updateRelatedMediaRequest(
             manager,
             event.entity as Media,

--- a/server/utils/nestedTransaction.ts
+++ b/server/utils/nestedTransaction.ts
@@ -1,0 +1,12 @@
+import type { EntityManager } from 'typeorm';
+
+// sqlite savepoints race on shared transactionDepth as it shares one query runner process-wide
+// so nesting collides on savepoint counter, see https://github.com/typeorm/typeorm/issues/10209
+// and later reverted by https://github.com/typeorm/typeorm/issues/11260
+export const withNestedTransaction = <T>(
+  manager: EntityManager,
+  run: (manager: EntityManager) => Promise<T>
+): Promise<T> =>
+  manager.connection.options.type === 'sqlite'
+    ? run(manager)
+    : manager.transaction(run);


### PR DESCRIPTION
## Description

The scanner loop could wedge the entire Postgres pool: every per-item Media save holds its connection inside an open transaction while the subscriber helpers awaited since #3223 acquire a second connection through the global `getRepository()`, so with bundles of 50 against the default pool of 10 and no acquisition timeout, every connection ends up held by a save waiting on a connection that can never be freed. This routes the subscriber DB work through event.manager so it rides the save's own connection, wrapped in `event.manager.transaction()` which nests as a savepoint on both the postgres and sqlite drivers, so a failure in related-request work rolls back to the savepoint and is logged as before instead of aborting the save. The detached `addMovie`/`addSeries` chains keep their own repositories since the transaction is gone by the time they run, and the per-season updates run sequentially because they now share one connection.

I also added a db timeout configuration which defaults to 30000ms when not set in env variables.

- Fixes #3365 

## How Has This Been Tested?

- I only tested unit tests but this can be tested using the preview tag (`preview-pgsql-starvation-fix`). ~~Awaiting testing by the reported users.~~
- Tested and confirmed working by the reported users.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of media request and status updates by keeping related database operations within the same transaction.
  * Preserved correct ordering when processing TV season request updates.
  * Prevented unnecessary external service checks when requested movies are already available.
  * Added a configurable database connection wait timeout, defaulting to 30 seconds.

* **Documentation**
  * Documented the new database connection timeout setting, including how to allow indefinite waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->