### PR TITLE
fix(datasource): register entities and subscribers explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "preinstall": "npx only-allow pnpm",
     "postinstall": "next telemetry disable",
     "dev": "nodemon -e ts,json,yml --watch server --watch seerr-api.yml --exec 'ts-node -r tsconfig-paths/register --files --project server/tsconfig.json server/index.ts'",
-    "build:server": "tsc --project server/tsconfig.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && copyfiles -u 2 \"server/i18n/locale/*.json\" dist/i18n && tsc-alias -p server/tsconfig.json",
+    "build:server": "tsc --project server/tsconfig.build.json && copyfiles -u 2 server/templates/**/*.{html,pug} dist/templates && copyfiles -u 2 \"server/i18n/locale/*.json\" dist/i18n && tsc-alias -p server/tsconfig.build.json",
     "build:next": "next build",
     "build": "pnpm build:next && pnpm build:server",
     "lint": "eslint \"./server/**/*.{ts,tsx}\" \"./src/**/*.{ts,tsx}\" --cache",

--- a/server/datasource.ts
+++ b/server/datasource.ts
@@ -1,9 +1,51 @@
+import { Blocklist } from '@server/entity/Blocklist';
+import DiscoverSlider from '@server/entity/DiscoverSlider';
+import Issue from '@server/entity/Issue';
+import IssueComment from '@server/entity/IssueComment';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import OverrideRule from '@server/entity/OverrideRule';
+import Season from '@server/entity/Season';
+import SeasonRequest from '@server/entity/SeasonRequest';
+import { Session } from '@server/entity/Session';
+import { User } from '@server/entity/User';
+import { UserPushSubscription } from '@server/entity/UserPushSubscription';
+import { UserSettings } from '@server/entity/UserSettings';
+import { Watchlist } from '@server/entity/Watchlist';
+import { IssueCommentSubscriber } from '@server/subscriber/IssueCommentSubscriber';
+import { IssueSubscriber } from '@server/subscriber/IssueSubscriber';
+import { MediaRequestSubscriber } from '@server/subscriber/MediaRequestSubscriber';
+import { MediaSubscriber } from '@server/subscriber/MediaSubscriber';
 import fs from 'fs';
 import type { TlsOptions } from 'tls';
 import type { DataSourceOptions, EntityTarget, Repository } from 'typeorm';
 import { DataSource } from 'typeorm';
 
 const DB_SSL_PREFIX = 'DB_SSL_';
+
+const entities = [
+  Blocklist,
+  DiscoverSlider,
+  Issue,
+  IssueComment,
+  Media,
+  MediaRequest,
+  OverrideRule,
+  Season,
+  SeasonRequest,
+  Session,
+  User,
+  UserPushSubscription,
+  UserSettings,
+  Watchlist,
+];
+
+const subscribers = [
+  IssueCommentSubscriber,
+  IssueSubscriber,
+  MediaRequestSubscriber,
+  MediaSubscriber,
+];
 
 function boolFromEnv(envVar: string, defaultVal = false) {
   if (process.env[envVar]) {
@@ -53,9 +95,9 @@ const testConfig: DataSourceOptions = {
   synchronize: true,
   dropSchema: true,
   logging: boolFromEnv('DB_LOG_QUERIES'),
-  entities: ['server/entity/**/*.ts'],
+  entities,
   migrations: ['server/migration/sqlite/**/*.ts'],
-  subscribers: ['server/subscriber/**/*.ts'],
+  subscribers,
 };
 
 const devConfig: DataSourceOptions = {
@@ -67,9 +109,9 @@ const devConfig: DataSourceOptions = {
   migrationsRun: false,
   logging: boolFromEnv('DB_LOG_QUERIES'),
   enableWAL: true,
-  entities: ['server/entity/**/*.ts'],
+  entities,
   migrations: ['server/migration/sqlite/**/*.ts'],
-  subscribers: ['server/subscriber/**/*.ts'],
+  subscribers,
 };
 
 const prodConfig: DataSourceOptions = {
@@ -81,9 +123,9 @@ const prodConfig: DataSourceOptions = {
   migrationsRun: false,
   logging: boolFromEnv('DB_LOG_QUERIES'),
   enableWAL: true,
-  entities: ['dist/entity/**/*.js'],
+  entities,
   migrations: ['dist/migration/sqlite/**/*.js'],
-  subscribers: ['dist/subscriber/**/*.js'],
+  subscribers,
 };
 
 const postgresDevConfig: DataSourceOptions = {
@@ -102,9 +144,9 @@ const postgresDevConfig: DataSourceOptions = {
   synchronize: false,
   migrationsRun: true,
   logging: boolFromEnv('DB_LOG_QUERIES'),
-  entities: ['server/entity/**/*.ts'],
+  entities,
   migrations: ['server/migration/postgres/**/*.ts'],
-  subscribers: ['server/subscriber/**/*.ts'],
+  subscribers,
 };
 
 const postgresProdConfig: DataSourceOptions = {
@@ -123,9 +165,9 @@ const postgresProdConfig: DataSourceOptions = {
   synchronize: false,
   migrationsRun: false,
   logging: boolFromEnv('DB_LOG_QUERIES'),
-  entities: ['dist/entity/**/*.js'],
+  entities,
   migrations: ['dist/migration/postgres/**/*.js'],
-  subscribers: ['dist/subscriber/**/*.js'],
+  subscribers,
 };
 
 export const isPgsql = process.env.DB_TYPE === 'postgres';

--- a/server/scripts/prepareTestDb.ts
+++ b/server/scripts/prepareTestDb.ts
@@ -12,6 +12,7 @@ const prepareDb = async () => {
   await seedTestDb({
     preserveDb: process.env.PRESERVE_DB === 'true',
     withMigrations: process.env.WITH_MIGRATIONS === 'true',
+    allowOutsideTest: true,
   });
 };
 

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"]
+}

--- a/server/utils/seedTestDb.test.ts
+++ b/server/utils/seedTestDb.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { resetTestDb, seedTestDb } from '@server/utils/seedTestDb';
+
+// NODE_ENV is typed readonly, so it is swapped through the whole env object
+function setNodeEnv(value: string | undefined) {
+  Object.assign(process.env, { NODE_ENV: value });
+}
+
+describe('test database guard', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+  });
+
+  it('refuses to seed when NODE_ENV is not test', async () => {
+    setNodeEnv('production');
+
+    await assert.rejects(() => seedTestDb(), /Refusing to seed/);
+  });
+
+  it('refuses to reset when NODE_ENV is not test', async () => {
+    setNodeEnv('production');
+
+    await assert.rejects(() => resetTestDb(), /Refusing to reset/);
+  });
+});

--- a/server/utils/seedTestDb.ts
+++ b/server/utils/seedTestDb.ts
@@ -8,12 +8,24 @@ export interface SeedDbOptions {
   preserveDb?: boolean;
   /** If true, runs migrations instead of synchronizing schema */
   withMigrations?: boolean;
+  /** If true, permits seeding while NODE_ENV is not test */
+  allowOutsideTest?: boolean;
 }
 
 // Precomputed bcrypt hash of 'test1234'. We precompute this to avoid
 // having to hash the password every time we seed the database.
 const TEST_USER_PASSWORD_HASH =
   '$2b$12$Z5V2P5HZgmx4/AnWFMZN1.aD5AM1NucNi.mhNTSQ9oVtmdzu7Le/a';
+
+function assertTestDatabase(operation: string, allowOutsideTest = false): void {
+  if (allowOutsideTest || process.env.NODE_ENV === 'test') {
+    return;
+  }
+
+  throw new Error(
+    `Refusing to ${operation} while NODE_ENV is not test: this drops every table and seeds accounts with a known password.`
+  );
+}
 
 /**
  * Seeds test users into the database.
@@ -68,6 +80,8 @@ async function seedTestUsers(): Promise<void> {
  * Used by both Cypress tests and Vitest unit tests.
  */
 export async function seedTestDb(options: SeedDbOptions = {}): Promise<void> {
+  assertTestDatabase('seed the test database', options.allowOutsideTest);
+
   const dbConnection = dataSource.isInitialized
     ? dataSource
     : await dataSource.initialize();
@@ -91,6 +105,8 @@ export async function seedTestDb(options: SeedDbOptions = {}): Promise<void> {
  * Assumes DB has been initialized.
  */
 export async function resetTestDb(): Promise<void> {
+  assertTestDatabase('reset the test database');
+
   await dataSource.synchronize(true);
   await seedTestUsers();
 }


### PR DESCRIPTION
## Description

TypeORM entities and subscribers load from directory globs over every `.ts` file under `server/entity` and `server/subscriber`. While it is **harmless** today since neither folder has a test file, but drop one in and requiring it runs the module body, which calls `setupTestDb()` again. That registers a second root `before` and `beforeEach` after the runner already built its tree, so two schema rebuilds collide on the single in-memory sqlite connection: "cannot start a transaction within a transaction," every test cancelled, nothing in the failure pointing at the actual file or the actual error.

**Production is worse.** `build:server` compiles every `.ts` under `server`, test files included, and production loads `dist/entity/**/*.js`, so a compiled test file there runs its module body at boot. `seedTestDb` calls `dropDatabase()` on the shared `dataSource` with no check on which database it's pointing at, then rebuilds the schema and seeds `admin@seerr.dev` with `Permission.ADMIN` and a hardcoded bcrypt hash. I confirmed this against a throwaway sqlite file under `NODE_ENV=production` and it dropped a table I'd put there first, rebuilt 15 tables, and left those two accounts behind.

> [!important]
> **No released version is affected.** No tag ships a test file under `dist/entity` or `dist/subscriber`, so there's nothing to fix or disclose.

Now, `seedTestDb` and `resetTestDb` refuse to run unless `NODE_ENV` is test. `cypress:prepare`, now opts in via `seedTestDb({ allowOutsideTest: true })`. This deny-unless-permitted was added because a plain node process with no `NODE_ENV` set resolves to `devConfig` against `config/db/db.sqlite3`, someone's real database if they're running from source.

In addition, `build:server` points at a new `server/tsconfig.build.json` that excludes `*.test.ts`, so `dist` stops shipping the compiled test files it currently produces. Config was separated because because `typecheck:server` is the only thing type checking those files, and the root `tsconfig` covers `src` only and excluding at the base would've silently dropped the files from CI.

Lastly, typeORM gets the `entity` and `subscriber` classes **directly instead of globs**, which also drops the duplicated `ts`/`js` patterns across the five config variants. Narrowing the globs to skip `*.test.ts` would achieve the same thing provided the files named are named that way in directories and a differently named test file, a helper, or a newly globbed directory brings the whole thing back. Classes mean nothing is matched by pattern, at the cost of a list to keep current, forget to add an `entity` and it throws` EntityMetadataNotFoundError` the first time its repository is used anyways. Much more safer this way. Migrations stay globbed.

## How Has This Been Tested?

- Checked the dist if the test files were carried after build
- Checked if the tests still run
- Checked if entities and subscribers were properly loaded.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database configuration reliability across supported environments.
  * Added configurable PostgreSQL connection timeouts, defaulting to 30 seconds.
  * Prevented accidental test database seeding or resets outside test environments.

* **Build**
  * Updated server builds to exclude test files from production compilation.

* **Tests**
  * Added coverage verifying safeguards against unsafe test database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->