### PR TITLE
fix(ui): stop appear leaking onto the DOM in Modal and SlideOver

### DIFF
--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -89,7 +89,6 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 
     return ReactDOM.createPortal(
       <Transition.Child
-        appear
         as="div"
         className="fixed bottom-0 left-0 right-0 top-0 z-50 flex h-full w-full items-center justify-center bg-gray-800/70"
         enter="transition-opacity duration-300"

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -57,7 +57,6 @@ const SlideOver = ({
         <div className="absolute inset-0 overflow-hidden">
           <section className="absolute inset-y-0 right-0 flex max-w-full">
             <Transition.Child
-              appear
               enter="transition-transform ease-in-out duration-500 sm:duration-700"
               enterFrom="translate-x-full"
               enterTo="translate-x-0"


### PR DESCRIPTION
## Description

`Transition.Child` does not destructure `appear` out of its props, so it falls through into theirProps and gets spread onto the rendered node, producing "Received `true` for a non-boolean attribute `appear`". Every modal renders through Common/Modal, so warning fired app-wide. The prop was redundant anyways since TransitionChild reads appear from context via `useTransitionContext()`, which the root Transition populates. Removing it is behaviourally inert.

## How Has This Been Tested?

- Manually checked the browser logs with fix applied while opening a modal/slideover

## Screenshots / Logs (if applicable)
Previously:
<img width="1572" height="514" alt="image" src="https://github.com/user-attachments/assets/51722ad7-7376-4c0f-97ea-085191c9a665" />
<img width="1552" height="351" alt="image" src="https://github.com/user-attachments/assets/4b6c1617-4516-49ad-99c4-5a7707e580c9" />

Now:
(no errors. I mean I can't really screenshot nothing)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial modal and slide-over rendering by preventing unintended duplicate entrance animations.
  * Preserved transition effects for loading states, dialogs, and subsequent panel interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->