### PR TITLE
fix(scanner): confirm orphan candidates against the servers before declining

### DIFF
--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -81,6 +81,23 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
     }
   };
 
+  public getLibraryMoviesByTmdbId = async (
+    tmdbId: number
+  ): Promise<RadarrMovie[]> => {
+    try {
+      const response = await this.axios.get<RadarrMovie[]>('/movie', {
+        params: { tmdbId },
+      });
+
+      return response.data;
+    } catch (e) {
+      throw new Error(
+        `[Radarr] Failed to retrieve movies by TMDB ID: ${e.message}`,
+        { cause: e }
+      );
+    }
+  };
+
   public getMovie = async ({ id }: { id: number }): Promise<RadarrMovie> => {
     try {
       const response = await this.axios.get<RadarrMovie>(`/movie/${id}`);

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -130,6 +130,23 @@ class SonarrAPI extends ServarrBase<{
     }
   }
 
+  public async getLibrarySeriesByTvdbId(
+    tvdbId: number
+  ): Promise<SonarrSeries[]> {
+    try {
+      const response = await this.axios.get<SonarrSeries[]>('/series', {
+        params: { tvdbId },
+      });
+
+      return response.data;
+    } catch (e) {
+      throw new Error(
+        `[Sonarr] Failed to retrieve series by TVDB ID: ${e.message}`,
+        { cause: e }
+      );
+    }
+  }
+
   public async getSeriesById(id: number): Promise<SonarrSeries> {
     try {
       const response = await this.axios.get<SonarrSeries>(`/series/${id}`);

--- a/server/lib/scanners/radarr/index.ts
+++ b/server/lib/scanners/radarr/index.ts
@@ -164,6 +164,39 @@ class RadarrScanner
     }
   }
 
+  private async existsInAnyServer(
+    tmdbId: number,
+    is4k: boolean
+  ): Promise<boolean> {
+    const servers = this.servers.filter(
+      (server) =>
+        server.syncEnabled && (this.enable4kMovie && server.is4k) === is4k
+    );
+
+    for (const server of servers) {
+      try {
+        const api = new RadarrAPI({
+          apiKey: server.apiKey,
+          url: RadarrAPI.buildUrl(server, '/api/v3'),
+        });
+        const movies = await api.getLibraryMoviesByTmdbId(tmdbId);
+
+        if (movies.some((movie) => movie.tmdbId === tmdbId)) {
+          return true;
+        }
+      } catch (e) {
+        this.log(
+          `Could not confirm movie ${tmdbId} against Radarr server ${server.name}. Skipping cleanup for it.`,
+          'warn',
+          { errorMessage: e.message }
+        );
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private async cleanupOrphanedMovies(): Promise<void> {
     const mediaRepository = getRepository(Media);
 
@@ -175,6 +208,10 @@ class RadarrScanner
 
       for (const media of processingMovies) {
         if (!this.scannedTmdbIds.has(media.tmdbId)) {
+          if (await this.existsInAnyServer(media.tmdbId, false)) {
+            continue;
+          }
+
           media.status = MediaStatus.UNKNOWN;
           await mediaRepository.save(media);
           await this.declineOrphanedRequests(media, false);
@@ -202,6 +239,10 @@ class RadarrScanner
 
       for (const media of processing4kMovies) {
         if (!this.scanned4kTmdbIds.has(media.tmdbId)) {
+          if (await this.existsInAnyServer(media.tmdbId, true)) {
+            continue;
+          }
+
           media.status4k = MediaStatus.UNKNOWN;
           await mediaRepository.save(media);
           await this.declineOrphanedRequests(media, true);

--- a/server/lib/scanners/radarr/radarr.test.ts
+++ b/server/lib/scanners/radarr/radarr.test.ts
@@ -25,6 +25,17 @@ Object.defineProperty(RadarrAPI.prototype, 'getMovies', {
   configurable: true,
 });
 
+let getLibraryMoviesByTmdbIdImpl: (
+  tmdbId: number
+) => Promise<RadarrMovie[]> = async () => [];
+Object.defineProperty(RadarrAPI.prototype, 'getLibraryMoviesByTmdbId', {
+  set() {},
+  get() {
+    return async (tmdbId: number) => getLibraryMoviesByTmdbIdImpl(tmdbId);
+  },
+  configurable: true,
+});
+
 mock.method(MediaRequest, 'sendNotification', async () => undefined);
 
 setupTestDb();
@@ -76,6 +87,7 @@ function fakeRadarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
 describe('Radarr Scanner', () => {
   beforeEach(() => {
     getMoviesImpl = async () => [];
+    getLibraryMoviesByTmdbIdImpl = async () => [];
   });
 
   describe('unmonitored movie handling', () => {
@@ -355,6 +367,76 @@ describe('Radarr Scanner', () => {
         where: { tmdbId: 902 },
       });
       assert.strictEqual(updatedExisting.status, MediaStatus.AVAILABLE);
+    });
+
+    it('does not reset a movie added to Radarr after the scan started', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 910;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 111 })];
+      getLibraryMoviesByTmdbIdImpl = async (tmdbId) => [
+        fakeRadarrMovie({ tmdbId }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 910 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('does not reset a movie when the server cannot be reached', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 911;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 111 })];
+      getLibraryMoviesByTmdbIdImpl = async () => {
+        throw new Error('connect ECONNREFUSED');
+      };
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 911 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('resets a movie when the server returns no row matching its id', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 912;
+      media.mediaType = MediaType.MOVIE;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureRadarr([{ syncEnabled: true }]);
+      getMoviesImpl = async () => [fakeRadarrMovie({ tmdbId: 111 })];
+      getLibraryMoviesByTmdbIdImpl = async () => [
+        fakeRadarrMovie({ tmdbId: 111 }),
+        fakeRadarrMovie({ tmdbId: 222 }),
+      ];
+
+      await radarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 912 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
     });
   });
 

--- a/server/lib/scanners/sonarr/index.ts
+++ b/server/lib/scanners/sonarr/index.ts
@@ -235,6 +235,39 @@ class SonarrScanner
     }
   }
 
+  private async existsInAnyServer(
+    tvdbId: number,
+    is4k: boolean
+  ): Promise<boolean> {
+    const servers = this.servers.filter(
+      (server) =>
+        server.syncEnabled && (this.enable4kShow && server.is4k) === is4k
+    );
+
+    for (const server of servers) {
+      try {
+        const api = new SonarrAPI({
+          apiKey: server.apiKey,
+          url: SonarrAPI.buildUrl(server, '/api/v3'),
+        });
+        const series = await api.getLibrarySeriesByTvdbId(tvdbId);
+
+        if (series.some((show) => show.tvdbId === tvdbId)) {
+          return true;
+        }
+      } catch (e) {
+        this.log(
+          `Could not confirm series ${tvdbId} against Sonarr server ${server.name}. Skipping cleanup for it.`,
+          'warn',
+          { errorMessage: e.message }
+        );
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private async cleanupOrphanedShows(): Promise<void> {
     const mediaRepository = getRepository(Media);
 
@@ -246,6 +279,10 @@ class SonarrScanner
 
       for (const media of processingShows) {
         if (media.tvdbId && !this.scannedTvdbIds.has(media.tvdbId)) {
+          if (await this.existsInAnyServer(media.tvdbId, false)) {
+            continue;
+          }
+
           media.status = MediaStatus.UNKNOWN;
           for (const season of media.seasons) {
             if (season.status === MediaStatus.PROCESSING) {
@@ -275,6 +312,10 @@ class SonarrScanner
 
       for (const media of processing4kShows) {
         if (media.tvdbId && !this.scanned4kTvdbIds.has(media.tvdbId)) {
+          if (await this.existsInAnyServer(media.tvdbId, true)) {
+            continue;
+          }
+
           media.status4k = MediaStatus.UNKNOWN;
           for (const season of media.seasons) {
             if (season.status4k === MediaStatus.PROCESSING) {

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -31,6 +31,17 @@ Object.defineProperty(SonarrAPI.prototype, 'getSeries', {
   configurable: true,
 });
 
+let getLibrarySeriesByTvdbIdImpl: (
+  tvdbId: number
+) => Promise<SonarrSeries[]> = async () => [];
+Object.defineProperty(SonarrAPI.prototype, 'getLibrarySeriesByTvdbId', {
+  set() {},
+  get() {
+    return async (tvdbId: number) => getLibrarySeriesByTvdbIdImpl(tvdbId);
+  },
+  configurable: true,
+});
+
 function fakeTmdbShow(
   tmdbId: number,
   seasons: TmdbTvSeasonResult[] = [
@@ -164,6 +175,7 @@ function configureSonarr(overrides: Partial<SonarrSettings>[] = [{}]): void {
 describe('Sonarr Scanner', () => {
   beforeEach(() => {
     getSeriesImpl = async () => [];
+    getLibrarySeriesByTvdbIdImpl = async () => [];
     getShowByTvdbIdImpl = async () => fakeTmdbShow(1);
     getTvShowImpl = async () => fakeTmdbShow(1);
   });
@@ -425,6 +437,79 @@ describe('Sonarr Scanner', () => {
         relations: ['seasons'],
       });
       assert.notStrictEqual(updatedExisting.status, MediaStatus.UNKNOWN);
+    });
+
+    it('does not reset a show added to Sonarr after the scan started', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1020;
+      media.tvdbId = 620;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 111 })];
+      getLibrarySeriesByTvdbIdImpl = async (tvdbId) => [
+        fakeSonarrSeries({ tvdbId }),
+      ];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1020 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('does not reset a show when the server cannot be reached', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1021;
+      media.tvdbId = 621;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 111 })];
+      getLibrarySeriesByTvdbIdImpl = async () => {
+        throw new Error('connect ECONNREFUSED');
+      };
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1021 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.PROCESSING);
+    });
+
+    it('resets a show when the server returns no row matching its id', async () => {
+      const mediaRepository = getRepository(Media);
+
+      const media = new Media();
+      media.tmdbId = 1022;
+      media.tvdbId = 622;
+      media.mediaType = MediaType.TV;
+      media.status = MediaStatus.PROCESSING;
+      await mediaRepository.save(media);
+
+      configureSonarr([{ syncEnabled: true }]);
+      getSeriesImpl = async () => [fakeSonarrSeries({ tvdbId: 111 })];
+      getLibrarySeriesByTvdbIdImpl = async () => [
+        fakeSonarrSeries({ tvdbId: 111 }),
+        fakeSonarrSeries({ tvdbId: 222 }),
+      ];
+
+      await sonarrScanner.run();
+
+      const updated = await mediaRepository.findOneOrFail({
+        where: { tmdbId: 1022 },
+      });
+      assert.strictEqual(updated.status, MediaStatus.UNKNOWN);
     });
 
     it('skips shows without a tvdbId during cleanup', async () => {


### PR DESCRIPTION
## Description

The Radarr and Sonarr scanners take a snapshot of the library at the start of a run and, at the end, decline any in-progress request that isn't in it. Anything requested while the scan is still running was never in that snapshot, so it gets declined a few minutes after Radarr or Sonarr already accepted it. On the default schedule, since both scan jobs fall on a watchlist sync tick and nothing stops the two running at the same time either thus this happening.

Before declining anything, the scanners now check the candidate against the servers directly  instead of trusting the snapshot. If that check can't be completed the request is left alone, so a server being briefly unreachable can't decline someone's request.

## How Has This Been Tested?

- [X] Tested via unit tests
- [x] Tested by reporter (available to test via `preview-scanner-decline-race-fix`)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [X] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Radarr and Sonarr library synchronization during scans.
  * Prevents media added after a scan begins from being incorrectly marked as missing.
  * Preserves processing status when servers are unreachable or verification fails.
  * Correctly resets status only when a confirmed library lookup finds no matching movie or series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->