### PR TITLE
fix(plex): do not cache invalid Discover watchlist responses

### DIFF
--- a/server/api/plextv.test.ts
+++ b/server/api/plextv.test.ts
@@ -1,0 +1,278 @@
+import PlexTvAPI, { type PlexWatchlistCache } from '@server/api/plextv';
+import cacheManager from '@server/lib/cache';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+function getAxios(api: PlexTvAPI): AxiosInstance {
+  return (api as unknown as { axios: AxiosInstance }).axios;
+}
+
+function watchlistCache() {
+  return cacheManager.getCache('plexwatchlist').data;
+}
+
+describe('PlexTvAPI getWatchlist', () => {
+  afterEach(() => {
+    mock.restoreAll();
+    cacheManager.getCache('plexwatchlist').flush();
+    cacheManager.getCache('plextv').flush();
+  });
+
+  it('does not cache or crash on a 2xx body without MediaContainer', async () => {
+    const api = new PlexTvAPI('token-empty');
+    mock.method(getAxios(api), 'get', async () => ({
+      status: 200,
+      headers: { etag: '"poison"' },
+      data: { errors: [{ code: 1001, message: 'Unavailable' }] },
+    }));
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 0,
+      items: [],
+    });
+    assert.equal(watchlistCache().get('token-empty'), undefined);
+  });
+
+  it('keeps a valid cached watchlist when Discover returns a 2xx without MediaContainer', async () => {
+    const api = new PlexTvAPI('token-stale');
+    watchlistCache().set<PlexWatchlistCache>('token-stale', {
+      etag: '"good"',
+      response: {
+        MediaContainer: { totalSize: 4, Metadata: [] },
+      },
+    });
+    mock.method(getAxios(api), 'get', async () => ({
+      status: 200,
+      headers: { etag: '"poison"' },
+      data: '<html>error</html>',
+    }));
+
+    const result = await api.getWatchlist();
+
+    assert.equal(result.totalSize, 4);
+    assert.equal(
+      watchlistCache().get<PlexWatchlistCache>('token-stale')?.etag,
+      '"good"'
+    );
+  });
+
+  it('drops a poisoned cache entry and does not send If-None-Match', async () => {
+    const api = new PlexTvAPI('token-poisoned');
+    watchlistCache().set('token-poisoned', {
+      etag: '"bad"',
+      response: { errors: ['nope'] },
+    });
+
+    let requestConfig: AxiosRequestConfig | undefined;
+    mock.method(
+      getAxios(api),
+      'get',
+      async (_url: string, config?: AxiosRequestConfig) => {
+        requestConfig = config;
+        return {
+          status: 200,
+          headers: { etag: '"fresh"' },
+          data: { MediaContainer: { totalSize: 0 } },
+        };
+      }
+    );
+
+    const result = await api.getWatchlist();
+
+    assert.equal(result.totalSize, 0);
+    assert.equal(requestConfig?.headers?.['If-None-Match'], undefined);
+    assert.equal(
+      watchlistCache().get<PlexWatchlistCache>('token-poisoned')?.etag,
+      '"fresh"'
+    );
+  });
+
+  it('does not cache a 2xx body whose MediaContainer is an array', async () => {
+    const api = new PlexTvAPI('token-array');
+    mock.method(getAxios(api), 'get', async () => ({
+      status: 200,
+      headers: { etag: '"array"' },
+      data: { MediaContainer: [] },
+    }));
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 0,
+      items: [],
+    });
+    assert.equal(watchlistCache().get('token-array'), undefined);
+  });
+
+  it('does not cache a 2xx body whose totalSize is not a number', async () => {
+    const api = new PlexTvAPI('token-bad-size');
+    mock.method(getAxios(api), 'get', async () => ({
+      status: 200,
+      headers: { etag: '"bad-size"' },
+      data: { MediaContainer: { totalSize: 'invalid' } },
+    }));
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 0,
+      items: [],
+    });
+    assert.equal(watchlistCache().get('token-bad-size'), undefined);
+  });
+
+  it('returns an empty watchlist when the watchlist fetch fails', async () => {
+    const api = new PlexTvAPI('token-fetch-error');
+    mock.method(getAxios(api), 'get', async () => {
+      throw new Error('network down');
+    });
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 0,
+      items: [],
+    });
+  });
+
+  it('propagates cache manager failures instead of returning an empty watchlist', async () => {
+    const api = new PlexTvAPI('token-cache-error');
+    const cacheError = new Error('cache unavailable');
+    mock.method(cacheManager, 'getCache', () => {
+      throw cacheError;
+    });
+
+    await assert.rejects(() => api.getWatchlist(), cacheError);
+  });
+
+  it('skips items whose metadata request returns 404', async () => {
+    const api = new PlexTvAPI('token-404');
+    mock.method(getAxios(api), 'get', async (url: string) => {
+      if (url === '/library/sections/watchlist/all') {
+        return {
+          status: 200,
+          headers: { etag: '"fresh"' },
+          data: {
+            MediaContainer: { totalSize: 1, Metadata: [{ ratingKey: 'abc' }] },
+          },
+        };
+      }
+
+      if (url === '/library/metadata/abc') {
+        throw Object.assign(new Error('not found'), {
+          response: { status: 404 },
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 1,
+      items: [],
+    });
+  });
+
+  it('skips items whose metadata response contains no metadata', async () => {
+    const api = new PlexTvAPI('token-no-meta');
+    mock.method(getAxios(api), 'get', async (url: string) => {
+      if (url === '/library/sections/watchlist/all') {
+        return {
+          status: 200,
+          headers: { etag: '"fresh"' },
+          data: {
+            MediaContainer: {
+              totalSize: 2,
+              Metadata: [{ ratingKey: 'empty' }, { ratingKey: 'good' }],
+            },
+          },
+        };
+      }
+
+      if (url === '/library/metadata/empty') {
+        return { status: 200, data: { MediaContainer: {} } };
+      }
+
+      if (url === '/library/metadata/good') {
+        return {
+          status: 200,
+          data: {
+            MediaContainer: {
+              Metadata: [
+                {
+                  ratingKey: 'good',
+                  type: 'movie',
+                  title: 'Good Movie',
+                  Guid: [{ id: 'tmdb://550' }],
+                },
+              ],
+            },
+          },
+        };
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const result = await api.getWatchlist();
+
+    assert.deepEqual(result, {
+      offset: 0,
+      size: 20,
+      totalSize: 2,
+      items: [
+        {
+          ratingKey: 'good',
+          tmdbId: 550,
+          tvdbId: undefined,
+          title: 'Good Movie',
+          type: 'movie',
+        },
+      ],
+    });
+  });
+
+  it('propagates non-404 errors from metadata resolution', async () => {
+    const api = new PlexTvAPI('token-500');
+    mock.method(getAxios(api), 'get', async (url: string) => {
+      if (url === '/library/sections/watchlist/all') {
+        return {
+          status: 200,
+          headers: { etag: '"fresh"' },
+          data: {
+            MediaContainer: { totalSize: 1, Metadata: [{ ratingKey: 'abc' }] },
+          },
+        };
+      }
+
+      if (url === '/library/metadata/abc') {
+        throw Object.assign(new Error('upstream'), {
+          response: { status: 500 },
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await assert.rejects(
+      () => api.getWatchlist(),
+      (e: unknown) =>
+        (e as { response?: { status?: number } }).response?.status === 500
+    );
+  });
+});

--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -104,7 +104,28 @@ interface WatchlistResponse {
     Metadata?: {
       ratingKey: string;
     }[];
+    Video?: {
+      ratingKey: string;
+    }[];
   };
+}
+
+function isWatchlistResponse(data: unknown): data is WatchlistResponse {
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    !('MediaContainer' in data)
+  ) {
+    return false;
+  }
+
+  const { MediaContainer: container } = data as WatchlistResponse;
+  return (
+    typeof container === 'object' &&
+    container !== null &&
+    !Array.isArray(container) &&
+    typeof container.totalSize === 'number'
+  );
 }
 
 type PlexMetadataItem = {
@@ -116,7 +137,7 @@ type PlexMetadataItem = {
   }[];
 };
 interface MetadataResponse {
-  MediaContainer: {
+  MediaContainer?: {
     Metadata?: PlexMetadataItem[];
     Video?: PlexMetadataItem[];
   };
@@ -131,7 +152,7 @@ export interface PlexWatchlistItem {
 }
 
 export interface PlexWatchlistCache {
-  etag: string;
+  etag?: string;
   response: WatchlistResponse;
 }
 
@@ -277,11 +298,18 @@ class PlexTvAPI extends ExternalAPI {
     totalSize: number;
     items: PlexWatchlistItem[];
   }> {
+    const watchlistCache = cacheManager.getCache('plexwatchlist');
+    let cachedWatchlist = watchlistCache.data.get<PlexWatchlistCache>(
+      this.authToken
+    );
+
     try {
-      const watchlistCache = cacheManager.getCache('plexwatchlist');
-      let cachedWatchlist = watchlistCache.data.get<PlexWatchlistCache>(
-        this.authToken
-      );
+      // Drop poisoned entries so we don't send If-None-Match for a body
+      // without MediaContainer (which would 304 and keep failing).
+      if (cachedWatchlist && !isWatchlistResponse(cachedWatchlist.response)) {
+        watchlistCache.data.del(this.authToken);
+        cachedWatchlist = undefined;
+      }
 
       const response = await this.axios.get<WatchlistResponse>(
         '/library/sections/watchlist/all',
@@ -290,16 +318,20 @@ class PlexTvAPI extends ExternalAPI {
             'X-Plex-Container-Start': offset,
             'X-Plex-Container-Size': size,
           },
-          headers: {
-            'If-None-Match': cachedWatchlist?.etag,
-          },
+          headers: cachedWatchlist?.etag
+            ? { 'If-None-Match': cachedWatchlist.etag }
+            : undefined,
           baseURL: 'https://discover.provider.plex.tv',
           validateStatus: (status) => status < 400, // Allow HTTP 304 to return without error
         }
       );
 
       // If we don't recieve HTTP 304, the watchlist has been updated and we need to update the cache.
-      if (response.status >= 200 && response.status <= 299) {
+      if (
+        response.status >= 200 &&
+        response.status <= 299 &&
+        isWatchlistResponse(response.data)
+      ) {
         cachedWatchlist = {
           etag: response.headers.etag,
           response: response.data,
@@ -310,74 +342,6 @@ class PlexTvAPI extends ExternalAPI {
           cachedWatchlist
         );
       }
-
-      const watchlistDetails = await Promise.all(
-        (cachedWatchlist?.response.MediaContainer.Metadata ?? []).map(
-          async (watchlistItem) => {
-            let detailedResponse: MetadataResponse;
-            try {
-              detailedResponse = await this.getRolling<MetadataResponse>(
-                `/library/metadata/${watchlistItem.ratingKey}`,
-                {
-                  baseURL: 'https://discover.provider.plex.tv',
-                }
-              );
-            } catch (e) {
-              if (e.response?.status === 404) {
-                logger.warn(
-                  `Item with ratingKey ${watchlistItem.ratingKey} not found, it may have been removed from the server.`,
-                  { label: 'Plex.TV Metadata API' }
-                );
-                return null;
-              } else {
-                throw e;
-              }
-            }
-
-            const metadata =
-              detailedResponse.MediaContainer.Metadata?.[0] ??
-              detailedResponse.MediaContainer.Video?.[0];
-
-            if (!metadata) {
-              logger.warn(
-                `Item with ratingKey ${watchlistItem.ratingKey} returned no metadata, skipping.`,
-                { label: 'Plex.TV Metadata API' }
-              );
-              return null;
-            }
-
-            const tmdbString = metadata.Guid?.find((guid) =>
-              guid.id.startsWith('tmdb')
-            );
-            const tvdbString = metadata.Guid?.find((guid) =>
-              guid.id.startsWith('tvdb')
-            );
-
-            return {
-              ratingKey: metadata.ratingKey,
-              // This should always be set? But I guess it also cannot be?
-              // We will filter out the 0's afterwards
-              tmdbId: tmdbString ? Number(tmdbString.id.split('//')[1]) : 0,
-              tvdbId: tvdbString
-                ? Number(tvdbString.id.split('//')[1])
-                : undefined,
-              title: metadata.title,
-              type: metadata.type,
-            };
-          }
-        )
-      );
-
-      const filteredList = watchlistDetails.filter(
-        (detail) => detail?.tmdbId
-      ) as PlexWatchlistItem[];
-
-      return {
-        offset,
-        size,
-        totalSize: cachedWatchlist?.response.MediaContainer.totalSize ?? 0,
-        items: filteredList,
-      };
     } catch (e) {
       logger.error('Failed to retrieve watchlist items', {
         label: 'Plex.TV Metadata API',
@@ -390,6 +354,78 @@ class PlexTvAPI extends ExternalAPI {
         items: [],
       };
     }
+
+    const metadata = cachedWatchlist?.response.MediaContainer.Metadata;
+    const video = cachedWatchlist?.response.MediaContainer.Video;
+    const watchlistItems = Array.isArray(metadata)
+      ? metadata
+      : Array.isArray(video)
+        ? video
+        : [];
+
+    const watchlistDetails = await Promise.all(
+      watchlistItems.map(async (watchlistItem) => {
+        let detailedResponse: MetadataResponse;
+        try {
+          detailedResponse = await this.getRolling<MetadataResponse>(
+            `/library/metadata/${watchlistItem.ratingKey}`,
+            {
+              baseURL: 'https://discover.provider.plex.tv',
+            }
+          );
+        } catch (e) {
+          if (e.response?.status === 404) {
+            logger.warn(
+              `Item with ratingKey ${watchlistItem.ratingKey} not found, it may have been removed from the server.`,
+              { label: 'Plex.TV Metadata API' }
+            );
+            return null;
+          } else {
+            throw e;
+          }
+        }
+
+        const metadata =
+          detailedResponse.MediaContainer?.Metadata?.[0] ??
+          detailedResponse.MediaContainer?.Video?.[0];
+
+        if (!metadata) {
+          logger.debug(
+            `Item with ratingKey ${watchlistItem.ratingKey} returned no metadata, skipping.`,
+            { label: 'Plex.TV Metadata API' }
+          );
+          return null;
+        }
+
+        const tmdbString = metadata.Guid?.find((guid) =>
+          guid.id.startsWith('tmdb')
+        );
+        const tvdbString = metadata.Guid?.find((guid) =>
+          guid.id.startsWith('tvdb')
+        );
+
+        return {
+          ratingKey: metadata.ratingKey,
+          // This should always be set? But I guess it also cannot be?
+          // We will filter out the 0's afterwards
+          tmdbId: tmdbString ? Number(tmdbString.id.split('//')[1]) : 0,
+          tvdbId: tvdbString ? Number(tvdbString.id.split('//')[1]) : undefined,
+          title: metadata.title,
+          type: metadata.type,
+        };
+      })
+    );
+
+    const filteredList = watchlistDetails.filter(
+      (detail) => detail?.tmdbId
+    ) as PlexWatchlistItem[];
+
+    return {
+      offset,
+      size,
+      totalSize: cachedWatchlist?.response.MediaContainer.totalSize ?? 0,
+      items: filteredList,
+    };
   }
 
   public async pingToken() {


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When Plex Discover API hiccups, a request to `/library/sections/watchlist/all` can return (and that's a big CAN here) a `2xx` response with invalid data (error JSON, HTML, or an empty object).

Before, we treated this as a valid watchlist and cached it, causing watchlist item retrieval to fail for every user with the watchlist feature enabled.

This is hard to reproduce, and the bad response can get cached with an `ETag`, causing Discover to keep returning `304`s and reusing the poisoned cache.

Clearing Plex Watchlist (and Plex TV)'s cache, or restarting the container, fixes it. However this is not a viable solution.

This PR then validates watchlist responses before caching, keeps the last good cache when needed, and handles invalid or missing data gracefully.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchlist handling for additional video entry formats.
  * Invalid cached responses are discarded instead of reused.
  * Conditional requests are sent only when valid cache metadata is available.
  * Missing optional metadata is handled safely, while non-not-found errors continue to surface correctly.
* **Tests**
  * Added comprehensive coverage for malformed responses, caching, fetch failures, metadata handling, and item mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->