### PR TITLE
fix(override-rules): match default *arr server by id

### DIFF
--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -252,13 +252,21 @@ export class MediaRequest {
         ? settings.sonarr.find((s) => s.is4k && s.isDefault)?.id
         : settings.sonarr.find((s) => !s.is4k && s.isDefault)?.id;
 
+      const defaultServiceId =
+        requestBody.mediaType === MediaType.MOVIE
+          ? defaultRadarrId
+          : defaultSonarrId;
+
       const overrideRuleRepository = getRepository(OverrideRule);
-      const overrideRules = await overrideRuleRepository.find({
-        where:
-          requestBody.mediaType === MediaType.MOVIE
-            ? { radarrServiceId: defaultRadarrId }
-            : { sonarrServiceId: defaultSonarrId },
-      });
+      const overrideRules =
+        defaultServiceId === undefined
+          ? []
+          : await overrideRuleRepository.find({
+              where:
+                requestBody.mediaType === MediaType.MOVIE
+                  ? { radarrServiceId: defaultServiceId }
+                  : { sonarrServiceId: defaultServiceId },
+            });
 
       const appliedOverrideRules = overrideRules.filter((rule) => {
         const hasAnimeKeyword =

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -246,11 +246,11 @@ export class MediaRequest {
 
     if (useOverrides) {
       const defaultRadarrId = requestBody.is4k
-        ? settings.radarr.findIndex((r) => r.is4k && r.isDefault)
-        : settings.radarr.findIndex((r) => !r.is4k && r.isDefault);
+        ? settings.radarr.find((r) => r.is4k && r.isDefault)?.id
+        : settings.radarr.find((r) => !r.is4k && r.isDefault)?.id;
       const defaultSonarrId = requestBody.is4k
-        ? settings.sonarr.findIndex((s) => s.is4k && s.isDefault)
-        : settings.sonarr.findIndex((s) => !s.is4k && s.isDefault);
+        ? settings.sonarr.find((s) => s.is4k && s.isDefault)?.id
+        : settings.sonarr.find((s) => !s.is4k && s.isDefault)?.id;
 
       const overrideRuleRepository = getRepository(OverrideRule);
       const overrideRules = await overrideRuleRepository.find({

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -252,20 +252,17 @@ export class MediaRequest {
         ? settings.sonarr.find((s) => s.is4k && s.isDefault)?.id
         : settings.sonarr.find((s) => !s.is4k && s.isDefault)?.id;
 
-      const defaultServiceId =
+      const [defaultServiceIdField, defaultServiceId] =
         requestBody.mediaType === MediaType.MOVIE
-          ? defaultRadarrId
-          : defaultSonarrId;
+          ? (['radarrServiceId', defaultRadarrId] as const)
+          : (['sonarrServiceId', defaultSonarrId] as const);
 
       const overrideRuleRepository = getRepository(OverrideRule);
       const overrideRules =
         defaultServiceId === undefined
           ? []
           : await overrideRuleRepository.find({
-              where:
-                requestBody.mediaType === MediaType.MOVIE
-                  ? { radarrServiceId: defaultServiceId }
-                  : { sonarrServiceId: defaultServiceId },
+              where: { [defaultServiceIdField]: defaultServiceId },
             });
 
       const appliedOverrideRules = overrideRules.filter((rule) => {

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -33,12 +33,6 @@ const sendNotificationMock = mock.method(
   async () => undefined
 ).mock;
 
-// getMovie/getTvShow are class-field arrow functions (own instance
-// properties), so they can't be mocked via a plain prototype assignment —
-// intercept them with a prototype accessor whose setter is a no-op, so the
-// constructor's `this.getMovie = ...` hits the no-op setter instead of
-// shadowing the prototype getter. (Pattern copied from
-// availabilitySync.test.ts.)
 const getMovieImpl: (args: {
   movieId: number;
   language?: string;
@@ -87,10 +81,6 @@ function fakeTmdbShow(tmdbId: number): TmdbTvDetails {
   } as unknown as TmdbTvDetails;
 }
 
-// Copied from server/lib/scanners/radarr/radarr.test.ts's configureRadarr —
-// `id` defaults to array index i unless overridden, so an explicit `id`
-// that differs from array position simulates a server that was deleted and
-// re-added (the scenario that exposes the override-rule matching bug).
 function configureRadarr(overrides: Partial<RadarrSettings>[]): void {
   const settings = getSettings();
   settings.radarr = overrides.map((o, i) => ({
@@ -114,8 +104,6 @@ function configureRadarr(overrides: Partial<RadarrSettings>[]): void {
   })) as RadarrSettings[];
 }
 
-// Copied from server/lib/scanners/sonarr/sonarr.test.ts's configureSonarr,
-// same reasoning as configureRadarr above.
 function configureSonarr(overrides: Partial<SonarrSettings>[]): void {
   const settings = getSettings();
   settings.sonarr = overrides.map((o, i) => ({
@@ -653,8 +641,6 @@ describe('DELETE /request/:requestId, deleted media status restoration', () => {
 
 describe('POST /request (movie), override rules', () => {
   it('applies an override rule when the default Radarr server id differs from its array index', async () => {
-    // Simulates a Radarr server that was deleted and re-added: it sits at
-    // array index 0, but its persistent id is 5 (id != index).
     configureRadarr([{ id: 5, isDefault: true, is4k: false }]);
     getSettings().sonarr = [];
 

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { before, beforeEach, describe, it, mock } from 'node:test';
 
+import TheMovieDb from '@server/api/themoviedb';
+import type {
+  TmdbMovieDetails,
+  TmdbTvDetails,
+} from '@server/api/themoviedb/interfaces';
 import {
   MediaRequestStatus,
   MediaStatus,
@@ -9,7 +14,9 @@ import {
 import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
+import OverrideRule from '@server/entity/OverrideRule';
 import { User } from '@server/entity/User';
+import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
 import { setupTestDb } from '@server/test/db';
@@ -25,6 +32,114 @@ const sendNotificationMock = mock.method(
   'sendNotification',
   async () => undefined
 ).mock;
+
+// getMovie/getTvShow are class-field arrow functions (own instance
+// properties), so they can't be mocked via a plain prototype assignment —
+// intercept them with a prototype accessor whose setter is a no-op, so the
+// constructor's `this.getMovie = ...` hits the no-op setter instead of
+// shadowing the prototype getter. (Pattern copied from
+// availabilitySync.test.ts.)
+const getMovieImpl: (args: {
+  movieId: number;
+  language?: string;
+}) => Promise<TmdbMovieDetails> = async ({ movieId }) => fakeTmdbMovie(movieId);
+
+Object.defineProperty(TheMovieDb.prototype, 'getMovie', {
+  get() {
+    return async (args: { movieId: number; language?: string }) =>
+      getMovieImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+const getTvShowImpl: (args: {
+  tvId: number;
+  language?: string;
+}) => Promise<TmdbTvDetails> = async ({ tvId }) => fakeTmdbShow(tvId);
+
+Object.defineProperty(TheMovieDb.prototype, 'getTvShow', {
+  get() {
+    return async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args);
+  },
+  set() {},
+  configurable: true,
+});
+
+function fakeTmdbMovie(tmdbId: number): TmdbMovieDetails {
+  return {
+    id: tmdbId,
+    genres: [],
+    original_language: 'en',
+    keywords: { keywords: [] },
+    external_ids: {},
+  } as unknown as TmdbMovieDetails;
+}
+
+function fakeTmdbShow(tmdbId: number): TmdbTvDetails {
+  return {
+    id: tmdbId,
+    genres: [],
+    original_language: 'en',
+    keywords: { results: [] },
+    external_ids: {},
+  } as unknown as TmdbTvDetails;
+}
+
+// Copied from server/lib/scanners/radarr/radarr.test.ts's configureRadarr —
+// `id` defaults to array index i unless overridden, so an explicit `id`
+// that differs from array position simulates a server that was deleted and
+// re-added (the scenario that exposes the override-rule matching bug).
+function configureRadarr(overrides: Partial<RadarrSettings>[]): void {
+  const settings = getSettings();
+  settings.radarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Radarr ${i}`,
+    hostname: 'localhost',
+    port: 7878,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/movies',
+    is4k: false,
+    minimumAvailability: 'released',
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as RadarrSettings[];
+}
+
+// Copied from server/lib/scanners/sonarr/sonarr.test.ts's configureSonarr,
+// same reasoning as configureRadarr above.
+function configureSonarr(overrides: Partial<SonarrSettings>[]): void {
+  const settings = getSettings();
+  settings.sonarr = overrides.map((o, i) => ({
+    id: i,
+    name: `Sonarr ${i}`,
+    hostname: 'localhost',
+    port: 8989,
+    apiKey: 'test-key',
+    baseUrl: '',
+    useSsl: false,
+    activeProfileId: 1,
+    activeDirectory: '/tv',
+    activeLanguageProfileId: 1,
+    animeTags: [],
+    is4k: false,
+    enableSeasonFolders: true,
+    tags: [],
+    isDefault: i === 0,
+    syncEnabled: true,
+    preventSearch: false,
+    externalUrl: '',
+    ...o,
+  })) as SonarrSettings[];
+}
 
 let app: Express;
 
@@ -533,5 +648,125 @@ describe('DELETE /request/:requestId, deleted media status restoration', () => {
 
     const updated = await mediaRepo.findOneOrFail({ where: { id: media.id } });
     assert.strictEqual(updated.status, MediaStatus.PARTIALLY_AVAILABLE);
+  });
+});
+
+describe('POST /request (movie), override rules', () => {
+  it('applies an override rule when the default Radarr server id differs from its array index', async () => {
+    // Simulates a Radarr server that was deleted and re-added: it sits at
+    // array index 0, but its persistent id is 5 (id != index).
+    configureRadarr([{ id: 5, isDefault: true, is4k: false }]);
+    getSettings().sonarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        radarrServiceId: 5,
+        users: String(friend.id),
+        rootFolder: '/overridden/movies',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.MOVIE,
+      mediaId: 88001,
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, '/overridden/movies');
+  });
+
+  it('applies an override rule when the default Radarr server id matches its array index (sanity check)', async () => {
+    configureRadarr([{ id: 0, isDefault: true, is4k: false }]);
+    getSettings().sonarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        radarrServiceId: 0,
+        users: String(friend.id),
+        rootFolder: '/overridden/movies',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.MOVIE,
+      mediaId: 88002,
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, '/overridden/movies');
+  });
+});
+
+describe('POST /request (tv), override rules', () => {
+  it('applies an override rule when the default Sonarr server id differs from its array index', async () => {
+    configureSonarr([{ id: 5, isDefault: true, is4k: false }]);
+    getSettings().radarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        sonarrServiceId: 5,
+        users: String(friend.id),
+        rootFolder: '/overridden/tv',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.TV,
+      mediaId: 88003,
+      seasons: [1],
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, '/overridden/tv');
+  });
+
+  it('applies an override rule when the default Sonarr server id matches its array index (sanity check)', async () => {
+    configureSonarr([{ id: 0, isDefault: true, is4k: false }]);
+    getSettings().radarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        sonarrServiceId: 0,
+        users: String(friend.id),
+        rootFolder: '/overridden/tv',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.TV,
+      mediaId: 88004,
+      seasons: [1],
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, '/overridden/tv');
   });
 });

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -695,6 +695,34 @@ describe('POST /request (movie), override rules', () => {
     assert.strictEqual(res.status, 201);
     assert.strictEqual(res.body.rootFolder, '/overridden/movies');
   });
+
+  it('does not apply an unrelated override rule when there is no default Radarr server configured', async () => {
+    getSettings().radarr = [];
+    getSettings().sonarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        radarrServiceId: 999,
+        users: String(friend.id),
+        rootFolder: '/overridden/movies',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.MOVIE,
+      mediaId: 88005,
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, null);
+  });
 });
 
 describe('POST /request (tv), override rules', () => {
@@ -754,5 +782,34 @@ describe('POST /request (tv), override rules', () => {
 
     assert.strictEqual(res.status, 201);
     assert.strictEqual(res.body.rootFolder, '/overridden/tv');
+  });
+
+  it('does not apply an unrelated override rule when there is no default Sonarr server configured', async () => {
+    getSettings().radarr = [];
+    getSettings().sonarr = [];
+
+    const userRepo = getRepository(User);
+    const friend = await userRepo.findOneOrFail({
+      where: { email: 'friend@seerr.dev' },
+    });
+
+    const overrideRuleRepo = getRepository(OverrideRule);
+    await overrideRuleRepo.save(
+      new OverrideRule({
+        sonarrServiceId: 999,
+        users: String(friend.id),
+        rootFolder: '/overridden/tv',
+      })
+    );
+
+    const agent = await loginAs('friend@seerr.dev', 'test1234');
+    const res = await agent.post('/request').send({
+      mediaType: MediaType.TV,
+      mediaId: 88006,
+      seasons: [1],
+    });
+
+    assert.strictEqual(res.status, 201);
+    assert.strictEqual(res.body.rootFolder, null);
   });
 });


### PR DESCRIPTION

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail --> Override rules are matched against a server's persistent id, but the default-server lookup used findIndex when determining if the request matched the rule. The use of findIndex led to Override rules comparing that id against the server's position in the settings array instead of its id. If a server had been deleted or if an instance had multiple servers configured, the array index and id would diverge so a matching override rule would silently never apply even when all the conditions were met.

This change makes the default-server lookup match by id instead of by findIndex to ensure that the match is done correctly and override rules are applied when the conditions are met. I added regression coverage in request.test.ts for both Radarr and Sonarr to cover the scenario where the findIndex array position and the persistent id do not match and a test where the findIndex array position and the persistent id do match. 

AI Disclosure: I diagnosed the bug myself and came up with the fix but had Claude help write the regression tests which I reviewed before completing testing. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes issue reported in the discord by staky where override rule was not applying. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. --> I ran the unit test and will have the original reporter test the fix. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected override-rule selection for default Radarr and Sonarr services, including configurations where service IDs differ from their list positions.
  * Prevented invalid override-rule lookups when no default media service is configured.

* **Tests**
  * Added coverage for movie and TV requests using matching and non-matching service IDs.
  * Added test scenarios for override rules and configurable media service settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->