### PR TITLE
fix(ui): don't mark empty collections as available

### DIFF
--- a/src/components/CollectionDetails/index.tsx
+++ b/src/components/CollectionDetails/index.tsx
@@ -179,6 +179,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   if (isCollectionBlocklisted) {
     collectionStatus = MediaStatus.BLOCKLISTED;
   } else if (
+    data.parts.length > 0 &&
     data.parts.every(
       (part) =>
         part.mediaInfo && part.mediaInfo.status === MediaStatus.AVAILABLE
@@ -195,6 +196,7 @@ const CollectionDetails = ({ collection }: CollectionDetailsProps) => {
   }
 
   if (
+    data.parts.length > 0 &&
     data.parts.every(
       (part) =>
         part.mediaInfo && part.mediaInfo.status4k === MediaStatus.AVAILABLE


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A TMDB collection with no movies at all (e.g. `/collection/1741483`) was showing as `Available`.

Collection status is derived with `parts.every(...)`.
An empty array makes `every()` return `true`, so we treated "no parts" as "all parts available."
Same bug applied to the 4K badge.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with an empty: `collection/1741483`

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection and 4K collection availability now requires at least one part, with every part available.
  * Empty collections are no longer incorrectly marked as available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->