### PR TITLE
fix(settings): mutate the query-string status key for modal immediately

### DIFF
--- a/src/components/Settings/SettingsMain/index.tsx
+++ b/src/components/Settings/SettingsMain/index.tsx
@@ -211,7 +211,7 @@ const SettingsMain = () => {
                 versionCheck: values?.versionCheck,
               });
               mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate('/api/v1/status?checkUpdateAvailable=false');
 
               if (setLocale) {
                 setLocale(

--- a/src/components/Settings/SettingsNetwork/index.tsx
+++ b/src/components/Settings/SettingsNetwork/index.tsx
@@ -175,7 +175,7 @@ const SettingsNetwork = () => {
                 apiRequestTimeout: Number(values.apiRequestTimeout) * 1000,
               });
               mutate('/api/v1/settings/public');
-              mutate('/api/v1/status');
+              mutate('/api/v1/status?checkUpdateAvailable=false');
 
               addToast(intl.formatMessage(messages.toastSettingsSuccess), {
                 autoDismiss: true,


### PR DESCRIPTION
## Description

StatusChecker polls /api/v1/status?checkUpdateAvailable=false on a 60 second interval, and that subscription derives the server restart required modal. The network and general settings forms called mutate on these after saving a reqstart-required field, a bare key that predates the checkUpdateAvailable query param in #3137 put on StatusChecker's key. SWR matches keys by exact string, so that mutate no longer touched the subscription it was meant to refresh and the modal only appeared on the next poll, up to a minute later. Both call sites no mutate the key that it actually holds.

This was accidentally added to #3375 as https://github.com/seerr-team/seerr/pull/3375/changes/4d414ba33bbbe28468f7621d4012e168372ef22b instead of https://github.com/seerr-team/seerr/pull/3368

## How Has This Been Tested?

(no need)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status refresh behavior after saving main or network settings.
  * Prevented unnecessary update-availability checks during these refreshes, providing a smoother settings-saving experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->