### PR TITLE
fix(db): drop stale auth unique on sqlite push subscriptions

### DIFF
--- a/server/migration/sqlite/1786619443939-DropPushSubscriptionAuthUnique.ts
+++ b/server/migration/sqlite/1786619443939-DropPushSubscriptionAuthUnique.ts
@@ -1,0 +1,41 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+// SQLite kept the "auth" UNIQUE that Postgres dropped in 1743023615532-UpdateWebPush.
+// Hand-written because the generated rebuild re-adds it and never converges.
+export class DropPushSubscriptionAuthUnique1786619443939 implements MigrationInterface {
+  name = 'DropPushSubscriptionAuthUnique1786619443939';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `CREATE TABLE "temporary_user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "user_push_subscription"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_user_push_subscription" RENAME TO "user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_03f7958328e311761b0de675fb"`);
+    await queryRunner.query(
+      `ALTER TABLE "user_push_subscription" RENAME TO "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_push_subscription" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "endpoint" varchar NOT NULL, "p256dh" varchar NOT NULL, "auth" varchar NOT NULL, "userId" integer, "userAgent" varchar, "createdAt" datetime DEFAULT (CURRENT_TIMESTAMP), CONSTRAINT "UQ_f90ab5a4ed54905a4bb51a7148b" UNIQUE ("auth"), CONSTRAINT "UQ_6427d07d9a171a3a1ab87480005" UNIQUE ("endpoint", "userId"), CONSTRAINT "FK_03f7958328e311761b0de675fbe" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "user_push_subscription"("id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt") SELECT "id", "endpoint", "p256dh", "auth", "userId", "userAgent", "createdAt" FROM "temporary_user_push_subscription"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_user_push_subscription"`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_03f7958328e311761b0de675fb" ON "user_push_subscription" ("userId") `
+    );
+  }
+}


### PR DESCRIPTION
## Description

`user_push_subscription.auth` carries a UNIQUE constraint on sqlite that neither the entity nor postgres has. The constraint `UQ_f90ab5a4ed54905a4bb51a7148b`.

The `UpdateWebPush` pair diverged. `postgres/1743023615532-UpdateWebPush.ts` drops the constraint, and the sqlite twin `1743023610704-UpdateWebPush.ts` never does, carrying it forward through four rebuilds instead. This dates to an upstream overseerr merge issue, which is also why there are two `UpdateWebPush` migrations. 

TypeORM cannot generate a fix. It sees the extra unique and emits a table rebuild to drop it, but the temp table it produces re-includes `UQ_f90ab5a4ed54905a4bb51a7148b`, so the diff never converges and it emits the rebuild twice per `up()`. The practical cost of that was that every generated sqlite migration inherited the noise. For example, `1781732036510-AddIgnoreQuotaToMediaRequest` carries 12 `user_push_subscription` references that have nothing to do with its subject. 

## How Has This Been Tested?

I have tested this extensively with sqlite and postgres on fresh and already existing instances. No behavioural changes. It just fixes sqlite's broken migration generation

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Push subscriptions can now share the same authentication value when associated with different endpoints.
  * Existing push subscription data, relationships, and endpoint uniqueness protections are preserved during database updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->