### PR TITLE
fix(requests): enforce pending and failed states on request routes

### DIFF
--- a/seerr-api.yml
+++ b/seerr-api.yml
@@ -6651,6 +6651,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaRequest'
+        '409':
+          description: Only pending requests can be modified
     delete:
       summary: Delete request
       description: Removes a request. If the user has the `MANAGE_REQUESTS` permission, any request can be removed. Otherwise, only pending requests can be removed.
@@ -6691,6 +6693,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaRequest'
+        '409':
+          description: Only failed requests can be retried
   /request/{requestId}/{status}:
     post:
       summary: Update a request's status
@@ -6722,6 +6726,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MediaRequest'
+        '400':
+          description: Status must be approve or decline
+        '409':
+          description: Only pending requests can be approved or declined
   /movie/{movieId}:
     get:
       summary: Get movie details

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -211,6 +211,27 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.profileId, 7);
     assert.strictEqual(saved.rootFolder, '/updated/movies');
   });
+
+  it('refuses to modify a request that is no longer pending', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRequest = await seedRequest(MediaRequestStatus.APPROVED);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.MOVIE,
+      serverId: 3,
+      rootFolder: '/updated/movies',
+    });
+
+    assert.strictEqual(res.status, 409);
+    assert.match(res.body.message, /pending/i);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.serverId, null);
+    assert.strictEqual(saved.rootFolder, null);
+  });
 });
 
 describe('POST /request/:requestId/:status', () => {
@@ -241,6 +262,52 @@ describe('POST /request/:requestId/:status', () => {
       assert.ok(persisted.updatedAt > pending.updatedAt);
     });
   }
+
+  it('rejects a status the route does not define', async () => {
+    const repo = getRepository(MediaRequest);
+    const pending = await seedRequest();
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/frobnicate`);
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /approve/i);
+
+    const persisted = await repo.findOneOrFail({
+      where: { id: pending.id },
+      relations: { modifiedBy: true },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.PENDING);
+    assert.ok(!persisted.modifiedBy);
+  });
+
+  it('refuses to act on a request that is no longer pending', async () => {
+    const repo = getRepository(MediaRequest);
+    const approved = await seedRequest(MediaRequestStatus.APPROVED);
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${approved.id}/decline`);
+
+    assert.strictEqual(res.status, 409);
+    assert.match(res.body.message, /pending/i);
+
+    const persisted = await repo.findOneOrFail({ where: { id: approved.id } });
+    assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
+  });
+
+  it('rejects the removed pending verb even on a non-pending request', async () => {
+    const repo = getRepository(MediaRequest);
+    const declined = await seedRequest(MediaRequestStatus.DECLINED);
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${declined.id}/pending`);
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /approve/i);
+
+    const persisted = await repo.findOneOrFail({ where: { id: declined.id } });
+    assert.strictEqual(persisted.status, MediaRequestStatus.DECLINED);
+  });
 });
 
 describe('POST /request/:requestId/retry', () => {
@@ -263,6 +330,20 @@ describe('POST /request/:requestId/retry', () => {
     assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
     assert.strictEqual(persisted.modifiedBy?.email, 'admin@seerr.dev');
     assert.ok(persisted.updatedAt > failed.updatedAt);
+  });
+
+  it('refuses to retry a request that has not failed', async () => {
+    const repo = getRepository(MediaRequest);
+    const pending = await seedRequest();
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/retry`);
+
+    assert.strictEqual(res.status, 409);
+    assert.match(res.body.message, /failed/i);
+
+    const persisted = await repo.findOneOrFail({ where: { id: pending.id } });
+    assert.strictEqual(persisted.status, MediaRequestStatus.PENDING);
   });
 });
 

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -485,6 +485,13 @@ requestRoutes.put<{ requestId: string }>(
         });
       }
 
+      if (request.status !== MediaRequestStatus.PENDING) {
+        return next({
+          status: 409,
+          message: 'Only pending requests can be modified.',
+        });
+      }
+
       let requestUser = request.requestedBy;
 
       if (
@@ -644,6 +651,13 @@ requestRoutes.post<{
         relations: { requestedBy: true, modifiedBy: true },
       });
 
+      if (request.status !== MediaRequestStatus.FAILED) {
+        return next({
+          status: 409,
+          message: 'Only failed requests can be retried.',
+        });
+      }
+
       // this also triggers updating the parent media's status & sending to *arr
       request.status = MediaRequestStatus.APPROVED;
       request.modifiedBy = req.user;
@@ -662,7 +676,7 @@ requestRoutes.post<{
 
 requestRoutes.post<{
   requestId: string;
-  status: 'pending' | 'approve' | 'decline';
+  status: 'approve' | 'decline';
 }>(
   '/:requestId/:status',
   isAuthenticated(Permission.MANAGE_REQUESTS),
@@ -678,15 +692,24 @@ requestRoutes.post<{
       let newStatus: MediaRequestStatus;
 
       switch (req.params.status) {
-        case 'pending':
-          newStatus = MediaRequestStatus.PENDING;
-          break;
         case 'approve':
           newStatus = MediaRequestStatus.APPROVED;
           break;
         case 'decline':
           newStatus = MediaRequestStatus.DECLINED;
           break;
+        default:
+          return next({
+            status: 400,
+            message: 'Status must be approve or decline.',
+          });
+      }
+
+      if (request.status !== MediaRequestStatus.PENDING) {
+        return next({
+          status: 409,
+          message: 'Only pending requests can be approved or declined.',
+        });
       }
 
       request.status = newStatus;


### PR DESCRIPTION
## Description

A request is only editable while it is pending, and every state other than pending and failed are terminal. The frontend enforces that everywhere: the edit modal only opens from pending-gated triggers in `RequestItem`, `RequestCard`, `RequestBlock` and `RequestButton`, approve and decline only render while pending, and retry only renders on a failed request. 

While working on #3378 I noticed that the API enforces none of it, so PUT will happily rewrite an approved request, approve and decline will move a completed or declined one, and retry sets APPROVED regardless of what the request was before.

This PR adds the three guards the product already implies. PUT and the approve and decline route reject anything that is not currently pending, and retry rejects anything that has not failed, all with 409 and a message naming the state that was expected.

Nothing in the frontend changes. I checked every path that can reach these routes, including the edit then approve flow in the request modals, which is safe because both modals send the PUT before posting the approve, so the request is still pending at each step. The two `modifyRequest` helpers are typed to approve and decline only, so moving a request back to pending is not something the UI can ask for at all.

Worth nothing though that blocking transitions out of declined means an accidental decline cannot be undone through the API, since approve on a declined request now returns 409. That is already the case in the UI anyways, where a declined request offers no buttons, so this hardens a gap that already existed.

## How Has This Been Tested?

- Tested using unit tests

## Screenshots / Logs (if applicable)

## Checklist:

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Prevented updates to requests that are no longer pending.
* Restricted retries to failed requests and approvals or declines to pending requests.
* Rejected unsupported status values with clear error responses.
* Returned conflict responses when operations are invalid for the request’s current state.
* Preserved request data and status when conflicting operations are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->