### PR TITLE
fix(requests): stop editing a request from stealing another's season

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -394,7 +394,7 @@ describe('PUT /request/:requestId (tv)', () => {
       where: { id: mediaRequest.id },
     });
     assert.deepStrictEqual(
-      saved.seasons.map((s) => s.seasonNumber).sort(),
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
       [1, 2]
     );
 

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -339,6 +339,75 @@ describe('PUT /request/:requestId (movie)', () => {
   });
 });
 
+describe('PUT /request/:requestId (tv)', () => {
+  it('does not add a season held by another request', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const otherUser = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId: 67890,
+        status: MediaStatus.PENDING,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const seedTvRequest = (requestedBy: User, seasons: number[]) =>
+      requestRepo.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.PENDING,
+          media,
+          requestedBy,
+          is4k: false,
+          seasons: seasons.map(
+            (seasonNumber) =>
+              new SeasonRequest({
+                seasonNumber,
+                status: MediaRequestStatus.PENDING,
+              })
+          ),
+        })
+      );
+
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+    const otherRequest = await seedTvRequest(otherUser, [3]);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+
+    const otherSaved = await requestRepo.findOneOrFail({
+      where: { id: otherRequest.id },
+    });
+    assert.deepStrictEqual(
+      otherSaved.seasons.map((s) => s.seasonNumber),
+      [3]
+    );
+  });
+});
+
 describe('POST /request/:requestId/:status', () => {
   const cases = [
     { action: 'approve', expected: MediaRequestStatus.APPROVED },

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -571,7 +571,7 @@ requestRoutes.put<{ requestId: string }>(
           });
         }
 
-        const newSeasons = requestedSeasons.filter(
+        const newSeasons = filteredSeasons.filter(
           (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
         );
 


### PR DESCRIPTION
## Description

Editing a series request worked out which seasons to add from the raw list the client sent, instead of the list already filtered against seasons other live requests hold. A season somebody else had requested therefore slipped past the check meant to catch exactly that and got added anyway, so one season existed on two requests, counted against two people's quotas, and went to Sonarr twice.

This pr fixes it. The seasons to add now come from the filtered list, so an edit can only ever end up with seasons that were actually available to it. This is stacked on the entity loading PR below it for ordering only, nothing here depends on that change.

## How Has This Been Tested?

- Via the attached unit test

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TV request updates so seasons already assigned to another active request aren’t duplicated or reassigned.
  * Existing season assignments, including 4K status, are now preserved correctly when updating or removing requests.
  * Orphaned processing seasons now reset when no active request remains, while unrelated or actively covered seasons remain unchanged.
  * Improved request status validation to prevent invalid actions and provide clearer errors.
  * Retry actions are limited to failed requests, while approvals and declines apply only to pending requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->