### PR TITLE
fix(requests): scope download status to requested seasons on request cards

### DIFF
--- a/server/test/index.mts
+++ b/server/test/index.mts
@@ -59,6 +59,9 @@ if (positionals.length > 0) {
   for await (const entry of glob(join(BASE_DIR, 'server/**/*.test.ts'))) {
     files.push(resolve(entry));
   }
+  for await (const entry of glob(join(BASE_DIR, 'src/**/*.test.ts'))) {
+    files.push(resolve(entry));
+  }
   files.sort();
 }
 

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -10,7 +10,10 @@ import useToasts from '@app/hooks/useToasts';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
+import {
+  getRequestDownloadStatus,
+  refreshIntervalHelper,
+} from '@app/utils/refreshIntervalHelper';
 import { withProperties } from '@app/utils/typeHelpers';
 import {
   ArrowPathIcon,
@@ -74,6 +77,15 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
     iOSPlexUrl: requestData?.media?.iOSPlexUrl,
     iOSPlexUrl4k: requestData?.media?.iOSPlexUrl4k,
   });
+
+  const requestDownloadStatus = getRequestDownloadStatus(
+    requestData?.media?.[
+      requestData?.is4k ? 'downloadStatus4k' : 'downloadStatus'
+    ],
+    requestData?.type === 'tv'
+      ? (requestData?.seasons ?? []).map((season) => season.seasonNumber)
+      : []
+  );
 
   const deleteRequest = async () => {
     await axios.delete(`/api/v1/media/${requestData?.media.id}`);
@@ -149,23 +161,9 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
                           requestData.is4k ? 'status4k' : 'status'
                         ]
                       }
-                      downloadItem={
-                        requestData.media[
-                          requestData.is4k
-                            ? 'downloadStatus4k'
-                            : 'downloadStatus'
-                        ]
-                      }
+                      downloadItem={requestDownloadStatus}
                       title={intl.formatMessage(messages.unknowntitle)}
-                      inProgress={
-                        (
-                          requestData.media[
-                            requestData.is4k
-                              ? 'downloadStatus4k'
-                              : 'downloadStatus'
-                          ] ?? []
-                        ).length > 0
-                      }
+                      inProgress={requestDownloadStatus.length > 0}
                       is4k={requestData.is4k}
                       mediaType={requestData.type}
                       plexUrl={requestData.is4k ? plexUrl4k : plexUrl}
@@ -327,6 +325,13 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
     return <RequestCardError requestData={requestData} />;
   }
 
+  const requestDownloadStatus = getRequestDownloadStatus(
+    requestData.media[requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'],
+    requestData.type === 'tv'
+      ? requestData.seasons.map((season) => season.seasonNumber)
+      : []
+  );
+
   return (
     <>
       <RequestModal
@@ -457,19 +462,9 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
                 status={
                   requestData.media[requestData.is4k ? 'status4k' : 'status']
                 }
-                downloadItem={
-                  requestData.media[
-                    requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'
-                  ]
-                }
+                downloadItem={requestDownloadStatus}
                 title={isMovie(title) ? title.title : title.name}
-                inProgress={
-                  (
-                    requestData.media[
-                      requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'
-                    ] ?? []
-                  ).length > 0
-                }
+                inProgress={requestDownloadStatus.length > 0}
                 is4k={requestData.is4k}
                 tmdbId={requestData.media.tmdbId}
                 mediaType={requestData.type}

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -10,7 +10,10 @@ import useToasts from '@app/hooks/useToasts';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
+import {
+  getRequestDownloadStatus,
+  refreshIntervalHelper,
+} from '@app/utils/refreshIntervalHelper';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -80,6 +83,15 @@ const RequestItemError = ({
     iOSPlexUrl4k: requestData?.media?.iOSPlexUrl4k,
   });
 
+  const requestDownloadStatus = getRequestDownloadStatus(
+    requestData?.media?.[
+      requestData?.is4k ? 'downloadStatus4k' : 'downloadStatus'
+    ],
+    requestData?.type === 'tv'
+      ? (requestData?.seasons ?? []).map((season) => season.seasonNumber)
+      : []
+  );
+
   return (
     <div className="flex h-64 w-full flex-col justify-center rounded-xl bg-gray-800 py-4 text-gray-400 shadow-md ring-1 ring-red-500 xl:h-28 xl:flex-row">
       <div className="flex w-full flex-col justify-between overflow-hidden sm:flex-row">
@@ -139,21 +151,9 @@ const RequestItemError = ({
                         requestData.is4k ? 'status4k' : 'status'
                       ]
                     }
-                    downloadItem={
-                      requestData.media[
-                        requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'
-                      ]
-                    }
+                    downloadItem={requestDownloadStatus}
                     title={intl.formatMessage(messages.unknowntitle)}
-                    inProgress={
-                      (
-                        requestData.media[
-                          requestData.is4k
-                            ? 'downloadStatus4k'
-                            : 'downloadStatus'
-                        ] ?? []
-                      ).length > 0
-                    }
+                    inProgress={requestDownloadStatus.length > 0}
                     is4k={requestData.is4k}
                     mediaType={requestData.type}
                     plexUrl={requestData.is4k ? plexUrl4k : plexUrl}
@@ -414,6 +414,13 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
     );
   }
 
+  const requestDownloadStatus = getRequestDownloadStatus(
+    requestData.media[requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'],
+    requestData.type === 'tv'
+      ? requestData.seasons.map((season) => season.seasonNumber)
+      : []
+  );
+
   return (
     <>
       <RequestModal
@@ -540,19 +547,9 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                   status={
                     requestData.media[requestData.is4k ? 'status4k' : 'status']
                   }
-                  downloadItem={
-                    requestData.media[
-                      requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'
-                    ]
-                  }
+                  downloadItem={requestDownloadStatus}
                   title={isMovie(title) ? title.title : title.name}
-                  inProgress={
-                    (
-                      requestData.media[
-                        requestData.is4k ? 'downloadStatus4k' : 'downloadStatus'
-                      ] ?? []
-                    ).length > 0
-                  }
+                  inProgress={requestDownloadStatus.length > 0}
                   is4k={requestData.is4k}
                   tmdbId={requestData.media.tmdbId}
                   mediaType={requestData.type}

--- a/src/utils/refreshIntervalHelper.test.ts
+++ b/src/utils/refreshIntervalHelper.test.ts
@@ -1,0 +1,127 @@
+import { MediaType } from '@server/constants/media';
+import type { DownloadingItem } from '@server/lib/downloadtracker';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getRequestDownloadStatus } from './refreshIntervalHelper';
+
+const createDownloadItem = (
+  overrides: Partial<DownloadingItem> & Pick<DownloadingItem, 'downloadId'>
+): DownloadingItem => ({
+  mediaType: MediaType.TV,
+  externalId: 1,
+  size: 1000,
+  sizeLeft: 500,
+  status: 'downloading',
+  timeLeft: '00:05:00',
+  estimatedCompletionTime: new Date('2026-01-01T00:00:00Z'),
+  title: 'Test Show',
+  ...overrides,
+});
+
+const getRequestStatus = (
+  downloadStatus: DownloadingItem[] | undefined,
+  seasonNumbers: number[]
+) => {
+  const downloadItem = getRequestDownloadStatus(downloadStatus, seasonNumbers);
+
+  return {
+    downloadItem,
+    inProgress: downloadItem.length > 0,
+  };
+};
+
+describe('getRequestDownloadStatus', () => {
+  it('returns an empty array when downloadStatus is undefined', () => {
+    const status = getRequestStatus(undefined, [1]);
+
+    assert.deepEqual(status.downloadItem, []);
+    assert.equal(status.inProgress, false);
+  });
+
+  it('returns all items when seasonNumbers is empty', () => {
+    const movieDownload = createDownloadItem({
+      downloadId: 'movie-1',
+      mediaType: MediaType.MOVIE,
+    });
+    const tvDownload = createDownloadItem({
+      downloadId: 'tv-1',
+      episode: {
+        id: 1,
+        seasonNumber: 2,
+        episodeNumber: 3,
+        absoluteEpisodeNumber: 3,
+      },
+    });
+    const downloads = [movieDownload, tvDownload];
+
+    const status = getRequestStatus(downloads, []);
+
+    assert.deepEqual(status.downloadItem, downloads);
+    assert.equal(status.inProgress, true);
+  });
+
+  it('returns only items whose episode season matches the request seasons', () => {
+    const seasonOne = createDownloadItem({
+      downloadId: 's1',
+      episode: {
+        id: 1,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        absoluteEpisodeNumber: 1,
+      },
+    });
+    const seasonThree = createDownloadItem({
+      downloadId: 's3',
+      episode: {
+        id: 3,
+        seasonNumber: 3,
+        episodeNumber: 1,
+        absoluteEpisodeNumber: 10,
+      },
+    });
+    const downloads = [seasonOne, seasonThree];
+
+    const status = getRequestStatus(downloads, [3]);
+
+    assert.deepEqual(status.downloadItem, [seasonThree]);
+    assert.equal(status.inProgress, true);
+  });
+
+  it('returns an empty array when no items match the request seasons', () => {
+    const seasonThree = createDownloadItem({
+      downloadId: 's3',
+      episode: {
+        id: 3,
+        seasonNumber: 3,
+        episodeNumber: 1,
+        absoluteEpisodeNumber: 10,
+      },
+    });
+
+    const status = getRequestStatus([seasonThree], [1, 2]);
+
+    assert.deepEqual(status.downloadItem, []);
+    assert.equal(status.inProgress, false);
+  });
+
+  it('excludes items without episode metadata when filtering by season', () => {
+    const withoutEpisode = createDownloadItem({
+      downloadId: 'missing-episode',
+    });
+    const seasonTwo = createDownloadItem({
+      downloadId: 's2',
+      episode: {
+        id: 2,
+        seasonNumber: 2,
+        episodeNumber: 4,
+        absoluteEpisodeNumber: 4,
+      },
+    });
+    const downloads = [withoutEpisode, seasonTwo];
+
+    const status = getRequestStatus(downloads, [2]);
+
+    assert.deepEqual(status.downloadItem, [seasonTwo]);
+    assert.equal(status.inProgress, true);
+  });
+});

--- a/src/utils/refreshIntervalHelper.ts
+++ b/src/utils/refreshIntervalHelper.ts
@@ -1,5 +1,20 @@
 import type { DownloadingItem } from '@server/lib/downloadtracker';
 
+export const getRequestDownloadStatus = (
+  downloadStatus: DownloadingItem[] | undefined,
+  seasonNumbers: number[]
+): DownloadingItem[] => {
+  const items = downloadStatus ?? [];
+
+  if (!seasonNumbers.length) {
+    return items;
+  }
+
+  return items.filter(
+    (item) => item.episode && seasonNumbers.includes(item.episode.seasonNumber)
+  );
+};
+
 export const refreshIntervalHelper = (
   downloadItem: {
     downloadStatus: DownloadingItem[] | undefined;


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR fixes request cards showing another season's processing state when the same show has multiple season requests.

Each card already shows the right season number, but the status badge was reading the shared `media.downloadStatus` for the whole show. For example, if S3 was downloading, every **Locke & Key** card said "Processing S3", including the S1 and S2 ones.

> [!NOTE]
> Since the test lives in `src/`, `pnpm lint` was complaining about the import path, I had to "fix" this as well.

## How Has This Been Tested?

Put fake requests to dev instance to reproduce prod issue + unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

#### Before
<img width="1434" height="244" alt="image" src="https://github.com/user-attachments/assets/67849ad8-ed5a-40a3-a508-e0d6d7ec8d17" />

#### After
<img width="1097" height="247" alt="image" src="https://github.com/user-attachments/assets/bedb9922-b0d8-4aa5-83f6-ad351ed0afe5" />

This also applies to the **Requests** list page.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download status indicators for movie and TV requests.
  - TV request statuses now accurately reflect downloads for the selected seasons.
  - Corrected in-progress indicators when download information is missing, incomplete, or filtered.
  - Applied consistent status handling across request cards and request lists.

- **Tests**
  - Added coverage for filtered, unfiltered, unavailable, and incomplete download statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->