### PR TITLE
feat(requests): allow different users to request already available media

### DIFF
--- a/server/api/servarr/radarr.test.ts
+++ b/server/api/servarr/radarr.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, mock } from 'node:test';
 
 import type { AxiosInstance } from 'axios';
 
+import type { RadarrMovieOptions } from '@server/api/servarr/radarr';
 import RadarrAPI from '@server/api/servarr/radarr';
 
 function buildRadarr(): RadarrAPI {
@@ -11,6 +12,39 @@ function buildRadarr(): RadarrAPI {
 
 function getAxios(radarr: RadarrAPI): AxiosInstance {
   return (radarr as unknown as { axios: AxiosInstance }).axios;
+}
+
+function baseOptions(
+  overrides: Partial<RadarrMovieOptions> = {}
+): RadarrMovieOptions {
+  return {
+    title: 'Test Movie',
+    qualityProfileId: 1,
+    minimumAvailability: 'released',
+    tags: [],
+    profileId: 1,
+    year: 1999,
+    rootFolderPath: '/movies',
+    tmdbId: 550,
+    monitored: true,
+    ...overrides,
+  };
+}
+
+function getMergeTags(
+  radarr: RadarrAPI
+): (
+  existing: number[],
+  incoming?: number[]
+) => { tags: number[]; changed: boolean } {
+  return (
+    radarr as unknown as {
+      mergeTags: (
+        existing: number[],
+        incoming?: number[]
+      ) => { tags: number[]; changed: boolean };
+    }
+  ).mergeTags.bind(radarr);
 }
 
 describe('RadarrAPI removeMovie', () => {
@@ -89,6 +123,163 @@ describe('RadarrAPI removeMovie', () => {
         (e as { response?: { status?: number } }).response?.status === 404
     );
     assert.strictEqual(del.mock.callCount(), 0);
+  });
+});
+
+describe('RadarrAPI mergeTags', () => {
+  it('returns existing tags unchanged when no incoming tags are given', () => {
+    const radarr = buildRadarr();
+    const result = getMergeTags(radarr)([1, 2], undefined);
+    assert.deepStrictEqual(result, { tags: [1, 2], changed: false });
+  });
+
+  it('reports unchanged when incoming tags are already a subset of existing tags', () => {
+    const radarr = buildRadarr();
+    const result = getMergeTags(radarr)([1, 2, 3], [2]);
+    assert.strictEqual(result.changed, false);
+    assert.deepStrictEqual(result.tags, [1, 2, 3]);
+  });
+
+  it('merges in new tags and reports changed', () => {
+    const radarr = buildRadarr();
+    const result = getMergeTags(radarr)([1, 2], [2, 3]);
+    assert.strictEqual(result.changed, true);
+    assert.deepStrictEqual(result.tags, [1, 2, 3]);
+  });
+});
+
+describe('RadarrAPI addMovie', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('merges the requester tag when the movie already has a file', async () => {
+    const radarr = buildRadarr();
+    mock.method(RadarrAPI.prototype, 'getMovieByTmdbId', async () => ({
+      id: 7,
+      title: 'Test Movie',
+      hasFile: true,
+      tags: [1, 2],
+    }));
+    const put = mock.method(
+      getAxios(radarr),
+      'put',
+      async (_url: string, body: unknown) => ({
+        data: { ...(body as Record<string, unknown>), id: 7 },
+      })
+    );
+
+    const result = await radarr.addMovie(baseOptions({ tags: [3] }));
+
+    assert.strictEqual(put.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      (put.mock.calls[0].arguments[1] as { tags: number[] }).tags,
+      [1, 2, 3]
+    );
+    assert.strictEqual(result.id, 7);
+  });
+
+  it('skips the PUT when the movie already has a file and no new tags to add', async () => {
+    const radarr = buildRadarr();
+    mock.method(RadarrAPI.prototype, 'getMovieByTmdbId', async () => ({
+      id: 7,
+      title: 'Test Movie',
+      hasFile: true,
+      tags: [1, 2],
+    }));
+    const put = mock.method(getAxios(radarr), 'put', async () => ({
+      data: {},
+    }));
+
+    const result = await radarr.addMovie(baseOptions({ tags: [1] }));
+
+    assert.strictEqual(put.mock.callCount(), 0);
+    assert.strictEqual(result.id, 7);
+  });
+
+  it('merges the requester tag when the movie is monitored but not yet downloaded', async () => {
+    const radarr = buildRadarr();
+    mock.method(RadarrAPI.prototype, 'getMovieByTmdbId', async () => ({
+      id: 7,
+      title: 'Test Movie',
+      hasFile: false,
+      monitored: true,
+      tags: [1],
+    }));
+    const put = mock.method(
+      getAxios(radarr),
+      'put',
+      async (_url: string, body: unknown) => ({
+        data: { ...(body as Record<string, unknown>), id: 7, hasFile: false },
+      })
+    );
+    const search = mock.method(
+      RadarrAPI.prototype,
+      'searchMovie',
+      async () => undefined
+    );
+
+    await radarr.addMovie(baseOptions({ tags: [2], searchNow: false }));
+
+    assert.strictEqual(put.mock.callCount(), 1);
+    assert.deepStrictEqual(
+      (put.mock.calls[0].arguments[1] as { tags: number[] }).tags,
+      [1, 2]
+    );
+    assert.strictEqual(search.mock.callCount(), 0);
+  });
+
+  it('triggers a search after merging tags when searchNow is set and the movie has no file', async () => {
+    const radarr = buildRadarr();
+    mock.method(RadarrAPI.prototype, 'getMovieByTmdbId', async () => ({
+      id: 7,
+      title: 'Test Movie',
+      hasFile: false,
+      monitored: true,
+      tags: [1],
+    }));
+    mock.method(
+      getAxios(radarr),
+      'put',
+      async (_url: string, body: unknown) => ({
+        data: { ...(body as Record<string, unknown>), id: 7, hasFile: false },
+      })
+    );
+    const search = mock.method(
+      RadarrAPI.prototype,
+      'searchMovie',
+      async () => undefined
+    );
+
+    await radarr.addMovie(baseOptions({ tags: [2], searchNow: true }));
+
+    assert.strictEqual(search.mock.callCount(), 1);
+    assert.strictEqual(search.mock.calls[0].arguments[0], 7);
+  });
+
+  it('leaves an already-monitored movie with no new tags unchanged (regression guard)', async () => {
+    const radarr = buildRadarr();
+    mock.method(RadarrAPI.prototype, 'getMovieByTmdbId', async () => ({
+      id: 7,
+      title: 'Test Movie',
+      hasFile: false,
+      monitored: true,
+      tags: [1],
+    }));
+    const put = mock.method(getAxios(radarr), 'put', async () => ({
+      data: {},
+    }));
+    const search = mock.method(
+      RadarrAPI.prototype,
+      'searchMovie',
+      async () => undefined
+    );
+
+    const result = await radarr.addMovie(
+      baseOptions({ tags: [1], searchNow: false })
+    );
+
+    assert.strictEqual(put.mock.callCount(), 0);
+    assert.strictEqual(search.mock.callCount(), 0);
+    assert.strictEqual(result.id, 7);
   });
 });
 

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -1,5 +1,6 @@
 import logger from '@server/logger';
 import type { AxiosResponse } from 'axios';
+import { isEqual } from 'lodash';
 import ServarrBase from './base';
 
 export interface RadarrMovieOptions {
@@ -124,16 +125,36 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
       const movie = await this.getMovieByTmdbId(options.tmdbId);
 
       if (movie.hasFile) {
+        const { tags: mergedTags, changed } = this.mergeTags(
+          movie.tags,
+          options.tags
+        );
+
+        if (!changed) {
+          logger.info(
+            'Title already exists and is available. Skipping add and returning success',
+            {
+              label: 'Radarr',
+              movie,
+            }
+          );
+          return movie;
+        }
+
+        const response = await this.axios.put<RadarrMovie>(`/movie`, {
+          ...movie,
+          tags: mergedTags,
+        });
         logger.info(
-          'Title already exists and is available. Skipping add and returning success',
+          'Title already exists and is available. Merged requester tag.',
           {
             label: 'Radarr',
-            movie,
+            movieId: response.data.id,
+            movieTitle: response.data.title,
           }
         );
-        return movie;
+        return response.data;
       }
-
       // movie exists in Radarr but is neither downloaded nor monitored
       if (movie.id && !movie.monitored) {
         const response = await this.axios.put<RadarrMovie>(`/movie`, {
@@ -183,27 +204,48 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
 
       if (movie.id) {
         // Movie exists and is already monitored
-        logger.info('Movie is already monitored in Radarr.', {
-          label: 'Radarr',
-          movieId: movie.id,
-          movieTitle: movie.title,
-          hasFile: movie.hasFile,
-        });
+        const { tags: mergedTags, changed: tagsChanged } = this.mergeTags(
+          movie.tags,
+          options.tags
+        );
 
+        let current = movie;
+        if (tagsChanged) {
+          const response = await this.axios.put<RadarrMovie>(`/movie`, {
+            ...movie,
+            tags: mergedTags,
+          });
+          logger.info(
+            'Movie already exists in Radarr and merged requester tag.',
+            {
+              label: 'Radarr',
+              movieId: response.data.id,
+              movieTitle: response.data.title,
+            }
+          );
+          current = response.data;
+        } else {
+          logger.info('Movie is already monitored in Radarr.', {
+            label: 'Radarr',
+            movieId: movie.id,
+            movieTitle: movie.title,
+            hasFile: movie.hasFile,
+          });
+        }
         // If searchNow is requested and movie doesn't have a file, trigger search
         if (options.searchNow && !movie.hasFile) {
           logger.info(
             'Triggering search for existing monitored movie without file',
             {
               label: 'Radarr',
-              movieId: movie.id,
-              movieTitle: movie.title,
+              movieId: current.id,
+              movieTitle: current.title,
             }
           );
-          this.searchMovie(movie.id);
+          this.searchMovie(current.id);
         }
 
-        return movie;
+        return current;
       }
 
       const response = await this.axios.post<RadarrMovie>(`/movie`, {
@@ -249,6 +291,18 @@ class RadarrAPI extends ServarrBase<{ movieId: number }> {
       throw new Error('Failed to add movie to Radarr', { cause: e });
     }
   };
+
+  private mergeTags(
+    existingTags: number[],
+    incomingTags?: number[]
+  ): { tags: number[]; changed: boolean } {
+    if (!incomingTags) {
+      return { tags: existingTags, changed: false };
+    }
+    const merged = Array.from(new Set([...existingTags, ...incomingTags]));
+    const changed = !isEqual(new Set(merged), new Set(existingTags));
+    return { tags: merged, changed };
+  }
 
   public async searchMovie(movieId: number): Promise<void> {
     logger.info('Executing movie search command', {

--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import ExternalAPI from '@server/api/externalapi';
+import { MediaType } from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import {
+  DuplicateMediaRequestError,
+  MediaRequest,
+  QuotaRestrictedError,
+} from '@server/entity/MediaRequest';
+import { User } from '@server/entity/User';
+import { setupTestDb } from '@server/test/db';
+
+// get is a prototype method unlike getMovie, and replaces the cache lookup too
+const externalApiGetMock = mock.method(
+  ExternalAPI.prototype as unknown as {
+    get: (endpoint: string) => Promise<unknown>;
+  },
+  'get',
+  async (endpoint: string) => {
+    const movieId = Number(endpoint.replace('/movie/', ''));
+
+    if (!movieId) {
+      throw new Error(`Unstubbed external endpoint: ${endpoint}`);
+    }
+
+    return {
+      id: movieId,
+      external_ids: {},
+      // Skips getMovie's localized fallback call
+      videos: { results: [{ type: 'Trailer', key: 'trailer' }] },
+    };
+  }
+).mock;
+
+mock.method(MediaRequest, 'sendNotification', async () => undefined);
+
+setupTestDb();
+
+beforeEach(() => {
+  externalApiGetMock.resetCalls();
+});
+
+async function seedRequester(movieQuotaLimit: number): Promise<User> {
+  const userRepository = getRepository(User);
+
+  const requester = await userRepository.findOneOrFail({
+    where: { email: 'friend@seerr.dev' },
+  });
+  requester.movieQuotaLimit = movieQuotaLimit;
+
+  return userRepository.save(requester);
+}
+
+function requestMovies(mediaIds: number[], requester: User) {
+  return Promise.allSettled(
+    mediaIds.map((mediaId) =>
+      MediaRequest.request(
+        { mediaId, mediaType: MediaType.MOVIE, is4k: false },
+        requester
+      )
+    )
+  );
+}
+
+function rejections(results: PromiseSettledResult<MediaRequest>[]) {
+  return results.filter(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  );
+}
+
+describe('MediaRequest.request', () => {
+  it('rejects the second of two concurrent requests at the movie quota', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(1);
+
+    const results = await requestMovies([11111, 22222], requester);
+    const rejected = rejections(results);
+
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof QuotaRestrictedError);
+    assert.strictEqual(await requestRepository.count(), 1);
+    assert.strictEqual(externalApiGetMock.callCount(), 1);
+  });
+
+  it('rejects a concurrent duplicate request for the same movie', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(5);
+
+    const results = await requestMovies([33333, 33333], requester);
+    const rejected = rejections(results);
+
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof DuplicateMediaRequestError);
+    assert.strictEqual(await requestRepository.count(), 1);
+    assert.strictEqual(externalApiGetMock.callCount(), 2);
+  });
+});

--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -9,7 +9,9 @@ import {
   MediaRequest,
   QuotaRestrictedError,
 } from '@server/entity/MediaRequest';
+import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
+import { Permission } from '@server/lib/permissions';
 import { setupTestDb } from '@server/test/db';
 
 // get is a prototype method unlike getMovie, and replaces the cache lookup too
@@ -19,15 +21,16 @@ const externalApiGetMock = mock.method(
   },
   'get',
   async (endpoint: string) => {
-    const movieId = Number(endpoint.replace('/movie/', ''));
+    const tmdbId = Number(endpoint.replace(/^\/(movie|tv)\//, ''));
 
-    if (!movieId) {
+    if (!tmdbId) {
       throw new Error(`Unstubbed external endpoint: ${endpoint}`);
     }
 
     return {
-      id: movieId,
+      id: tmdbId,
       external_ids: {},
+      seasons: [1, 2, 3].map((season_number) => ({ season_number })),
       // Skips getMovie's localized fallback call
       videos: { results: [{ type: 'Trailer', key: 'trailer' }] },
     };
@@ -51,6 +54,12 @@ async function seedRequester(movieQuotaLimit: number): Promise<User> {
   requester.movieQuotaLimit = movieQuotaLimit;
 
   return userRepository.save(requester);
+}
+
+async function createRequester(email: string): Promise<User> {
+  return getRepository(User).save(
+    new User({ email, permissions: Permission.REQUEST, avatar: '' })
+  );
 }
 
 function requestMovies(mediaIds: number[], requester: User) {
@@ -95,5 +104,69 @@ describe('MediaRequest.request', () => {
     assert.ok(rejected[0].reason instanceof DuplicateMediaRequestError);
     assert.strictEqual(await requestRepository.count(), 1);
     assert.strictEqual(externalApiGetMock.callCount(), 2);
+  });
+
+  it('rejects a duplicate request that omits is4k', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(5);
+    const body = { mediaId: 66666, mediaType: MediaType.MOVIE };
+
+    await MediaRequest.request(body, requester);
+
+    await assert.rejects(
+      () => MediaRequest.request(body, requester),
+      DuplicateMediaRequestError
+    );
+    assert.strictEqual(await requestRepository.count(), 1);
+  });
+
+  it('rejects a concurrent duplicate request from a different user', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const requester = await seedRequester(5);
+    const otherRequester = await createRequester('second@seerr.dev');
+
+    const results = await Promise.allSettled(
+      [requester, otherRequester].map((user) =>
+        MediaRequest.request(
+          { mediaId: 44444, mediaType: MediaType.MOVIE, is4k: false },
+          user
+        )
+      )
+    );
+    const rejected = rejections(results);
+
+    assert.strictEqual(rejected.length, 1);
+    assert.ok(rejected[0].reason instanceof DuplicateMediaRequestError);
+    assert.strictEqual(await requestRepository.count(), 1);
+  });
+
+  it('gives an overlapping season to only one of two concurrent users', async () => {
+    const seasonRequestRepository = getRepository(SeasonRequest);
+    const requester = await seedRequester(5);
+    const otherRequester = await createRequester('second@seerr.dev');
+
+    const results = await Promise.allSettled(
+      [
+        [requester, [1, 2]],
+        [otherRequester, [2, 3]],
+      ].map(([user, seasons]) =>
+        MediaRequest.request(
+          {
+            mediaId: 55555,
+            mediaType: MediaType.TV,
+            seasons: seasons as number[],
+            is4k: false,
+          },
+          user as User
+        )
+      )
+    );
+
+    assert.strictEqual(rejections(results).length, 0);
+    assert.strictEqual(
+      await seasonRequestRepository.count({ where: { seasonNumber: 2 } }),
+      1
+    );
+    assert.strictEqual(await seasonRequestRepository.count(), 3);
   });
 });

--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -2,13 +2,15 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it, mock } from 'node:test';
 
 import ExternalAPI from '@server/api/externalapi';
-import { MediaType } from '@server/constants/media';
+import { MediaStatus, MediaType } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
 import {
   DuplicateMediaRequestError,
   MediaRequest,
   QuotaRestrictedError,
 } from '@server/entity/MediaRequest';
+import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
 import { Permission } from '@server/lib/permissions';
@@ -168,5 +170,130 @@ describe('MediaRequest.request', () => {
       1
     );
     assert.strictEqual(await seasonRequestRepository.count(), 3);
+  });
+
+  it('allows a different user to request a movie once it is already available', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const mediaRepository = getRepository(Media);
+    const requester = await seedRequester(5);
+    const otherRequester = await createRequester('second@seerr.dev');
+
+    await MediaRequest.request(
+      { mediaId: 77777, mediaType: MediaType.MOVIE, is4k: false },
+      requester
+    );
+
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 77777, mediaType: MediaType.MOVIE },
+    });
+    // Use a raw update, not save(), so MediaSubscriber's auto-complete-on-
+    // available cascade doesn't fire and change the first request's status
+    // out from under this test.
+    await mediaRepository.update(media.id, { status: MediaStatus.AVAILABLE });
+
+    const second = await MediaRequest.request(
+      { mediaId: 77777, mediaType: MediaType.MOVIE, is4k: false },
+      otherRequester
+    );
+
+    assert.strictEqual(second.requestedBy.id, otherRequester.id);
+    assert.strictEqual(await requestRepository.count(), 2);
+  });
+
+  it('still blocks the same user from requesting a movie again even once it is available', async () => {
+    const mediaRepository = getRepository(Media);
+    const requester = await seedRequester(5);
+
+    await MediaRequest.request(
+      { mediaId: 88888, mediaType: MediaType.MOVIE, is4k: false },
+      requester
+    );
+
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 88888, mediaType: MediaType.MOVIE },
+    });
+    await mediaRepository.update(media.id, { status: MediaStatus.AVAILABLE });
+
+    await assert.rejects(
+      () =>
+        MediaRequest.request(
+          { mediaId: 88888, mediaType: MediaType.MOVIE, is4k: false },
+          requester
+        ),
+      DuplicateMediaRequestError
+    );
+  });
+
+  it('allows a different user to request a season already held by another active request once that season is available', async () => {
+    const seasonRequestRepository = getRepository(SeasonRequest);
+    const mediaRepository = getRepository(Media);
+    const seasonRepository = getRepository(Season);
+    const requester = await seedRequester(5);
+    const otherRequester = await createRequester('second@seerr.dev');
+
+    await MediaRequest.request(
+      { mediaId: 99999, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      requester
+    );
+
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 99999, mediaType: MediaType.TV },
+    });
+    await seasonRepository.save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+
+    const second = await MediaRequest.request(
+      { mediaId: 99999, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      otherRequester
+    );
+
+    assert.strictEqual(second.requestedBy.id, otherRequester.id);
+    assert.strictEqual(
+      await seasonRequestRepository.count({ where: { seasonNumber: 1 } }),
+      2
+    );
+  });
+
+  it('allows requesting an already-available season that has no existing request at all', async () => {
+    const mediaRepository = getRepository(Media);
+    const seasonRepository = getRepository(Season);
+    const requester = await createRequester('third@seerr.dev');
+
+    // Seed the media/season directly with no prior request, mirroring a
+    // title whose availability was picked up by a library scan rather than
+    // a request.
+    const media = await mediaRepository.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId: 111111,
+        status: MediaStatus.UNKNOWN,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+    await seasonRepository.save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+
+    const request = await MediaRequest.request(
+      { mediaId: 111111, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      requester
+    );
+
+    assert.strictEqual(request.requestedBy.id, requester.id);
+    assert.strictEqual(
+      request.seasons.map((s) => s.seasonNumber).includes(1),
+      true
+    );
   });
 });

--- a/server/entity/MediaRequest.test.ts
+++ b/server/entity/MediaRequest.test.ts
@@ -2,12 +2,17 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it, mock } from 'node:test';
 
 import ExternalAPI from '@server/api/externalapi';
-import { MediaStatus, MediaType } from '@server/constants/media';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import {
   DuplicateMediaRequestError,
   MediaRequest,
+  NoSeasonsAvailableError,
   QuotaRestrictedError,
 } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
@@ -224,6 +229,60 @@ describe('MediaRequest.request', () => {
     );
   });
 
+  it('still blocks the same user from requesting a movie again once their own request is COMPLETED and the media is still available', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const mediaRepository = getRepository(Media);
+    const requester = await seedRequester(5);
+
+    const first = await MediaRequest.request(
+      { mediaId: 77776, mediaType: MediaType.MOVIE, is4k: false },
+      requester
+    );
+    // Raw updates, not save(), so MediaSubscriber's afterUpdate cascade
+    // doesn't fire and interfere with this test's isolated setup.
+    await requestRepository.update(first.id, {
+      status: MediaRequestStatus.COMPLETED,
+    });
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 77776, mediaType: MediaType.MOVIE },
+    });
+    await mediaRepository.update(media.id, { status: MediaStatus.AVAILABLE });
+
+    await assert.rejects(
+      () =>
+        MediaRequest.request(
+          { mediaId: 77776, mediaType: MediaType.MOVIE, is4k: false },
+          requester
+        ),
+      DuplicateMediaRequestError
+    );
+  });
+
+  it('allows the same user to re-request a movie once their COMPLETED request no longer has available media (e.g. it was deleted)', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const mediaRepository = getRepository(Media);
+    const requester = await seedRequester(5);
+
+    const first = await MediaRequest.request(
+      { mediaId: 77775, mediaType: MediaType.MOVIE, is4k: false },
+      requester
+    );
+    await requestRepository.update(first.id, {
+      status: MediaRequestStatus.COMPLETED,
+    });
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 77775, mediaType: MediaType.MOVIE },
+    });
+    await mediaRepository.update(media.id, { status: MediaStatus.DELETED });
+
+    const second = await MediaRequest.request(
+      { mediaId: 77775, mediaType: MediaType.MOVIE, is4k: false },
+      requester
+    );
+
+    assert.strictEqual(second.requestedBy.id, requester.id);
+  });
+
   it('allows a different user to request a season already held by another active request once that season is available', async () => {
     const seasonRequestRepository = getRepository(SeasonRequest);
     const mediaRepository = getRepository(Media);
@@ -295,5 +354,78 @@ describe('MediaRequest.request', () => {
       request.seasons.map((s) => s.seasonNumber).includes(1),
       true
     );
+  });
+
+  it('still blocks the same user from requesting a season again once their own request is COMPLETED and the season is still available', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const mediaRepository = getRepository(Media);
+    const seasonRepository = getRepository(Season);
+    const requester = await seedRequester(5);
+
+    const first = await MediaRequest.request(
+      { mediaId: 111112, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      requester
+    );
+    await requestRepository.update(first.id, {
+      status: MediaRequestStatus.COMPLETED,
+    });
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 111112, mediaType: MediaType.TV },
+    });
+    await seasonRepository.save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+
+    await assert.rejects(
+      () =>
+        MediaRequest.request(
+          {
+            mediaId: 111112,
+            mediaType: MediaType.TV,
+            seasons: [1],
+            is4k: false,
+          },
+          requester
+        ),
+      NoSeasonsAvailableError
+    );
+  });
+
+  it('allows the same user to re-request a season once their COMPLETED request season is no longer available (e.g. it was deleted)', async () => {
+    const requestRepository = getRepository(MediaRequest);
+    const mediaRepository = getRepository(Media);
+    const seasonRepository = getRepository(Season);
+    const requester = await seedRequester(5);
+
+    const first = await MediaRequest.request(
+      { mediaId: 111113, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      requester
+    );
+    await requestRepository.update(first.id, {
+      status: MediaRequestStatus.COMPLETED,
+    });
+    const media = await mediaRepository.findOneOrFail({
+      where: { tmdbId: 111113, mediaType: MediaType.TV },
+    });
+    await seasonRepository.save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.DELETED,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+
+    const second = await MediaRequest.request(
+      { mediaId: 111113, mediaType: MediaType.TV, seasons: [1], is4k: false },
+      requester
+    );
+
+    assert.strictEqual(second.requestedBy.id, requester.id);
   });
 });

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -14,6 +14,7 @@ import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
+import requestLock from '@server/utils/requestLock';
 import { truncate } from 'lodash';
 import {
   AfterInsert,
@@ -48,6 +49,16 @@ export class MediaRequest {
     requestBody: MediaRequestBody,
     user: User,
     options: MediaRequestOptions = {}
+  ): Promise<MediaRequest> {
+    return requestLock.dispatch(requestBody.userId || user.id, () =>
+      MediaRequest.createRequest(requestBody, user, options)
+    );
+  }
+
+  private static async createRequest(
+    requestBody: MediaRequestBody,
+    user: User,
+    options: MediaRequestOptions
   ): Promise<MediaRequest> {
     const tmdb = new TheMovieDb();
     const mediaRepository = getRepository(Media);

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -14,7 +14,7 @@ import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
-import requestLock from '@server/utils/requestLock';
+import requestLock, { mediaLock } from '@server/utils/requestLock';
 import { truncate } from 'lodash';
 import {
   AfterInsert,
@@ -50,8 +50,13 @@ export class MediaRequest {
     user: User,
     options: MediaRequestOptions = {}
   ): Promise<MediaRequest> {
-    return requestLock.dispatch(requestBody.userId || user.id, () =>
-      MediaRequest.createRequest(requestBody, user, options)
+    // is4k is optional, and an undefined one binds as null in the duplicate query
+    const body = { ...requestBody, is4k: !!requestBody.is4k };
+
+    return requestLock.dispatch(body.userId || user.id, () =>
+      mediaLock.dispatch(`${body.mediaType}:${body.mediaId}:${body.is4k}`, () =>
+        MediaRequest.createRequest(body, user, options)
+      )
     );
   }
 

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -165,7 +165,7 @@ export class MediaRequest {
         tmdbId: requestBody.mediaId,
         mediaType: requestBody.mediaType,
       },
-      relations: ['requests'],
+      relations: ['requests', 'requests.requestedBy'],
     });
 
     if (!media) {
@@ -215,28 +215,35 @@ export class MediaRequest {
       })
       .getMany();
 
+    const statusKey = requestBody.is4k ? 'status4k' : 'status';
+    const mediaAlreadyAvailable = media[statusKey] === MediaStatus.AVAILABLE;
+
     if (existing && existing.length > 0) {
-      // If there is an existing movie request that isn't declined, don't allow a new one.
-      if (
-        requestBody.mediaType === MediaType.MOVIE &&
-        existing[0].status !== MediaRequestStatus.DECLINED &&
-        existing[0].status !== MediaRequestStatus.COMPLETED
-      ) {
+      // Block a same-user duplicate at any status, or a different user's
+      // request unless the media is already available.
+      const blockingRequest = existing.find(
+        (r) =>
+          requestBody.mediaType === MediaType.MOVIE &&
+          r.status !== MediaRequestStatus.DECLINED &&
+          r.status !== MediaRequestStatus.COMPLETED &&
+          (r.requestedBy.id === requestUser.id || !mediaAlreadyAvailable)
+      );
+      if (blockingRequest) {
         logger.warn('Duplicate request for media blocked', {
           tmdbId: tmdbMedia.id,
           mediaType: requestBody.mediaType,
           is4k: requestBody.is4k,
           label: 'Media Request',
         });
-
         throw new DuplicateMediaRequestError(
-          'Request for this media already exists.'
+          blockingRequest.requestedBy.id === requestUser.id
+            ? 'You already have a request for this media.'
+            : 'Request for this media already exists.'
         );
       }
 
       // If an existing auto-request for this media exists from the same user,
       // don't allow a new one.
-      const statusKey = requestBody.is4k ? 'status4k' : 'status';
       if (
         existing.find(
           (r) =>
@@ -450,7 +457,15 @@ export class MediaRequest {
       // We need to check existing requests on this title to make sure we don't double up on seasons that were
       // already requested. In the case they were, we just throw out any duplicates but still approve the request.
       // (Unless there are no seasons, in which case we abort)
+      // A season only blocks a different user once it is already available; a
+      // same-user active request always blocks, same as the movie duplicate check.
       if (media.requests) {
+        const availableSeasonNumbers = new Set(
+          media.seasons
+            .filter((s) => s[statusKey] === MediaStatus.AVAILABLE)
+            .map((s) => s.seasonNumber)
+        );
+
         existingSeasons = media.requests
           .filter(
             (request) =>
@@ -459,30 +474,16 @@ export class MediaRequest {
               request.status !== MediaRequestStatus.COMPLETED
           )
           .reduce((seasons, request) => {
-            const combinedSeasons = request.seasons.map(
-              (season) => season.seasonNumber
-            );
-
-            return [...seasons, ...combinedSeasons];
+            const blockedSeasons = request.seasons
+              .map((s) => s.seasonNumber)
+              .filter(
+                (sn) =>
+                  request.requestedBy.id === requestUser.id ||
+                  !availableSeasonNumbers.has(sn)
+              );
+            return [...seasons, ...blockedSeasons];
           }, [] as number[]);
       }
-
-      // We should also check seasons that are available/partially available but don't have existing requests
-      if (media.seasons) {
-        existingSeasons = [
-          ...existingSeasons,
-          ...media.seasons
-            .filter(
-              (season) =>
-                season[requestBody.is4k ? 'status4k' : 'status'] !==
-                  MediaStatus.UNKNOWN &&
-                season[requestBody.is4k ? 'status4k' : 'status'] !==
-                  MediaStatus.DELETED
-            )
-            .map((season) => season.seasonNumber),
-        ];
-      }
-
       const finalSeasons = requestedSeasons.filter(
         (rs) => !existingSeasons.includes(rs)
       );

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -11,6 +11,10 @@ import OverrideRule from '@server/entity/OverrideRule';
 import type { MediaRequestBody } from '@server/interfaces/api/requestInterfaces';
 import notificationManager, { Notification } from '@server/lib/notifications';
 import { Permission } from '@server/lib/permissions';
+import {
+  isRequestStillBlocking,
+  isSeasonNumberRequestable,
+} from '@server/lib/requestRules';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { DbAwareColumn, resolveDbType } from '@server/utils/DbColumnHelper';
@@ -224,9 +228,11 @@ export class MediaRequest {
       const blockingRequest = existing.find(
         (r) =>
           requestBody.mediaType === MediaType.MOVIE &&
-          r.status !== MediaRequestStatus.DECLINED &&
-          r.status !== MediaRequestStatus.COMPLETED &&
-          (r.requestedBy.id === requestUser.id || !mediaAlreadyAvailable)
+          isRequestStillBlocking({
+            requestStatus: r.status,
+            isOwnRequest: r.requestedBy.id === requestUser.id,
+            targetAvailable: mediaAlreadyAvailable,
+          })
       );
       if (blockingRequest) {
         logger.warn('Duplicate request for media blocked', {
@@ -448,9 +454,9 @@ export class MediaRequest {
               .filter((season) => season.season_number !== 0)
               .map((season) => season.season_number)
           : (requestBody.seasons as number[]);
-      if (!settings.main.enableSpecialEpisodes) {
-        requestedSeasons = requestedSeasons.filter((sn) => sn > 0);
-      }
+      requestedSeasons = requestedSeasons.filter((sn) =>
+        isSeasonNumberRequestable(sn, settings.main.enableSpecialEpisodes)
+      );
 
       let existingSeasons: number[] = [];
 
@@ -467,19 +473,16 @@ export class MediaRequest {
         );
 
         existingSeasons = media.requests
-          .filter(
-            (request) =>
-              request.is4k === requestBody.is4k &&
-              request.status !== MediaRequestStatus.DECLINED &&
-              request.status !== MediaRequestStatus.COMPLETED
-          )
+          .filter((request) => request.is4k === requestBody.is4k)
           .reduce((seasons, request) => {
             const blockedSeasons = request.seasons
               .map((s) => s.seasonNumber)
-              .filter(
-                (sn) =>
-                  request.requestedBy.id === requestUser.id ||
-                  !availableSeasonNumbers.has(sn)
+              .filter((sn) =>
+                isRequestStillBlocking({
+                  requestStatus: request.status,
+                  isOwnRequest: request.requestedBy.id === requestUser.id,
+                  targetAvailable: availableSeasonNumbers.has(sn),
+                })
               );
             return [...seasons, ...blockedSeasons];
           }, [] as number[]);

--- a/server/lib/requestRules.ts
+++ b/server/lib/requestRules.ts
@@ -1,0 +1,26 @@
+import { MediaRequestStatus } from '@server/constants/media';
+
+export function isRequestStillBlocking({
+  requestStatus,
+  isOwnRequest,
+  targetAvailable,
+}: {
+  requestStatus: MediaRequestStatus;
+  isOwnRequest: boolean;
+  targetAvailable: boolean;
+}): boolean {
+  if (requestStatus === MediaRequestStatus.DECLINED) {
+    return false;
+  }
+  if (requestStatus === MediaRequestStatus.COMPLETED) {
+    return isOwnRequest && targetAvailable;
+  }
+  return isOwnRequest || !targetAvailable;
+}
+
+export function isSeasonNumberRequestable(
+  seasonNumber: number,
+  enableSpecialEpisodes: boolean
+): boolean {
+  return enableSpecialEpisodes || seasonNumber !== 0;
+}

--- a/server/lib/requestRules.ts
+++ b/server/lib/requestRules.ts
@@ -1,4 +1,6 @@
-import { MediaRequestStatus } from '@server/constants/media';
+import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
+import type { MediaRequest } from '@server/entity/MediaRequest';
+import type Season from '@server/entity/Season';
 
 export function isRequestStillBlocking({
   requestStatus,
@@ -23,4 +25,46 @@ export function isSeasonNumberRequestable(
   enableSpecialEpisodes: boolean
 ): boolean {
   return enableSpecialEpisodes || seasonNumber !== 0;
+}
+export function getBlockedSeasonNumbers({
+  seasons,
+  requests,
+  userId,
+  is4k,
+  ignoreSeasonNumbers,
+}: {
+  seasons: Season[];
+  requests: MediaRequest[];
+  userId?: number;
+  is4k: boolean;
+  ignoreSeasonNumbers?: number[];
+}): number[] {
+  const availableSeasonNumbers = new Set(
+    seasons
+      .filter(
+        (season) =>
+          season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+      )
+      .map((season) => season.seasonNumber)
+  );
+
+  return requests
+    .filter((request) => request.is4k === is4k)
+    .reduce((blockedSeasons, request) => {
+      return [
+        ...blockedSeasons,
+        ...request.seasons
+          .filter(
+            (season) => !ignoreSeasonNumbers?.includes(season.seasonNumber)
+          )
+          .map((sr) => sr.seasonNumber)
+          .filter((seasonNumber) =>
+            isRequestStillBlocking({
+              requestStatus: request.status,
+              isOwnRequest: request.requestedBy.id === userId,
+              targetAvailable: availableSeasonNumbers.has(seasonNumber),
+            })
+          ),
+      ];
+    }, [] as number[]);
 }

--- a/server/lib/scanners/baseScanner.ts
+++ b/server/lib/scanners/baseScanner.ts
@@ -306,7 +306,14 @@ class BaseScanner<T> {
         ) ?? []
       ).length;
 
-      for (const season of seasons) {
+      for (const rawSeason of seasons) {
+        // Files can't promote a season the provider reports as empty.
+        // Zeroing the counts leaves any existing status for availabilitySync to judge.
+        const season =
+          rawSeason.totalEpisodes > 0
+            ? rawSeason
+            : { ...rawSeason, episodes: 0, episodes4k: 0 };
+
         const existingSeason = media?.seasons.find(
           (es) => es.seasonNumber === season.seasonNumber
         );

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -15,6 +15,7 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import OverrideRule from '@server/entity/OverrideRule';
+import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
 import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
@@ -313,6 +314,75 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.serverId, 3);
     assert.strictEqual(saved.profileId, 7);
     assert.strictEqual(saved.rootFolder, '/updated/movies');
+  });
+});
+
+describe('PUT /request/:requestId (tv)', () => {
+  it('does not add a season held by another request', async () => {
+    const userRepo = getRepository(User);
+    const mediaRepo = getRepository(Media);
+    const requestRepo = getRepository(MediaRequest);
+
+    const owner = await userRepo.findOneOrFail({
+      where: { email: 'admin@seerr.dev' },
+    });
+    const otherUser = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.TV,
+        tmdbId: 67890,
+        status: MediaStatus.PENDING,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+
+    const seedTvRequest = (requestedBy: User, seasons: number[]) =>
+      requestRepo.save(
+        new MediaRequest({
+          type: MediaType.TV,
+          status: MediaRequestStatus.PENDING,
+          media,
+          requestedBy,
+          is4k: false,
+          seasons: seasons.map(
+            (seasonNumber) =>
+              new SeasonRequest({
+                seasonNumber,
+                status: MediaRequestStatus.PENDING,
+              })
+          ),
+        })
+      );
+
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+    const otherRequest = await seedTvRequest(otherUser, [3]);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort(),
+      [1, 2]
+    );
+
+    const otherSaved = await requestRepo.findOneOrFail({
+      where: { id: otherRequest.id },
+    });
+    assert.deepStrictEqual(
+      otherSaved.seasons.map((s) => s.seasonNumber),
+      [3]
+    );
   });
 });
 

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -15,6 +15,7 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import OverrideRule from '@server/entity/OverrideRule';
+import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
 import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
@@ -350,6 +351,19 @@ async function seedTvMedia(tmdbId: number) {
   );
 }
 
+async function seedMediaSeasons(
+  tmdbId: number,
+  seasons: { seasonNumber: number; status: MediaStatus }[]
+) {
+  const media = await seedTvMedia(tmdbId);
+  media.seasons = seasons.map(
+    ({ seasonNumber, status }) =>
+      new Season({ seasonNumber, status, status4k: MediaStatus.UNKNOWN })
+  );
+
+  return getRepository(Media).save(media);
+}
+
 async function seedTvRequest(
   requestedBy: User,
   seasons: number[],
@@ -407,6 +421,102 @@ describe('PUT /request/:requestId (tv)', () => {
     assert.deepStrictEqual(
       otherSaved.seasons.map((s) => s.seasonNumber),
       [3]
+    );
+  });
+});
+
+describe('PUT /request/:requestId (season availability)', () => {
+  it('does not add a season the media already has', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev');
+    const mediaRequest = await seedTvRequest(owner, [1]);
+    await seedMediaSeasons(67890, [
+      { seasonNumber: 2, status: MediaStatus.AVAILABLE },
+    ]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [1, 3]
+    );
+  });
+
+  it('returns 202 when every requested season is already covered', async () => {
+    const owner = await seedUser('friend@seerr.dev');
+    const mediaRequest = await seedTvRequest(owner, [1]);
+    await seedMediaSeasons(67890, [
+      { seasonNumber: 2, status: MediaStatus.AVAILABLE },
+    ]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [2],
+    });
+
+    assert.strictEqual(res.status, 202);
+  });
+
+  it('keeps the seasons it already holds once they are available', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev');
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+    await seedMediaSeasons(67890, [
+      { seasonNumber: 1, status: MediaStatus.AVAILABLE },
+      { seasonNumber: 2, status: MediaStatus.PROCESSING },
+    ]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2],
+      serverId: 3,
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [1, 2]
+    );
+    assert.strictEqual(saved.serverId, 3);
+  });
+
+  it('does not charge quota for a season the media already has', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', { tvQuotaLimit: 1 });
+    const mediaRequest = await seedTvRequest(owner, [1]);
+    await seedMediaSeasons(67890, [
+      { seasonNumber: 2, status: MediaStatus.AVAILABLE },
+    ]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber),
+      [1]
     );
   });
 });

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -372,7 +372,7 @@ describe('PUT /request/:requestId (tv)', () => {
       where: { id: mediaRequest.id },
     });
     assert.deepStrictEqual(
-      saved.seasons.map((s) => s.seasonNumber).sort(),
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
       [1, 2]
     );
 

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -317,45 +317,70 @@ describe('PUT /request/:requestId (movie)', () => {
   });
 });
 
-describe('PUT /request/:requestId (tv)', () => {
-  it('does not add a season held by another request', async () => {
-    const userRepo = getRepository(User);
-    const mediaRepo = getRepository(Media);
-    const requestRepo = getRepository(MediaRequest);
+async function seedUser(
+  email: string,
+  quotas: {
+    movieQuotaLimit?: number;
+    tvQuotaLimit?: number;
+    tvQuotaDays?: number;
+  } = {}
+) {
+  const userRepo = getRepository(User);
+  const user = await userRepo.findOneOrFail({ where: { email } });
+  Object.assign(user, quotas);
 
-    const owner = await userRepo.findOneOrFail({
-      where: { email: 'admin@seerr.dev' },
-    });
-    const otherUser = await userRepo.findOneOrFail({
-      where: { email: 'friend@seerr.dev' },
-    });
+  return userRepo.save(user);
+}
 
-    const media = await mediaRepo.save(
+async function seedTvMedia(tmdbId: number) {
+  const mediaRepo = getRepository(Media);
+
+  return (
+    (await mediaRepo.findOne({
+      where: { tmdbId, mediaType: MediaType.TV },
+    })) ??
+    (await mediaRepo.save(
       new Media({
         mediaType: MediaType.TV,
-        tmdbId: 67890,
+        tmdbId,
         status: MediaStatus.PENDING,
         status4k: MediaStatus.UNKNOWN,
       })
-    );
+    ))
+  );
+}
 
-    const seedTvRequest = (requestedBy: User, seasons: number[]) =>
-      requestRepo.save(
-        new MediaRequest({
-          type: MediaType.TV,
-          status: MediaRequestStatus.PENDING,
-          media,
-          requestedBy,
-          is4k: false,
-          seasons: seasons.map(
-            (seasonNumber) =>
-              new SeasonRequest({
-                seasonNumber,
-                status: MediaRequestStatus.PENDING,
-              })
-          ),
-        })
-      );
+async function seedTvRequest(
+  requestedBy: User,
+  seasons: number[],
+  { tmdbId = 67890, ignoreQuota = false, createdAt = new Date() } = {}
+) {
+  return getRepository(MediaRequest).save(
+    new MediaRequest({
+      type: MediaType.TV,
+      status: MediaRequestStatus.PENDING,
+      media: await seedTvMedia(tmdbId),
+      requestedBy,
+      is4k: false,
+      ignoreQuota,
+      createdAt,
+      seasons: seasons.map(
+        (seasonNumber) =>
+          new SeasonRequest({
+            seasonNumber,
+            status: MediaRequestStatus.PENDING,
+          })
+      ),
+    })
+  );
+}
+
+describe('PUT /request/:requestId (tv)', () => {
+  it('does not add a season held by another request', async () => {
+    const requestRepo = getRepository(MediaRequest);
+
+    const owner = await seedUser('admin@seerr.dev');
+    const otherUser = await seedUser('friend@seerr.dev');
 
     const mediaRequest = await seedTvRequest(owner, [1, 2]);
     const otherRequest = await seedTvRequest(otherUser, [3]);
@@ -382,6 +407,189 @@ describe('PUT /request/:requestId (tv)', () => {
     assert.deepStrictEqual(
       otherSaved.seasons.map((s) => s.seasonNumber),
       [3]
+    );
+  });
+});
+
+describe('PUT /request/:requestId (quota)', () => {
+  it('rejects adding seasons beyond the season limit', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', { tvQuotaLimit: 2 });
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [1, 2]
+    );
+  });
+
+  it('rejects adding seasons to a request older than the quota window', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', {
+      tvQuotaLimit: 2,
+      tvQuotaDays: 7,
+    });
+    const mediaRequest = await seedTvRequest(owner, [1, 2], {
+      createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [1, 2]
+    );
+  });
+
+  it('allows swapping seasons at the season limit', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', { tvQuotaLimit: 2 });
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [3, 4],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [3, 4]
+    );
+  });
+
+  it('rejects reassignment to a user without room for the existing seasons', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('admin@seerr.dev');
+    const target = await seedUser('friend@seerr.dev', { tvQuotaLimit: 1 });
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2],
+      userId: target.id,
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.requestedBy.id, owner.id);
+  });
+
+  it('rejects reassignment of a movie request to a user at their limit', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const mediaRepo = getRepository(Media);
+
+    const owner = await seedUser('admin@seerr.dev');
+    const target = await seedUser('friend@seerr.dev', { movieQuotaLimit: 1 });
+
+    // Uses up the target's single movie request
+    await seedRequest();
+
+    const media = await mediaRepo.save(
+      new Media({
+        mediaType: MediaType.MOVIE,
+        tmdbId: 55555,
+        status: MediaStatus.PENDING,
+        status4k: MediaStatus.UNKNOWN,
+      })
+    );
+    const mediaRequest = await requestRepo.save(
+      new MediaRequest({
+        type: MediaType.MOVIE,
+        status: MediaRequestStatus.PENDING,
+        media,
+        requestedBy: owner,
+        is4k: false,
+      })
+    );
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.MOVIE,
+      userId: target.id,
+    });
+
+    assert.strictEqual(res.status, 403);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.requestedBy.id, owner.id);
+  });
+
+  it('allows reassignment to a user who bypasses quotas', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', { tvQuotaLimit: 1 });
+    const target = await seedUser('admin@seerr.dev');
+    const mediaRequest = await seedTvRequest(owner, [1, 2]);
+
+    const agent = await loginAs('admin@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2],
+      userId: target.id,
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.strictEqual(saved.requestedBy.id, target.id);
+  });
+
+  it('allows an edit that exceeds the limit when the request ignores quota', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const owner = await seedUser('friend@seerr.dev', { tvQuotaLimit: 2 });
+
+    await seedTvRequest(owner, [1, 2], { tmdbId: 77777 });
+    const mediaRequest = await seedTvRequest(owner, [1, 2], {
+      ignoreQuota: true,
+    });
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.put(`/request/${mediaRequest.id}`).send({
+      mediaType: MediaType.TV,
+      seasons: [1, 2, 3],
+    });
+
+    assert.strictEqual(res.status, 200);
+
+    const saved = await requestRepo.findOneOrFail({
+      where: { id: mediaRequest.id },
+    });
+    assert.deepStrictEqual(
+      saved.seasons.map((s) => s.seasonNumber).sort((a, b) => a - b),
+      [1, 2, 3]
     );
   });
 });

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -25,6 +25,7 @@ import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
+import requestLock from '@server/utils/requestLock';
 import { Router } from 'express';
 
 const requestRoutes = Router();
@@ -462,136 +463,193 @@ requestRoutes.put<{ requestId: string }>(
   async (req, res, next) => {
     const requestRepository = getRepository(MediaRequest);
     const userRepository = getRepository(User);
+    const requestId = Number(req.params.requestId);
     try {
-      const request = await requestRepository.findOne({
-        where: {
-          id: Number(req.params.requestId),
-        },
-      });
-
-      if (!request) {
-        return next({ status: 404, message: 'Request not found.' });
-      }
-
-      if (
-        (request.requestedBy.id !== req.user?.id ||
-          (req.body.mediaType !== 'tv' &&
-            !req.user?.hasPermission(Permission.REQUEST_ADVANCED))) &&
-        !req.user?.hasPermission(Permission.MANAGE_REQUESTS)
-      ) {
-        return next({
-          status: 403,
-          message: 'You do not have permission to modify this request.',
+      // Ordering is request then owner here, user then media on create, so no cycle
+      return await requestLock.dispatch(`request:${requestId}`, async () => {
+        const request = await requestRepository.findOne({
+          where: {
+            id: requestId,
+          },
         });
-      }
 
-      let requestUser = request.requestedBy;
-
-      if (
-        req.body.userId &&
-        req.body.userId !== request.requestedBy.id &&
-        !req.user?.hasPermission([
-          Permission.MANAGE_USERS,
-          Permission.MANAGE_REQUESTS,
-        ])
-      ) {
-        return next({
-          status: 403,
-          message: 'You do not have permission to modify the request user.',
-        });
-      } else if (req.body.userId) {
-        requestUser = await userRepository.findOneOrFail({
-          where: { id: req.body.userId },
-        });
-      }
-
-      if (req.body.mediaType === MediaType.MOVIE) {
-        request.serverId = req.body.serverId;
-        request.profileId = req.body.profileId;
-        request.rootFolder = req.body.rootFolder;
-        request.tags = req.body.tags;
-        request.requestedBy = requestUser as User;
-
-        await requestRepository.save(request);
-      } else if (req.body.mediaType === MediaType.TV) {
-        const mediaRepository = getRepository(Media);
-        request.serverId = req.body.serverId;
-        request.profileId = req.body.profileId;
-        request.rootFolder = req.body.rootFolder;
-        request.languageProfileId = req.body.languageProfileId;
-        request.tags = req.body.tags;
-        request.requestedBy = requestUser as User;
-
-        const requestedSeasons = req.body.seasons as number[] | undefined;
-
-        if (!requestedSeasons || requestedSeasons.length === 0) {
-          throw new Error(
-            'Missing seasons. If you want to cancel a series request, use the DELETE method.'
-          );
+        if (!request) {
+          return next({ status: 404, message: 'Request not found.' });
         }
 
-        // Get existing media so we can work with all the requests
-        const media = await mediaRepository.findOneOrFail({
-          where: { tmdbId: request.media.tmdbId, mediaType: MediaType.TV },
-          relations: { requests: true },
-        });
+        if (
+          (request.requestedBy.id !== req.user?.id ||
+            (req.body.mediaType !== 'tv' &&
+              !req.user?.hasPermission(Permission.REQUEST_ADVANCED))) &&
+          !req.user?.hasPermission(Permission.MANAGE_REQUESTS)
+        ) {
+          return next({
+            status: 403,
+            message: 'You do not have permission to modify this request.',
+          });
+        }
 
-        // Get all requested seasons that are not part of this request we are editing
-        const existingSeasons = media.requests
-          .filter(
-            (r) =>
-              r.is4k === request.is4k &&
-              r.id !== request.id &&
-              r.status !== MediaRequestStatus.DECLINED &&
-              r.status !== MediaRequestStatus.COMPLETED
-          )
-          .reduce((seasons, r) => {
-            const combinedSeasons = r.seasons.map(
-              (season) => season.seasonNumber
+        const previousOwnerId = request.requestedBy.id;
+        let requestUser = request.requestedBy;
+
+        if (
+          req.body.userId &&
+          req.body.userId !== request.requestedBy.id &&
+          !req.user?.hasPermission([
+            Permission.MANAGE_USERS,
+            Permission.MANAGE_REQUESTS,
+          ])
+        ) {
+          return next({
+            status: 403,
+            message: 'You do not have permission to modify the request user.',
+          });
+        } else if (req.body.userId) {
+          requestUser = await userRepository.findOneOrFail({
+            where: { id: req.body.userId },
+          });
+        }
+
+        // Reassignment moves every season on the request onto the new owner's
+        // quota, so it is charged in full rather than as a delta
+        const ownerChanging = requestUser.id !== previousOwnerId;
+
+        return requestLock.dispatch(requestUser.id, async () => {
+          if (req.body.mediaType === MediaType.MOVIE) {
+            if (ownerChanging && !request.ignoreQuota) {
+              const quotas = await requestUser.getQuota();
+
+              if (quotas.movie.restricted) {
+                return next({
+                  status: 403,
+                  message: 'Movie Quota exceeded.',
+                });
+              }
+            }
+
+            request.serverId = req.body.serverId;
+            request.profileId = req.body.profileId;
+            request.rootFolder = req.body.rootFolder;
+            request.tags = req.body.tags;
+            request.requestedBy = requestUser as User;
+
+            await requestRepository.save(request);
+          } else if (req.body.mediaType === MediaType.TV) {
+            const mediaRepository = getRepository(Media);
+            request.serverId = req.body.serverId;
+            request.profileId = req.body.profileId;
+            request.rootFolder = req.body.rootFolder;
+            request.languageProfileId = req.body.languageProfileId;
+            request.tags = req.body.tags;
+            request.requestedBy = requestUser as User;
+
+            const requestedSeasons = req.body.seasons as number[] | undefined;
+
+            if (!requestedSeasons || requestedSeasons.length === 0) {
+              throw new Error(
+                'Missing seasons. If you want to cancel a series request, use the DELETE method.'
+              );
+            }
+
+            // Get existing media so we can work with all the requests
+            const media = await mediaRepository.findOneOrFail({
+              where: {
+                tmdbId: request.media.tmdbId,
+                mediaType: MediaType.TV,
+              },
+              relations: { requests: true },
+            });
+
+            // Get all requested seasons that are not part of this request we are editing
+            const existingSeasons = media.requests
+              .filter(
+                (r) =>
+                  r.is4k === request.is4k &&
+                  r.id !== request.id &&
+                  r.status !== MediaRequestStatus.DECLINED &&
+                  r.status !== MediaRequestStatus.COMPLETED
+              )
+              .reduce((seasons, r) => {
+                const combinedSeasons = r.seasons.map(
+                  (season) => season.seasonNumber
+                );
+
+                return [...seasons, ...combinedSeasons];
+              }, [] as number[]);
+
+            const filteredSeasons = requestedSeasons.filter(
+              (rs) => !existingSeasons.includes(rs)
             );
 
-            return [...seasons, ...combinedSeasons];
-          }, [] as number[]);
+            if (filteredSeasons.length === 0) {
+              return next({
+                status: 202,
+                message: 'No seasons available to request',
+              });
+            }
 
-        const filteredSeasons = requestedSeasons.filter(
-          (rs) => !existingSeasons.includes(rs)
-        );
+            const newSeasons = filteredSeasons.filter(
+              (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
+            );
 
-        if (filteredSeasons.length === 0) {
-          return next({
-            status: 202,
-            message: 'No seasons available to request',
-          });
-        }
+            if (!request.ignoreQuota) {
+              const quotas = await requestUser.getQuota();
 
-        const newSeasons = filteredSeasons.filter(
-          (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
-        );
+              // Only the seasons getQuota already counted for this owner are
+              // paid for, so the edit is charged for everything it left out
+              const quotaWindowStart = new Date();
+              if (quotas.tv.days) {
+                quotaWindowStart.setDate(
+                  quotaWindowStart.getDate() - quotas.tv.days
+                );
+              }
 
-        request.seasons = request.seasons.filter((rs) =>
-          filteredSeasons.includes(rs.seasonNumber)
-        );
+              const countedAlready =
+                !ownerChanging &&
+                (!quotas.tv.days || request.createdAt > quotaWindowStart);
 
-        if (newSeasons.length > 0) {
-          logger.debug('Adding new seasons to request', {
-            label: 'Media Request',
-            newSeasons,
-          });
-          request.seasons.push(
-            ...newSeasons.map(
-              (ns) =>
-                new SeasonRequest({
-                  seasonNumber: ns,
-                  status: MediaRequestStatus.PENDING,
-                })
-            )
-          );
-        }
+              const priorSeasonCount = countedAlready
+                ? request.seasons.length
+                : 0;
+              const requiredSeasons = filteredSeasons.length - priorSeasonCount;
 
-        await requestRepository.save(request);
-      }
+              if (
+                quotas.tv.limit &&
+                requiredSeasons > (quotas.tv.remaining ?? 0)
+              ) {
+                return next({
+                  status: 403,
+                  message: 'Series Quota exceeded.',
+                });
+              }
+            }
 
-      return res.status(200).json(request);
+            request.seasons = request.seasons.filter((rs) =>
+              filteredSeasons.includes(rs.seasonNumber)
+            );
+
+            if (newSeasons.length > 0) {
+              logger.debug('Adding new seasons to request', {
+                label: 'Media Request',
+                newSeasons,
+              });
+              request.seasons.push(
+                ...newSeasons.map(
+                  (ns) =>
+                    new SeasonRequest({
+                      seasonNumber: ns,
+                      status: MediaRequestStatus.PENDING,
+                    })
+                )
+              );
+            }
+
+            await requestRepository.save(request);
+          }
+
+          return res.status(200).json(request);
+        });
+      });
     } catch (e) {
       next({ status: 500, message: e.message });
     }

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -564,7 +564,7 @@ requestRoutes.put<{ requestId: string }>(
           });
         }
 
-        const newSeasons = requestedSeasons.filter(
+        const newSeasons = filteredSeasons.filter(
           (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
         );
 

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -577,20 +577,42 @@ requestRoutes.put<{ requestId: string }>(
                 return [...seasons, ...combinedSeasons];
               }, [] as number[]);
 
+            const currentSeasons = request.seasons.map((s) => s.seasonNumber);
+
+            // Seasons the media already covers cannot be requested again, while
+            // the ones this request holds stay on it
+            const coveredSeasons = (media.seasons ?? [])
+              .filter(
+                (season) =>
+                  season[request.is4k ? 'status4k' : 'status'] !==
+                    MediaStatus.UNKNOWN &&
+                  season[request.is4k ? 'status4k' : 'status'] !==
+                    MediaStatus.DELETED
+              )
+              .map((season) => season.seasonNumber)
+              .filter((sn) => !currentSeasons.includes(sn));
+
             const filteredSeasons = requestedSeasons.filter(
               (rs) => !existingSeasons.includes(rs)
             );
 
-            if (filteredSeasons.length === 0) {
+            const keptSeasons = filteredSeasons.filter((sn) =>
+              currentSeasons.includes(sn)
+            );
+
+            const newSeasons = filteredSeasons.filter(
+              (sn) =>
+                !currentSeasons.includes(sn) && !coveredSeasons.includes(sn)
+            );
+
+            const resultingSeasonCount = keptSeasons.length + newSeasons.length;
+
+            if (resultingSeasonCount === 0) {
               return next({
                 status: 202,
                 message: 'No seasons available to request',
               });
             }
-
-            const newSeasons = filteredSeasons.filter(
-              (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
-            );
 
             if (!request.ignoreQuota) {
               const quotas = await requestUser.getQuota();
@@ -611,7 +633,7 @@ requestRoutes.put<{ requestId: string }>(
               const priorSeasonCount = countedAlready
                 ? request.seasons.length
                 : 0;
-              const requiredSeasons = filteredSeasons.length - priorSeasonCount;
+              const requiredSeasons = resultingSeasonCount - priorSeasonCount;
 
               if (
                 quotas.tv.limit &&
@@ -625,7 +647,7 @@ requestRoutes.put<{ requestId: string }>(
             }
 
             request.seasons = request.seasons.filter((rs) =>
-              filteredSeasons.includes(rs.seasonNumber)
+              keptSeasons.includes(rs.seasonNumber)
             );
 
             if (newSeasons.length > 0) {

--- a/server/subscriber/MediaRequestSubscriber.test.ts
+++ b/server/subscriber/MediaRequestSubscriber.test.ts
@@ -362,6 +362,13 @@ describe('MediaRequestSubscriber.sendToRadarr', () => {
       where: { id: request.id },
     });
     assert.strictEqual(finalRequest.status, MediaRequestStatus.COMPLETED);
+
+    const persistedMedia = await getRepository(Media).findOneOrFail({
+      where: { id: media.id },
+    });
+    assert.strictEqual(persistedMedia.externalServiceId, 7);
+    assert.strictEqual(persistedMedia.externalServiceSlug, 'test-movie');
+    assert.strictEqual(persistedMedia.serviceId, 0);
   });
 
   it('marks the request FAILED, not COMPLETED, when addMovie rejects for already-available media', async () => {
@@ -455,6 +462,13 @@ describe('MediaRequestSubscriber.sendToSonarr', () => {
         (s) => s.status === MediaRequestStatus.COMPLETED
       )
     );
+
+    const persistedMedia = await getRepository(Media).findOneOrFail({
+      where: { id: media.id },
+    });
+    assert.strictEqual(persistedMedia.externalServiceId, 7);
+    assert.strictEqual(persistedMedia.externalServiceSlug, 'test-show');
+    assert.strictEqual(persistedMedia.serviceId, 0);
   });
 
   it('marks the request FAILED, not COMPLETED, when addSeries rejects for an already-available season', async () => {

--- a/server/subscriber/MediaRequestSubscriber.test.ts
+++ b/server/subscriber/MediaRequestSubscriber.test.ts
@@ -1,0 +1,490 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import ExternalAPI from '@server/api/externalapi';
+import type { Tag } from '@server/api/servarr/base';
+import type { RadarrMovie } from '@server/api/servarr/radarr';
+import RadarrAPI from '@server/api/servarr/radarr';
+import type { SonarrSeries } from '@server/api/servarr/sonarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import {
+  MediaRequestStatus,
+  MediaStatus,
+  MediaType,
+} from '@server/constants/media';
+import { getRepository } from '@server/datasource';
+import Media from '@server/entity/Media';
+import { MediaRequest } from '@server/entity/MediaRequest';
+import Season from '@server/entity/Season';
+import SeasonRequest from '@server/entity/SeasonRequest';
+import { User } from '@server/entity/User';
+import { Permission } from '@server/lib/permissions';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+import { setupTestDb } from '@server/test/db';
+
+const externalApiGetMock = mock.method(
+  ExternalAPI.prototype as unknown as {
+    get: (endpoint: string) => Promise<unknown>;
+  },
+  'get',
+  async (endpoint: string) => {
+    const tmdbId = Number(endpoint.replace(/^\/(movie|tv)\//, ''));
+    if (!tmdbId) {
+      throw new Error(`Unstubbed external endpoint: ${endpoint}`);
+    }
+    if (endpoint.startsWith('/movie/')) {
+      return {
+        id: tmdbId,
+        title: 'Test Movie',
+        release_date: '2020-01-01',
+        external_ids: {},
+        genres: [],
+        keywords: { keywords: [] },
+        videos: { results: [{ type: 'Trailer', key: 'trailer' }] },
+      };
+    }
+    return {
+      id: tmdbId,
+      name: 'Test Show',
+      external_ids: { tvdb_id: tmdbId },
+      keywords: { results: [] },
+      seasons: [1, 2, 3].map((season_number) => ({ season_number })),
+      videos: { results: [{ type: 'Trailer', key: 'trailer' }] },
+    };
+  }
+).mock;
+
+let getMovieByTmdbIdImpl: (id: number) => Promise<RadarrMovie> = async () => {
+  throw new Error('Unstubbed getMovieByTmdbId');
+};
+Object.defineProperty(RadarrAPI.prototype, 'getMovieByTmdbId', {
+  get() {
+    return async (id: number) => getMovieByTmdbIdImpl(id);
+  },
+  set() {},
+  configurable: true,
+});
+
+let addMovieImpl: RadarrAPI['addMovie'] = async () => {
+  throw new Error('Unstubbed addMovie');
+};
+Object.defineProperty(RadarrAPI.prototype, 'addMovie', {
+  get() {
+    return async (options: Parameters<RadarrAPI['addMovie']>[0]) =>
+      addMovieImpl(options);
+  },
+  set() {},
+  configurable: true,
+});
+
+let radarrGetTagsImpl: () => Promise<Tag[]> = async () => [];
+Object.defineProperty(RadarrAPI.prototype, 'getTags', {
+  get() {
+    return async () => radarrGetTagsImpl();
+  },
+  set() {},
+  configurable: true,
+});
+
+let radarrCreateTagImpl: (args: { label: string }) => Promise<Tag> = async ({
+  label,
+}) => ({ id: 1, label });
+Object.defineProperty(RadarrAPI.prototype, 'createTag', {
+  get() {
+    return async (args: { label: string }) => radarrCreateTagImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+// --- Mock SonarrAPI's arrow-function instance methods, same pattern ---
+let addSeriesImpl: SonarrAPI['addSeries'] = async () => {
+  throw new Error('Unstubbed addSeries');
+};
+Object.defineProperty(SonarrAPI.prototype, 'addSeries', {
+  get() {
+    return async (options: Parameters<SonarrAPI['addSeries']>[0]) =>
+      addSeriesImpl(options);
+  },
+  set() {},
+  configurable: true,
+});
+
+let sonarrGetTagsImpl: () => Promise<Tag[]> = async () => [];
+Object.defineProperty(SonarrAPI.prototype, 'getTags', {
+  get() {
+    return async () => sonarrGetTagsImpl();
+  },
+  set() {},
+  configurable: true,
+});
+
+let sonarrCreateTagImpl: (args: { label: string }) => Promise<Tag> = async ({
+  label,
+}) => ({ id: 1, label });
+Object.defineProperty(SonarrAPI.prototype, 'createTag', {
+  get() {
+    return async (args: { label: string }) => sonarrCreateTagImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+mock.method(MediaRequest, 'sendNotification', async () => undefined);
+
+setupTestDb();
+
+beforeEach(() => {
+  externalApiGetMock.resetCalls();
+  getMovieByTmdbIdImpl = async () => {
+    throw new Error('Unstubbed getMovieByTmdbId');
+  };
+  addMovieImpl = async () => {
+    throw new Error('Unstubbed addMovie');
+  };
+  addSeriesImpl = async () => {
+    throw new Error('Unstubbed addSeries');
+  };
+  radarrGetTagsImpl = async () => [];
+  sonarrGetTagsImpl = async () => [];
+  radarrCreateTagImpl = async ({ label }) => ({ id: 1, label });
+  sonarrCreateTagImpl = async ({ label }) => ({ id: 1, label });
+
+  const settings = getSettings();
+  settings.radarr = [
+    {
+      id: 0,
+      name: 'Radarr',
+      hostname: 'localhost',
+      port: 7878,
+      apiKey: 'test-key',
+      baseUrl: '',
+      useSsl: false,
+      activeProfileId: 1,
+      activeProfileName: 'Default',
+      activeDirectory: '/movies',
+      minimumAvailability: 'released',
+      tags: [],
+      is4k: false,
+      isDefault: true,
+      syncEnabled: true,
+      preventSearch: false,
+      tagRequests: true,
+      overrideRule: [],
+      externalUrl: '',
+    } as unknown as RadarrSettings,
+  ];
+  settings.sonarr = [
+    {
+      id: 0,
+      name: 'Sonarr',
+      hostname: 'localhost',
+      port: 8989,
+      apiKey: 'test-key',
+      baseUrl: '',
+      useSsl: false,
+      activeProfileId: 1,
+      activeDirectory: '/tv',
+      activeLanguageProfileId: 1,
+      animeTags: [],
+      is4k: false,
+      enableSeasonFolders: true,
+      tags: [],
+      isDefault: true,
+      syncEnabled: true,
+      preventSearch: false,
+      tagRequests: true,
+      seriesType: 'standard',
+      animeSeriesType: 'anime',
+      monitorNewItems: 'all',
+      externalUrl: '',
+    } as unknown as SonarrSettings,
+  ];
+});
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  { timeoutMs = 2000, intervalMs = 10 } = {}
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+}
+
+async function seedRequester(email: string): Promise<User> {
+  return getRepository(User).save(
+    new User({
+      email,
+      username: email.split('@')[0],
+      displayName: email.split('@')[0],
+      permissions: Permission.REQUEST,
+      avatar: '',
+    })
+  );
+}
+
+async function seedMovie(tmdbId: number, status: MediaStatus): Promise<Media> {
+  return getRepository(Media).save(
+    new Media({
+      mediaType: MediaType.MOVIE,
+      tmdbId,
+      status,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+}
+
+async function seedShow(tmdbId: number, tvdbId: number): Promise<Media> {
+  return getRepository(Media).save(
+    new Media({
+      mediaType: MediaType.TV,
+      tmdbId,
+      tvdbId,
+      status: MediaStatus.AVAILABLE,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+}
+
+async function insertMovieRequest(
+  media: Media,
+  requester: User
+): Promise<MediaRequest> {
+  return getRepository(MediaRequest).save(
+    new MediaRequest({
+      type: MediaType.MOVIE,
+      media,
+      requestedBy: requester,
+      status: MediaRequestStatus.APPROVED,
+      is4k: false,
+    })
+  );
+}
+
+async function insertShowRequest(
+  media: Media,
+  requester: User,
+  seasonNumbers: number[]
+): Promise<MediaRequest> {
+  const requestRepository = getRepository(MediaRequest);
+
+  const request = new MediaRequest({
+    type: MediaType.TV,
+    media,
+    requestedBy: requester,
+    status: MediaRequestStatus.APPROVED,
+    is4k: false,
+    seasons: seasonNumbers.map(
+      (seasonNumber) =>
+        new SeasonRequest({
+          seasonNumber,
+          status: MediaRequestStatus.APPROVED,
+        })
+    ),
+  });
+  const saved = await requestRepository.save(request);
+
+  return requestRepository.findOneOrFail({
+    where: { id: saved.id },
+    relations: { seasons: true, requestedBy: true, media: true },
+  });
+}
+
+function radarrMovie(overrides: Partial<RadarrMovie> = {}): RadarrMovie {
+  return {
+    id: 7,
+    title: 'Test Movie',
+    isAvailable: true,
+    monitored: true,
+    tmdbId: 12345,
+    imdbId: 'tt1',
+    titleSlug: 'test-movie',
+    folderName: 'Test Movie',
+    path: '/movies/Test Movie',
+    profileId: 1,
+    qualityProfileId: 1,
+    added: '2020-01-01',
+    hasFile: true,
+    tags: [],
+    ...overrides,
+  } as RadarrMovie;
+}
+
+function sonarrSeries(overrides: Partial<SonarrSeries> = {}): SonarrSeries {
+  return {
+    id: 7,
+    title: 'Test Show',
+    titleSlug: 'test-show',
+    tvdbId: 54321,
+    tags: [],
+    seasons: [],
+    ...overrides,
+  } as unknown as SonarrSeries;
+}
+
+describe('MediaRequestSubscriber.sendToRadarr', () => {
+  it('completes the request and includes the requester tag when the movie is already available', async () => {
+    const requester = await seedRequester('avail-movie@seerr.dev');
+    const media = await seedMovie(12345, MediaStatus.AVAILABLE);
+
+    radarrGetTagsImpl = async () => [
+      { id: 9, label: `${requester.id}-${requester.displayName}` },
+    ];
+
+    let receivedTags: number[] | undefined;
+    addMovieImpl = async (options) => {
+      receivedTags = options.tags;
+      return radarrMovie({ hasFile: true, tags: options.tags });
+    };
+
+    const request = await insertMovieRequest(media, requester);
+
+    // Wait for the subscriber's fire-and-forget addMovie chain to settle.
+    await waitFor(() => receivedTags !== undefined);
+
+    assert.ok(receivedTags?.includes(9), 'expected requester tag to be sent');
+
+    const requestRepository = getRepository(MediaRequest);
+    await waitFor(async () => {
+      const persisted = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      return persisted.status !== MediaRequestStatus.APPROVED;
+    });
+
+    const finalRequest = await requestRepository.findOneOrFail({
+      where: { id: request.id },
+    });
+    assert.strictEqual(finalRequest.status, MediaRequestStatus.COMPLETED);
+  });
+
+  it('marks the request FAILED, not COMPLETED, when addMovie rejects for already-available media', async () => {
+    const requester = await seedRequester('fail-movie@seerr.dev');
+    const media = await seedMovie(23456, MediaStatus.AVAILABLE);
+
+    addMovieImpl = async () => {
+      throw new Error('Radarr is unreachable');
+    };
+
+    const request = await insertMovieRequest(media, requester);
+
+    const requestRepository = getRepository(MediaRequest);
+    await waitFor(async () => {
+      const persisted = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      return persisted.status !== MediaRequestStatus.APPROVED;
+    });
+
+    const finalRequest = await requestRepository.findOneOrFail({
+      where: { id: request.id },
+    });
+    assert.strictEqual(finalRequest.status, MediaRequestStatus.FAILED);
+  });
+
+  it('does not mark the request COMPLETED when the movie is not yet available', async () => {
+    const requester = await seedRequester('pending-movie@seerr.dev');
+    const media = await seedMovie(34567, MediaStatus.PENDING);
+
+    let called = false;
+    addMovieImpl = async (options) => {
+      called = true;
+      return radarrMovie({ hasFile: false, tags: options.tags });
+    };
+
+    const request = await insertMovieRequest(media, requester);
+
+    await waitFor(() => called);
+
+    const persisted = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: request.id },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
+  });
+});
+
+describe('MediaRequestSubscriber.sendToSonarr', () => {
+  it('completes the request and includes the requester tag when the season is already available', async () => {
+    const requester = await seedRequester('avail-show@seerr.dev');
+    const media = await seedShow(99001, 5001);
+    await getRepository(Season).save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+    sonarrGetTagsImpl = async () => [
+      { id: 11, label: `${requester.id}-${requester.displayName}` },
+    ];
+
+    let receivedTags: number[] | undefined;
+    addSeriesImpl = async (options) => {
+      receivedTags = options.tags;
+      return sonarrSeries({ tags: options.tags });
+    };
+
+    const request = await insertShowRequest(media, requester, [1]);
+
+    await waitFor(() => receivedTags !== undefined);
+
+    assert.ok(receivedTags?.includes(11), 'expected requester tag to be sent');
+
+    const requestRepository = getRepository(MediaRequest);
+    await waitFor(async () => {
+      const persisted = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      return persisted.status !== MediaRequestStatus.APPROVED;
+    });
+
+    const finalRequest = await requestRepository.findOneOrFail({
+      where: { id: request.id },
+      relations: { seasons: true },
+    });
+    assert.strictEqual(finalRequest.status, MediaRequestStatus.COMPLETED);
+    assert.ok(
+      finalRequest.seasons.every(
+        (s) => s.status === MediaRequestStatus.COMPLETED
+      )
+    );
+  });
+
+  it('marks the request FAILED, not COMPLETED, when addSeries rejects for an already-available season', async () => {
+    const requester = await seedRequester('fail-show@seerr.dev');
+    const media = await seedShow(99002, 5002);
+    await getRepository(Season).save(
+      new Season({
+        seasonNumber: 1,
+        status: MediaStatus.AVAILABLE,
+        status4k: MediaStatus.UNKNOWN,
+        media: Promise.resolve(media),
+      })
+    );
+    addSeriesImpl = async () => {
+      throw new Error('Sonarr is unreachable');
+    };
+
+    const request = await insertShowRequest(media, requester, [1]);
+
+    const requestRepository = getRepository(MediaRequest);
+    await waitFor(async () => {
+      const persisted = await requestRepository.findOneOrFail({
+        where: { id: request.id },
+      });
+      return persisted.status !== MediaRequestStatus.APPROVED;
+    });
+
+    const finalRequest = await requestRepository.findOneOrFail({
+      where: { id: request.id },
+    });
+    assert.strictEqual(finalRequest.status, MediaRequestStatus.FAILED);
+  });
+});

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -297,21 +297,6 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           return;
         }
 
-        if (
-          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        ) {
-          logger.warn('Media already exists, marking request as COMPLETED', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-
-          const requestRepository = manager.getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.COMPLETED;
-          await requestRepository.save(entity);
-          return;
-        }
-
         const tmdb = new TheMovieDb();
         const radarr = new RadarrAPI({
           apiKey: radarrSettings.apiKey,

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -349,7 +349,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           }
         }
 
-        const alreadyAvailable =
+        const mediaAlreadyAvailable =
           media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE;
 
         const radarrMovieOptions: RadarrMovieOptions = {
@@ -389,7 +389,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
               radarrSettings?.id;
             await mediaRepository.save(media);
 
-            if (alreadyAvailable) {
+            if (mediaAlreadyAvailable) {
               logger.info(
                 'Media already available, applied requester tag and marking request as COMPLETED',
                 {
@@ -551,7 +551,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           throw new Error('Media data not found');
         }
 
-        const alreadyAvailable =
+        const mediaAlreadyAvailable =
           media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE;
 
         const tmdb = new TheMovieDb();
@@ -563,7 +563,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         const tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
 
         if (!tvdbId) {
-          if (!alreadyAvailable) {
+          if (!mediaAlreadyAvailable) {
             const requestRepository = manager.getRepository(MediaRequest);
             await mediaRepository.remove(media);
             await requestRepository.remove(entity);
@@ -737,7 +737,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               sonarrSettings?.id;
 
-            if (alreadyAvailable) {
+            if (mediaAlreadyAvailable) {
               logger.info(
                 'Media already available; applied requester tag and marking request as COMPLETED',
                 {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -364,6 +364,9 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           }
         }
 
+        const alreadyAvailable =
+          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE;
+
         const radarrMovieOptions: RadarrMovieOptions = {
           profileId: qualityProfile,
           qualityProfileId: qualityProfile,
@@ -400,6 +403,20 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               radarrSettings?.id;
             await mediaRepository.save(media);
+
+            if (alreadyAvailable) {
+              logger.info(
+                'Media already available, applied requester tag and marking request as COMPLETED',
+                {
+                  label: 'Media Request',
+                  requestId: entity.id,
+                  mediaId: entity.media.id,
+                }
+              );
+              const requestRepository = getRepository(MediaRequest);
+              entity.status = MediaRequestStatus.COMPLETED;
+              await requestRepository.save(entity);
+            }
           })
           .catch(async () => {
             try {
@@ -549,23 +566,8 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
           throw new Error('Media data not found');
         }
 
-        if (
-          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        ) {
-          logger.warn('Media already exists, marking request as COMPLETED', {
-            label: 'Media Request',
-            requestId: entity.id,
-            mediaId: entity.media.id,
-          });
-
-          const requestRepository = manager.getRepository(MediaRequest);
-          entity.status = MediaRequestStatus.COMPLETED;
-          entity.seasons.forEach((season) => {
-            season.status = MediaRequestStatus.COMPLETED;
-          });
-          await requestRepository.save(entity);
-          return;
-        }
+        const alreadyAvailable =
+          media[entity.is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE;
 
         const tmdb = new TheMovieDb();
         const sonarr = new SonarrAPI({
@@ -576,9 +578,11 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         const tvdbId = series.external_ids.tvdb_id ?? media.tvdbId;
 
         if (!tvdbId) {
-          const requestRepository = manager.getRepository(MediaRequest);
-          await mediaRepository.remove(media);
-          await requestRepository.remove(entity);
+          if (!alreadyAvailable) {
+            const requestRepository = manager.getRepository(MediaRequest);
+            await mediaRepository.remove(media);
+            await requestRepository.remove(entity);
+          }
           throw new Error('TVDB ID not found');
         }
 
@@ -747,7 +751,23 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             ] = sonarrSeries.titleSlug;
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               sonarrSettings?.id;
-            await mediaRepository.save(media);
+
+            if (alreadyAvailable) {
+              logger.info(
+                'Media already available; applied requester tag and marking request as COMPLETED',
+                {
+                  label: 'Media Request',
+                  requestId: entity.id,
+                  mediaId: entity.media.id,
+                }
+              );
+              const requestRepository = getRepository(MediaRequest);
+              entity.status = MediaRequestStatus.COMPLETED;
+              entity.seasons.forEach((season) => {
+                season.status = MediaRequestStatus.COMPLETED;
+              });
+              await requestRepository.save(entity);
+            }
           })
           .catch(async () => {
             try {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -736,6 +736,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
             ] = sonarrSeries.titleSlug;
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               sonarrSettings?.id;
+            await mediaRepository.save(media);
 
             if (mediaAlreadyAvailable) {
               logger.info(

--- a/server/utils/asyncLock.ts
+++ b/server/utils/asyncLock.ts
@@ -37,14 +37,14 @@ class AsyncLock {
     setImmediate(() => this.ee.emit(key));
   };
 
-  public dispatch = async (
+  public dispatch = async <T>(
     key: string | number,
-    callback: () => Promise<void>
-  ) => {
+    callback: () => Promise<T>
+  ): Promise<T> => {
     const skey = String(key);
     await this.acquire(skey);
     try {
-      await callback();
+      return await callback();
     } finally {
       this.release(skey);
     }

--- a/server/utils/requestLock.ts
+++ b/server/utils/requestLock.ts
@@ -1,0 +1,7 @@
+import AsyncLock from '@server/utils/asyncLock';
+
+// Keyed on user id. Never dispatch from a subscriber or transaction as a waiter
+// would block while holding the save's connection.
+const requestLock = new AsyncLock();
+
+export default requestLock;

--- a/server/utils/requestLock.ts
+++ b/server/utils/requestLock.ts
@@ -4,4 +4,7 @@ import AsyncLock from '@server/utils/asyncLock';
 // would block while holding the save's connection.
 const requestLock = new AsyncLock();
 
+// keyed on media. always taken inside requestLock, never around it.
+export const mediaLock = new AsyncLock();
+
 export default requestLock;

--- a/src/components/RequestButton/index.tsx
+++ b/src/components/RequestButton/index.tsx
@@ -13,6 +13,7 @@ import {
 import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import type Media from '@server/entity/Media';
 import type { MediaRequest } from '@server/entity/MediaRequest';
+import { isRequestStillBlocking } from '@server/lib/requestRules';
 import axios from 'axios';
 import { useMemo, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -92,6 +93,32 @@ const RequestButton = ({
       : undefined;
   }, [active4kRequests, user]);
 
+  const blockingRequest = useMemo(
+    () =>
+      media?.requests.find(
+        (r) =>
+          !r.is4k &&
+          isRequestStillBlocking({
+            requestStatus: r.status,
+            isOwnRequest: r.requestedBy.id === user?.id,
+            targetAvailable: media?.status === MediaStatus.AVAILABLE,
+          })
+      ),
+    [media, user]
+  );
+  const blocking4kRequest = useMemo(
+    () =>
+      media?.requests.find(
+        (r) =>
+          r.is4k &&
+          isRequestStillBlocking({
+            requestStatus: r.status,
+            isOwnRequest: r.requestedBy.id === user?.id,
+            targetAvailable: media?.status4k === MediaStatus.AVAILABLE,
+          })
+      ),
+    [media, user]
+  );
   const modifyRequest = async (
     request: MediaRequest,
     type: 'approve' | 'decline'
@@ -292,14 +319,19 @@ const RequestButton = ({
       svg: <ArrowDownTrayIcon />,
     });
   } else if (
-    mediaType === 'tv' &&
-    (!activeRequest || activeRequest.requestedBy.id !== user?.id) &&
-    hasPermission([Permission.REQUEST, Permission.REQUEST_TV], {
-      type: 'or',
-    }) &&
+    !blockingRequest &&
+    hasPermission(
+      [
+        Permission.REQUEST,
+        mediaType === 'movie'
+          ? Permission.REQUEST_MOVIE
+          : Permission.REQUEST_TV,
+      ],
+      { type: 'or' }
+    ) &&
     media &&
     media.status !== MediaStatus.BLOCKLISTED &&
-    !isShowComplete
+    !(mediaType === 'tv' && isShowComplete)
   ) {
     buttons.push({
       id: 'request-more',
@@ -339,15 +371,21 @@ const RequestButton = ({
       svg: <ArrowDownTrayIcon />,
     });
   } else if (
-    mediaType === 'tv' &&
-    (!active4kRequest || active4kRequest.requestedBy.id !== user?.id) &&
-    hasPermission([Permission.REQUEST_4K, Permission.REQUEST_4K_TV], {
-      type: 'or',
-    }) &&
+    !blocking4kRequest &&
+    hasPermission(
+      [
+        Permission.REQUEST_4K,
+        mediaType === 'movie'
+          ? Permission.REQUEST_4K_MOVIE
+          : Permission.REQUEST_4K_TV,
+      ],
+      { type: 'or' }
+    ) &&
     media &&
     media.status4k !== MediaStatus.BLOCKLISTED &&
-    !is4kShowComplete &&
-    settings.currentSettings.series4kEnabled
+    !(mediaType === 'tv' && is4kShowComplete) &&
+    ((settings.currentSettings.movie4kEnabled && mediaType === 'movie') ||
+      (settings.currentSettings.series4kEnabled && mediaType === 'tv'))
   ) {
     buttons.push({
       id: 'request-more-4k',

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -418,7 +418,7 @@ const TvRequestModal = ({
             : hasPermission(Permission.MANAGE_REQUESTS)
               ? intl.formatMessage(messages.approve)
               : intl.formatMessage(messages.edit)
-          : getAllRequestedSeasons().length >= getAllSeasons().length
+          : unrequestedSeasons.length === 0
             ? intl.formatMessage(messages.alreadyrequested)
             : !settings.currentSettings.partialRequestsEnabled
               ? intl.formatMessage(
@@ -441,7 +441,7 @@ const TvRequestModal = ({
               unrequestedSeasons.length > quota.tv.limit &&
               !requestOverrides?.ignoreQuota
             ? true
-            : getAllRequestedSeasons().length >= getAllSeasons().length ||
+            : unrequestedSeasons.length === 0 ||
               (settings.currentSettings.partialRequestsEnabled &&
                 selectedSeasons.length === 0)
       }

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -17,6 +17,10 @@ import type SeasonRequest from '@server/entity/SeasonRequest';
 import type { NonFunctionProperties } from '@server/interfaces/api/common';
 import type { QuotaResponse } from '@server/interfaces/api/userInterfaces';
 import { Permission } from '@server/lib/permissions';
+import {
+  isRequestStillBlocking,
+  isSeasonNumberRequestable,
+} from '@server/lib/requestRules';
 import type { TvDetails } from '@server/models/Tv';
 import axios from 'axios';
 import { useState } from 'react';
@@ -236,44 +240,48 @@ const TvRequestModal = ({
   };
 
   const getAllSeasons = (): number[] => {
-    let allSeasons = (data?.seasons ?? []).filter(
-      (season) => season.episodeCount !== 0
-    );
-    if (!settings.currentSettings.enableSpecialEpisodes) {
-      allSeasons = allSeasons.filter((season) => season.seasonNumber > 0);
-    }
-    return allSeasons.map((season) => season.seasonNumber);
+    return (data?.seasons ?? [])
+      .filter(
+        (season) =>
+          season.episodeCount !== 0 &&
+          isSeasonNumberRequestable(
+            season.seasonNumber,
+            settings.currentSettings.enableSpecialEpisodes
+          )
+      )
+      .map((season) => season.seasonNumber);
   };
 
   const getAllRequestedSeasons = (): number[] => {
-    const requestedSeasons = (data?.mediaInfo?.requests ?? [])
-      .filter(
-        (request) =>
-          request.is4k === is4k &&
-          request.status !== MediaRequestStatus.DECLINED &&
-          request.status !== MediaRequestStatus.COMPLETED
-      )
+    // Seasons already fully available don't block a different user from
+    // requesting them (mirrors the backend's duplicate-block rule); only
+    // the requesting user's own active request does.
+    const availableSeasonNumbers = new Set(
+      (data?.mediaInfo?.seasons ?? [])
+        .filter(
+          (season) =>
+            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        )
+        .map((season) => season.seasonNumber)
+    );
+
+    return (data?.mediaInfo?.requests ?? [])
+      .filter((request) => request.is4k === is4k)
       .reduce((requestedSeasons, request) => {
         return [
           ...requestedSeasons,
           ...request.seasons
             .filter((season) => !editingSeasons.includes(season.seasonNumber))
-            .map((sr) => sr.seasonNumber),
+            .map((sr) => sr.seasonNumber)
+            .filter((seasonNumber) =>
+              isRequestStillBlocking({
+                requestStatus: request.status,
+                isOwnRequest: request.requestedBy.id === user?.id,
+                targetAvailable: availableSeasonNumbers.has(seasonNumber),
+              })
+            ),
         ];
       }, [] as number[]);
-
-    const availableSeasons = (data?.mediaInfo?.seasons ?? [])
-      .filter(
-        (season) =>
-          (season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] ===
-              MediaStatus.PARTIALLY_AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.PROCESSING) &&
-          !requestedSeasons.includes(season.seasonNumber)
-      )
-      .map((season) => season.seasonNumber);
-
-    return [...requestedSeasons, ...availableSeasons];
   };
 
   const isSelectedSeason = (seasonNumber: number): boolean =>
@@ -577,8 +585,10 @@ const TvRequestModal = ({
                     .filter(
                       (season) =>
                         season.episodeCount !== 0 &&
-                        (settings.currentSettings.enableSpecialEpisodes ||
-                          season.seasonNumber !== 0)
+                        isSeasonNumberRequestable(
+                          season.seasonNumber,
+                          settings.currentSettings.enableSpecialEpisodes
+                        )
                     )
                     .map((season) => {
                       const seasonRequest = getSeasonRequest(
@@ -592,6 +602,15 @@ const TvRequestModal = ({
                           sn[is4k ? 'status4k' : 'status'] !==
                             MediaStatus.DELETED
                       );
+                      // Whether this season is locked from selection for the
+                      // current user — kept in sync with toggleSeason() via
+                      // getAllRequestedSeasons(), rather than mediaSeason/
+                      // seasonRequest, since those are truthy for seasons
+                      // that are available or held by other users' requests
+                      // even when this user is allowed to request them.
+                      const isBlockedSeason = getAllRequestedSeasons().includes(
+                        season.seasonNumber
+                      );
                       return (
                         <tr key={`season-${season.id}`}>
                           <td
@@ -604,11 +623,7 @@ const TvRequestModal = ({
                               role="checkbox"
                               tabIndex={0}
                               aria-checked={
-                                !!mediaSeason ||
-                                (!!seasonRequest &&
-                                  !editingSeasons.includes(
-                                    season.seasonNumber
-                                  )) ||
+                                isBlockedSeason ||
                                 isSelectedSeason(season.seasonNumber)
                               }
                               onClick={() => toggleSeason(season.seasonNumber)}
@@ -618,12 +633,10 @@ const TvRequestModal = ({
                                 }
                               }}
                               className={`relative inline-flex h-5 w-10 flex-shrink-0 cursor-pointer items-center justify-center pt-2 focus:outline-none ${
-                                mediaSeason ||
+                                isBlockedSeason ||
                                 (quota?.tv.limit &&
                                   currentlyRemaining <= 0 &&
-                                  !isSelectedSeason(season.seasonNumber)) ||
-                                (!!seasonRequest &&
-                                  !editingSeasons.includes(season.seasonNumber))
+                                  !isSelectedSeason(season.seasonNumber))
                                   ? 'opacity-50'
                                   : ''
                               }`}
@@ -631,11 +644,7 @@ const TvRequestModal = ({
                               <span
                                 aria-hidden="true"
                                 className={`${
-                                  !!mediaSeason ||
-                                  (!!seasonRequest &&
-                                    !editingSeasons.includes(
-                                      season.seasonNumber
-                                    )) ||
+                                  isBlockedSeason ||
                                   isSelectedSeason(season.seasonNumber)
                                     ? 'bg-indigo-500'
                                     : 'bg-gray-700'
@@ -644,11 +653,7 @@ const TvRequestModal = ({
                               <span
                                 aria-hidden="true"
                                 className={`${
-                                  !!mediaSeason ||
-                                  (!!seasonRequest &&
-                                    !editingSeasons.includes(
-                                      season.seasonNumber
-                                    )) ||
+                                  isBlockedSeason ||
                                   isSelectedSeason(season.seasonNumber)
                                     ? 'translate-x-5'
                                     : 'translate-x-0'

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -18,7 +18,7 @@ import type { NonFunctionProperties } from '@server/interfaces/api/common';
 import type { QuotaResponse } from '@server/interfaces/api/userInterfaces';
 import { Permission } from '@server/lib/permissions';
 import {
-  isRequestStillBlocking,
+  getBlockedSeasonNumbers,
   isSeasonNumberRequestable,
 } from '@server/lib/requestRules';
 import type { TvDetails } from '@server/models/Tv';
@@ -252,37 +252,14 @@ const TvRequestModal = ({
       .map((season) => season.seasonNumber);
   };
 
-  const getAllRequestedSeasons = (): number[] => {
-    // Seasons already fully available don't block a different user from
-    // requesting them (mirrors the backend's duplicate-block rule); only
-    // the requesting user's own active request does.
-    const availableSeasonNumbers = new Set(
-      (data?.mediaInfo?.seasons ?? [])
-        .filter(
-          (season) =>
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        )
-        .map((season) => season.seasonNumber)
-    );
-
-    return (data?.mediaInfo?.requests ?? [])
-      .filter((request) => request.is4k === is4k)
-      .reduce((requestedSeasons, request) => {
-        return [
-          ...requestedSeasons,
-          ...request.seasons
-            .filter((season) => !editingSeasons.includes(season.seasonNumber))
-            .map((sr) => sr.seasonNumber)
-            .filter((seasonNumber) =>
-              isRequestStillBlocking({
-                requestStatus: request.status,
-                isOwnRequest: request.requestedBy.id === user?.id,
-                targetAvailable: availableSeasonNumbers.has(seasonNumber),
-              })
-            ),
-        ];
-      }, [] as number[]);
-  };
+  const getAllRequestedSeasons = (): number[] =>
+    getBlockedSeasonNumbers({
+      seasons: data?.mediaInfo?.seasons ?? [],
+      requests: data?.mediaInfo?.requests ?? [],
+      userId: user?.id,
+      is4k,
+      ignoreSeasonNumbers: editingSeasons,
+    });
 
   const isSelectedSeason = (seasonNumber: number): boolean =>
     selectedSeasons.includes(seasonNumber);

--- a/src/components/Settings/SettingsNetwork/index.tsx
+++ b/src/components/Settings/SettingsNetwork/index.tsx
@@ -175,6 +175,7 @@ const SettingsNetwork = () => {
                 apiRequestTimeout: Number(values.apiRequestTimeout) * 1000,
               });
               mutate('/api/v1/settings/public');
+              // the key StatusChecker polls on, so the restart modal shows at once
               mutate('/api/v1/status?checkUpdateAvailable=false');
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -309,19 +309,26 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     return [...requestedSeasons, ...availableSeasons];
   };
 
-  const showHasSpecials = data.seasons.some(
-    (season) =>
-      season.seasonNumber === 0 &&
-      settings.currentSettings.enableSpecialEpisodes
-  );
+  // Mirrors the season list the request modal offers, so the two agree.
+  const requestableSeasons = data.seasons
+    .filter(
+      (season) =>
+        season.episodeCount !== 0 &&
+        (settings.currentSettings.enableSpecialEpisodes ||
+          season.seasonNumber !== 0)
+    )
+    .map((season) => season.seasonNumber);
 
-  const isComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(false).length;
+  const isSeasonSetComplete = (is4k: boolean) => {
+    const requested = getAllRequestedSeasons(is4k);
+    return requestableSeasons.every((seasonNumber) =>
+      requested.includes(seasonNumber)
+    );
+  };
 
-  const is4kComplete =
-    (showHasSpecials ? seasonCount + 1 : seasonCount) <=
-    getAllRequestedSeasons(true).length;
+  const isComplete = isSeasonSetComplete(false);
+
+  const is4kComplete = isSeasonSetComplete(true);
 
   const streamingRegion = user?.settings?.streamingRegion
     ? user.settings.streamingRegion

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -57,7 +57,7 @@ import {
 } from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
 import {
-  isRequestStillBlocking,
+  getBlockedSeasonNumbers,
   isSeasonNumberRequestable,
 } from '@server/lib/requestRules';
 import type { TvDetails as TvDetailsType } from '@server/models/Tv';
@@ -284,33 +284,13 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     );
   }
 
-  const getAllRequestedSeasons = (is4k: boolean): number[] => {
-    const availableSeasonNumbers = new Set(
-      (data?.mediaInfo?.seasons ?? [])
-        .filter(
-          (season) =>
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
-        )
-        .map((season) => season.seasonNumber)
-    );
-
-    return (data?.mediaInfo?.requests ?? [])
-      .filter((request) => request.is4k === is4k)
-      .reduce((requestedSeasons, request) => {
-        return [
-          ...requestedSeasons,
-          ...request.seasons
-            .map((sr) => sr.seasonNumber)
-            .filter((seasonNumber) =>
-              isRequestStillBlocking({
-                requestStatus: request.status,
-                isOwnRequest: request.requestedBy.id === user?.id,
-                targetAvailable: availableSeasonNumbers.has(seasonNumber),
-              })
-            ),
-        ];
-      }, [] as number[]);
-  };
+  const getAllRequestedSeasons = (is4k: boolean): number[] =>
+    getBlockedSeasonNumbers({
+      seasons: data?.mediaInfo?.seasons ?? [],
+      requests: data?.mediaInfo?.requests ?? [],
+      userId: user?.id,
+      is4k,
+    });
 
   // Mirrors the season list the request modal offers, so the two agree.
   const requestableSeasons = data.seasons

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -56,6 +56,10 @@ import {
   MediaType,
 } from '@server/constants/media';
 import { MediaServerType } from '@server/constants/server';
+import {
+  isRequestStillBlocking,
+  isSeasonNumberRequestable,
+} from '@server/lib/requestRules';
 import type { TvDetails as TvDetailsType } from '@server/models/Tv';
 import type { Crew } from '@server/models/common';
 import axios from 'axios';
@@ -281,32 +285,31 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
   }
 
   const getAllRequestedSeasons = (is4k: boolean): number[] => {
-    const requestedSeasons = (data?.mediaInfo?.requests ?? [])
-      .filter(
-        (request) =>
-          request.is4k === is4k &&
-          request.status !== MediaRequestStatus.DECLINED &&
-          request.status !== MediaRequestStatus.COMPLETED
-      )
+    const availableSeasonNumbers = new Set(
+      (data?.mediaInfo?.seasons ?? [])
+        .filter(
+          (season) =>
+            season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE
+        )
+        .map((season) => season.seasonNumber)
+    );
+
+    return (data?.mediaInfo?.requests ?? [])
+      .filter((request) => request.is4k === is4k)
       .reduce((requestedSeasons, request) => {
         return [
           ...requestedSeasons,
-          ...request.seasons.map((sr) => sr.seasonNumber),
+          ...request.seasons
+            .map((sr) => sr.seasonNumber)
+            .filter((seasonNumber) =>
+              isRequestStillBlocking({
+                requestStatus: request.status,
+                isOwnRequest: request.requestedBy.id === user?.id,
+                targetAvailable: availableSeasonNumbers.has(seasonNumber),
+              })
+            ),
         ];
       }, [] as number[]);
-
-    const availableSeasons = (data?.mediaInfo?.seasons ?? [])
-      .filter(
-        (season) =>
-          (season[is4k ? 'status4k' : 'status'] === MediaStatus.AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] ===
-              MediaStatus.PARTIALLY_AVAILABLE ||
-            season[is4k ? 'status4k' : 'status'] === MediaStatus.PROCESSING) &&
-          !requestedSeasons.includes(season.seasonNumber)
-      )
-      .map((season) => season.seasonNumber);
-
-    return [...requestedSeasons, ...availableSeasons];
   };
 
   // Mirrors the season list the request modal offers, so the two agree.
@@ -314,8 +317,10 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
     .filter(
       (season) =>
         season.episodeCount !== 0 &&
-        (settings.currentSettings.enableSpecialEpisodes ||
-          season.seasonNumber !== 0)
+        isSeasonNumberRequestable(
+          season.seasonNumber,
+          settings.currentSettings.enableSpecialEpisodes
+        )
     )
     .map((season) => season.seasonNumber);
 
@@ -800,10 +805,11 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
             {data.seasons
               .slice()
               .reverse()
-              .filter(
-                (season) =>
-                  settings.currentSettings.enableSpecialEpisodes ||
-                  season.seasonNumber !== 0
+              .filter((season) =>
+                isSeasonNumberRequestable(
+                  season.seasonNumber,
+                  settings.currentSettings.enableSpecialEpisodes
+                )
               )
               .map((season) => {
                 const show4k =


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->

Currently pointing at the cross-user-request-lock branch to incorporate the other fixes for requests by fallenbagel without them appearing in the diff. I did this to avoid duplicative work or merge errors down the line. 

Previously, Seer blocked all requests for media that was already requested by another user even once that media is fully available. This PR modifies the behavior so a different user can request media that's already available. I applied this specific gate to avoid reopening the in-flight request race that #3377 and #3380 protect against while enabling the ability for multiple users to request media. 

When the new request comes in for already-available media, MediaRequestSubscriber now actually calls Radarr/Sonarr's addMovie/addSeries instead of short-circuiting straight to COMPLETED, and RadarrAPI.addMovie merges the new requester's tag onto the existing movie instead of dropping it (Sonarr's addSeries already merged tags correctly).  

The frontend exposes the ability for users who have not request specific media to make the request so that their users tags are applied. 

**AI Disclosure:** Claude helped draft the tests which I verified.

<!--- Why is this change required? What problem does it solve? -->

Seer currently blocks any duplicate request for media, which breaks the common admin workflow of tagging Radarr/Sonarr items per requesting user to drive per-user Plex/Jellyfin/Emby library views: only the first user to request a title can ever do it via Seer and have the automatic user-tagging of the media applied. Anyone else who wants to request the media once it's already available is stuck with no way to create a request for the media via Seer and have their own tag applied . This closes item #1 of #2276 (item #2, per-user library visibility itself, is out of scope here and planned separately).


<!--- If it fixes an open issue, please link to the issue here. --> 

- Fixes #2276 


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- [x] Completed unit tests
- [x] Tested making requests for already available media that had not been requested by that user to see requests being completed.
- [x] Accepted these requests to ensure that tags were properly applied in Radarr
- [x] Attempted to make requests for media that the user had already requested to ensure it blocked the request from the UI and backend. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - “Request more” options now appear consistently for eligible movies and shows.
  - Existing Radarr items can receive updated requester tags without unnecessary changes.
- **Bug Fixes**
  - Improved processing and completion of already available media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->