### PR TITLE
fix: prevent hideAvailable/hideBlocklisted from filtering person results

### DIFF
--- a/src/components/MediaSlider/index.tsx
+++ b/src/components/MediaSlider/index.tsx
@@ -68,16 +68,16 @@ const MediaSlider = ({
   if (settings.currentSettings.hideAvailable) {
     titles = titles.filter(
       (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
-        i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE
+        !(i.mediaType === 'movie' || i.mediaType === 'tv') ||
+        (i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
+          i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE)
     );
   }
 
   if (settings.currentSettings.hideBlocklisted) {
     titles = titles.filter(
       (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
+        !(i.mediaType === 'movie' || i.mediaType === 'tv') ||
         i.mediaInfo?.status !== MediaStatus.BLOCKLISTED
     );
   }

--- a/src/hooks/useDiscover.ts
+++ b/src/hooks/useDiscover.ts
@@ -124,9 +124,9 @@ const useDiscover = <
   if (settings.currentSettings.hideAvailable && hideAvailable) {
     titles = titles.filter(
       (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
-        i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
-        i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE
+        !(i.mediaType === 'movie' || i.mediaType === 'tv') ||
+        (i.mediaInfo?.status !== MediaStatus.AVAILABLE &&
+          i.mediaInfo?.status !== MediaStatus.PARTIALLY_AVAILABLE)
     );
   }
 
@@ -137,7 +137,7 @@ const useDiscover = <
   ) {
     titles = titles.filter(
       (i) =>
-        (i.mediaType === 'movie' || i.mediaType === 'tv') &&
+        !(i.mediaType === 'movie' || i.mediaType === 'tv') ||
         i.mediaInfo?.status !== MediaStatus.BLOCKLISTED
     );
   }


### PR DESCRIPTION
## Description

- Fixes #3433

When hideAvailable or hideBlocklisted filter options are enabled, useDiscover and MediaSlider were filtering all items whose media type had no media status (such as Person search results), causing them to disappear from the slider. This fix ensures availability and blocklist filters only apply to Movie and TV items, allowing non-media results (e.g. Person cards) to display properly.

**AI Disclosure:** I researched the filtering logic in useDiscover and MediaSlider and implemented the type guard checks manually to prevent filtering non-media items.

## How Has This Been Tested?

Tested the changes against the discover view and media slider endpoints:
- Verified that when hideAvailable or hideBlocklisted is active, Person search results remain visible in discovery sliders.
- Verified that Movies and TV shows with available or blocklisted status continue to be filtered as expected.
- Ran unit test suite (pnpm test) and verified local build (pnpm build).

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build pnpm build
- [ ] Translation keys pnpm i18n:extract
- [ ] Database migration (if required)