### PR TITLE
fix(datasource): break import cycle mistyping postgres timestamps

### DIFF
--- a/server/datasource.ts
+++ b/server/datasource.ts
@@ -16,6 +16,7 @@ import { IssueCommentSubscriber } from '@server/subscriber/IssueCommentSubscribe
 import { IssueSubscriber } from '@server/subscriber/IssueSubscriber';
 import { MediaRequestSubscriber } from '@server/subscriber/MediaRequestSubscriber';
 import { MediaSubscriber } from '@server/subscriber/MediaSubscriber';
+import { isPgsql } from '@server/utils/dbType';
 import fs from 'fs';
 import type { TlsOptions } from 'tls';
 import type { DataSourceOptions, EntityTarget, Repository } from 'typeorm';
@@ -169,8 +170,6 @@ const postgresProdConfig: DataSourceOptions = {
   migrations: ['dist/migration/postgres/**/*.js'],
   subscribers,
 };
-
-export const isPgsql = process.env.DB_TYPE === 'postgres';
 
 function getDataSource(): DataSourceOptions {
   if (process.env.NODE_ENV === 'test') {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import csurf from '@dr.pogodin/csurf';
 import PlexAPI from '@server/api/plexapi';
-import dataSource, { getRepository, isPgsql } from '@server/datasource';
+import dataSource, { getRepository } from '@server/datasource';
 import DiscoverSlider from '@server/entity/DiscoverSlider';
 import { Session } from '@server/entity/Session';
 import { User } from '@server/entity/User';
@@ -29,6 +29,7 @@ import { getAppVersion } from '@server/utils/appVersion';
 import createCustomProxyAgent, {
   setForceIpv4First,
 } from '@server/utils/customProxyAgent';
+import { isPgsql } from '@server/utils/dbType';
 import { initializeDnsCache } from '@server/utils/dnsCache';
 import restartFlag from '@server/utils/restartFlag';
 import '@server/utils/userAgent';

--- a/server/utils/DbColumnHelper.ts
+++ b/server/utils/DbColumnHelper.ts
@@ -1,4 +1,4 @@
-import { isPgsql } from '@server/datasource';
+import { isPgsql } from '@server/utils/dbType';
 import type { ColumnOptions, ColumnType } from 'typeorm';
 import { Column } from 'typeorm';
 const pgTypeMapping: { [key: string]: ColumnType } = {

--- a/server/utils/dbType.ts
+++ b/server/utils/dbType.ts
@@ -1,0 +1,2 @@
+// Must stay import-free, entity decorators read this during datasource evaluation
+export const isPgsql = process.env.DB_TYPE === 'postgres';


### PR DESCRIPTION
## Description

Forgot to test PGSql when testing #3375 which replaced the entity globs with static imports, which hoist above the isPgsql declaration at the bottom of datasouce.ts. Entities therefore loaded while isPgsql was still undefined, and since resolveDbType runs as a decorator argument at class-definition time, every datatime column resolved to the sqlite type and Postgres refused to start. Moved isPgsql into an import-free module so reading it never depends on datasource.ts having finished evaluating.

- Fixes #3448

## How Has This Been Tested?

- Tested on sqlite and postgres.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized PostgreSQL database detection for more consistent database configuration.
  * Improved internal initialization reliability without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->