### PR TITLE
feat(helm): add extraManifests value

### DIFF
--- a/charts/seerr-chart/Chart.yaml
+++ b/charts/seerr-chart/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: '>=1.23.0-0'
 name: seerr-chart
 description: Seerr helm chart for Kubernetes
 type: application
-version: 3.9.1
+version: 3.10.0
 # renovate: image=ghcr.io/seerr-team/seerr
 appVersion: 'v3.4.1'
 maintainers:

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -1,6 +1,6 @@
 # seerr-chart
 
-![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.4.1](https://img.shields.io/badge/AppVersion-v3.4.1-informational?style=flat-square)
+![Version: 3.10.0](https://img.shields.io/badge/Version-3.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v3.4.1](https://img.shields.io/badge/AppVersion-v3.4.1-informational?style=flat-square)
 
 Seerr helm chart for Kubernetes
 
@@ -57,7 +57,7 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | dnsPolicy | string | `""` | docs: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | extraEnv | list | `[]` | Environment variables to add to the seerr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the seerr pods |
-| extraManifests | list | `[]` | Extra manifests to deploy with the release. Either a list or a map; each entry may be a YAML object or a string, and both are passed through `tpl`, so they can reference values and the chart's named templates. Use it for objects the chart does not render (NetworkPolicy, Gateway API policies, ExternalSecret, ServiceMonitor, ...) so the release owns and prunes them. |
+| extraManifests | list | `[]` | Extra manifests to deploy with the release.  |
 | fullnameOverride | string | `""` |  |
 | hostUsers | bool | `true` | docs: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -57,6 +57,7 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | dnsPolicy | string | `""` | docs: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | extraEnv | list | `[]` | Environment variables to add to the seerr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the seerr pods |
+| extraManifests | list | `[]` | Extra manifests to deploy with the release. Either a list or a map; each entry may be a YAML object or a string, and both are passed through `tpl`, so they can reference values and the chart's named templates. Use it for objects the chart does not render (NetworkPolicy, Gateway API policies, ExternalSecret, ServiceMonitor, ...) so the release owns and prunes them. |
 | fullnameOverride | string | `""` |  |
 | hostUsers | bool | `true` | docs: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/seerr-chart/README.md
+++ b/charts/seerr-chart/README.md
@@ -57,7 +57,7 @@ If `replicaCount` value was used - remove it. Helm update should work fine after
 | dnsPolicy | string | `""` | docs: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | extraEnv | list | `[]` | Environment variables to add to the seerr pods |
 | extraEnvFrom | list | `[]` | Environment variables from secrets or configmaps to add to the seerr pods |
-| extraManifests | list | `[]` | Extra manifests to deploy with the release.  |
+| extraManifests | list | `[]` | Extra manifests to deploy with the release. Entries are YAML objects or strings, both rendered through `tpl`. Objects are parsed as YAML first, so quote their template expressions. Use the string form to inject keys. |
 | fullnameOverride | string | `""` |  |
 | hostUsers | bool | `true` | docs: https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/ |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/seerr-chart/templates/extra-manifests.yaml
+++ b/charts/seerr-chart/templates/extra-manifests.yaml
@@ -1,0 +1,18 @@
+{{- /*
+Renders arbitrary manifests supplied in .Values.extraManifests, so objects the
+chart does not template (NetworkPolicy, Gateway API policies, ExternalSecret,
+ServiceMonitor, ...) can be owned and pruned by this release instead of being
+applied by hand.
+
+extraManifests may be a list or a map. Each entry is either a YAML object or a
+string; strings and objects are both passed through `tpl`, so they can use the
+release's values and the chart's named templates.
+*/ -}}
+{{- range $manifest := .Values.extraManifests }}
+---
+{{- if kindIs "string" $manifest }}
+{{ tpl $manifest $ }}
+{{- else }}
+{{ tpl (toYaml $manifest) $ }}
+{{- end }}
+{{- end }}

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -198,16 +198,19 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-# -- Extra manifests to deploy with the release. 
+# -- Extra manifests to deploy with the release. Entries are YAML objects or
+# strings, both rendered through `tpl`. Objects are parsed as YAML first, so
+# quote their template expressions. Use the string form to inject keys.
 extraManifests: []
 # - apiVersion: networking.k8s.io/v1
 #   kind: NetworkPolicy
 #   metadata:
-#     name: {{ include "seerr.fullname" . }}-allow-dns
+#     name: '{{ include "seerr.fullname" . }}-allow-dns'
 #   spec:
 #     podSelector:
 #       matchLabels:
-#         {{- include "seerr.selectorLabels" . | nindent 8 }}
+#         app.kubernetes.io/name: '{{ include "seerr.name" . }}'
+#         app.kubernetes.io/instance: '{{ .Release.Name }}'
 #     policyTypes:
 #       - Egress
 # - |
@@ -215,6 +218,8 @@ extraManifests: []
 #   kind: ConfigMap
 #   metadata:
 #     name: {{ include "seerr.fullname" . }}-extra
+#     labels:
+#       {{- include "seerr.labels" . | nindent 4 }}
 #   data:
 #     hostname: {{ (first .Values.route.main.hostnames) | quote }}
 

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -198,6 +198,30 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# -- Extra manifests to deploy with the release. Either a list or a map; each
+# entry may be a YAML object or a string, and both are passed through `tpl`, so
+# they can reference values and the chart's named templates. Use it for objects
+# the chart does not render (NetworkPolicy, Gateway API policies, ExternalSecret,
+# ServiceMonitor, ...) so the release owns and prunes them.
+extraManifests: []
+# - apiVersion: networking.k8s.io/v1
+#   kind: NetworkPolicy
+#   metadata:
+#     name: {{ include "seerr.fullname" . }}-allow-dns
+#   spec:
+#     podSelector:
+#       matchLabels:
+#         {{- include "seerr.selectorLabels" . | nindent 8 }}
+#     policyTypes:
+#       - Egress
+# - |
+#   apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: {{ include "seerr.fullname" . }}-extra
+#   data:
+#     hostname: {{ (first .Values.route.main.hostnames) | quote }}
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/seerr-chart/values.yaml
+++ b/charts/seerr-chart/values.yaml
@@ -198,11 +198,7 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-# -- Extra manifests to deploy with the release. Either a list or a map; each
-# entry may be a YAML object or a string, and both are passed through `tpl`, so
-# they can reference values and the chart's named templates. Use it for objects
-# the chart does not render (NetworkPolicy, Gateway API policies, ExternalSecret,
-# ServiceMonitor, ...) so the release owns and prunes them.
+# -- Extra manifests to deploy with the release. 
 extraManifests: []
 # - apiVersion: networking.k8s.io/v1
 #   kind: NetworkPolicy


### PR DESCRIPTION
## Description

Adds an `extraManifests` value so objects the chart does not template can be owned and pruned by the release instead of applied by hand.  Increased the minor helm chart version as part of this change too.

My specific usecase is deploying Seerr behind Envoy Gateway and my setup requires a SecurityPolicy and a BackendTrafficPolicy alongside the chart's HTTPRoute.  Other types of manifests that users may be manually adding are NetworkPolicy, ServiceMonitor and ExternalSecret that are not natively handled by the chart.

extraManifests accepts a list or a map. Each entry may be a YAML object or a string, and both are passed through `tpl`, so entries can reference values and the chart's named templates. An empty value renders nothing, so the default output is unchanged.

Claude Code was used to generate the initial code and comments that was then modified based on contributing.md.

## How Has This Been Tested?

I have validated this via rendering helm with and without any additional extraManifests to ensure both empty sets and additional manifests render properly.  

## Screenshots / Logs (if applicable)
N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deploying additional Kubernetes manifests alongside the Seerr Helm release.
  * Supports templated manifest definitions, including resources such as NetworkPolicies and ConfigMaps.
  * Manifest entries can be provided as YAML objects or strings.

* **Documentation**
  * Documented the new `extraManifests` configuration option.
  * Updated the Helm chart version to 3.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->