### PR TITLE
fix(requests): serialize request creation per user

### DIFF
--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import ExternalAPI from '@server/api/externalapi';
+import { MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import {
+  DuplicateMediaRequestError,
+  MediaRequest,
+  QuotaRestrictedError,
+} from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { setupTestDb } from '@server/test/db';
+
+// get is a prototype method unlike getMovie, and replaces the cache lookup too
+const externalApiGetMock = mock.method(
+  ExternalAPI.prototype as unknown as {
+    get: (endpoint: string) => Promise<unknown>;
+  },
+  'get',
+  async (endpoint: string) => {
+    const movieId = Number(endpoint.replace('/movie/', ''));
+
+    if (!movieId) {
+      throw new Error(`Unstubbed external endpoint: ${endpoint}`);
+    }
+
+    return {
+      id: movieId,
+      external_ids: {},
+      // Skips getMovie's localized fallback call
+      videos: { results: [{ type: 'Trailer', key: 'trailer' }] },
+    };
+  }
+).mock;
+
+mock.method(MediaRequest, 'sendNotification', async () => undefined);
+
+setupTestDb();
+
+beforeEach(() => {
+  externalApiGetMock.resetCalls();
+});
+
+async function seedRequester(movieQuotaLimit: number): Promise<User> {
+  const userRepository = getRepository(User);
+
+  const requester = await userRepository.findOneOrFail({
+    where: { email: 'friend@seerr.dev' },
+  });
+  requester.movieQuotaLimit = movieQuotaLimit;
+
+  return userRepository.save(requester);
+}
+
+function requestMovies(mediaIds: number[], requester: User) {
+  return Promise.allSettled(
+    mediaIds.map((mediaId) =>
+      MediaRequest.request(
+        { mediaId, mediaType: MediaType.MOVIE, is4k: false },
+        requester
+      )
+    )
+  );
+}
+
+function rejections(results: PromiseSettledResult<MediaRequest>[]) {
+  return results.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  );
+}
+
+describe('MediaRequest.request', () => {
+  it('rejects the second of two concurrent requests at the movie quota', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(1);
+
+    const results = await requestMovies([11111, 22222], requester);
+    const rejected = rejections(results);
+
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof QuotaRestrictedError);
+    assert.strictEqual(await requestRepository.count(), 1);
+    assert.strictEqual(externalApiGetMock.callCount(), 1);
+  });
+
+  it('rejects a concurrent duplicate request for the same movie', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(5);
+
+    const results = await requestMovies([33333, 33333], requester);
+    const rejected = rejections(results);
+
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof DuplicateMediaRequestError);
+    assert.strictEqual(await requestRepository.count(), 1);
+    assert.strictEqual(externalApiGetMock.callCount(), 2);
+  });
+});

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -14,6 +14,7 @@ import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
+import requestLock from '@server/utils/requestLock';
 import { truncate } from 'lodash';
 import {
   AfterInsert,
@@ -48,6 +49,16 @@ export class MediaRequest {
     requestBody: MediaRequestBody,
     user: User,
     options: MediaRequestOptions = {}
+  ): Promise<MediaRequest> {
+    return requestLock.dispatch(requestBody.userId || user.id, () =>
+      MediaRequest.createRequest(requestBody, user, options)
+    );
+  }
+
+  private static async createRequest(
+    requestBody: MediaRequestBody,
+    user: User,
+    options: MediaRequestOptions
   ): Promise<MediaRequest> {
     const tmdb = new TheMovieDb();
     const mediaRepository = getRepository(Media);

--- a/server/utils/asyncLock.ts
+++ b/server/utils/asyncLock.ts
@@ -37,14 +37,14 @@ class AsyncLock {
     setImmediate(() => this.ee.emit(key));
   };
 
-  public dispatch = async (
+  public dispatch = async <T>(
     key: string | number,
-    callback: () => Promise<void>
-  ) => {
+    callback: () => Promise<T>
+  ): Promise<T> => {
     const skey = String(key);
     await this.acquire(skey);
     try {
-      await callback();
+      return await callback();
     } finally {
       this.release(skey);
     }

--- a/server/utils/requestLock.ts
+++ b/server/utils/requestLock.ts
@@ -1,0 +1,7 @@
+import AsyncLock from '@server/utils/asyncLock';
+
+// Keyed on user id. Never dispatch from a subscriber or transaction as a waiter
+// would block while holding the save's connection.
+const requestLock = new AsyncLock();
+
+export default requestLock;


### PR DESCRIPTION
## Description

The quota check reads its counts and then saves, with nothing in between stopping another request from the same user passing the same check. Several requests submitted at once could all clear a quota with room for one. That is not theoretical, the collection request modal submits one request per selected part in parallel, so requesting a collection has always been able to go past the limit.

Creating a request now runs under a per-user lock, so the check and the save that follows it cannot interleave with that user's other requests. The lock also closes the same-user duplicate submit and the auto-request duplicate check, which had the same shape. It is taken before any database work, so a request waiting on it holds no pool connection.

## How Has This Been Tested?

- Only via the unit test attached to this PR

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved media request handling when multiple requests are submitted simultaneously.
  - Prevented concurrent requests from bypassing configured movie quotas.
  - Prevented duplicate requests for the same movie from being created during simultaneous submissions.
  - Preserved accurate request results while concurrent operations are processed safely.

- **Tests**
  - Added coverage for concurrent quota enforcement and duplicate-request prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->