### PR TITLE
test(cypress): stop dirty restartRequired flag cascading across specs

### DIFF
--- a/cypress/e2e/settings/general-settings.cy.ts
+++ b/cypress/e2e/settings/general-settings.cy.ts
@@ -3,6 +3,11 @@ describe('General Settings', () => {
     cy.loginAsAdmin();
   });
 
+  // A mid-test failure skips the in-test revert, leaving the restart modal up for every later spec.
+  afterEach(() => {
+    cy.request('POST', '/api/v1/settings/network', { trustProxy: false });
+  });
+
   it('opens the settings page from the home page', () => {
     cy.visit('/');
 


### PR DESCRIPTION
## Description

`general-settings.cy.ts`'s "modifies setting that requires restart" test reverts `trustProxy` as its own last step. If any assertion earlier in the test times out, on any of its retry attempts, that revert never runs, and the server-side `restartRequired` flag stays set. The "Server Restart Required" modal it drives is global, shown on every page, and this suite runs one continuous server process across all spec files with no restart between them and so a flag left dirty by this one test blocks every later spec for the rest of the run. This is what was behind the unrelated cross-spec failures seen recently (general-settings, tv-details, auto-request-settings, profile, user-list all failing on the same covered-by-modal error).

Adds an `afterEach` that reverts `trustProxy` directly through the API, unconditionally. Cypress re-runs `afterEach` after every attempt, including failed ones, so this clears the flag between the test's own retries and guarantees it's clear before the next spec runs regardless of how this one goes.

## How Has This Been Tested?

(no need)

## Screenshots / Logs (if applicable)
<img width="1000" height="660" alt="image" src="https://github.com/user-attachments/assets/043bc4fe-e0bd-4a5a-9a51-5dffb322c240" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test cleanup to ensure network settings are reset after each test.
  * Increased test isolation and reliability for general settings coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->