### PR TITLE
fix(ui): stop the slideover backdrop flashing back on close

### DIFF
--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -40,7 +40,7 @@ const SlideOver = ({
       enter="transition-opacity ease-in-out duration-300"
       enterFrom="opacity-0"
       enterTo="opacity-100"
-      leave="transition-opacity ease-in-out duration-300"
+      leave="transition-opacity ease-in-out duration-500 sm:duration-700"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
     >


### PR DESCRIPTION
## Description

The root `Transition` left on `duration-300` while its `Transition.Child` left on `duration-500 sm:duration700`. Headless UI keeps the subtree mounted until the child finishes, so from 300ms onward the root had completed its own transition and reverted to its base className `(bg-gray-800/70` at full opacity) while the panel was still mid-slide, partially off the right edge. This aligns the root's leave duration to the child's so both finish together and the subtree unmounts with the backdrop still at `opacity-0`. The panel's motion is unchanged and this only affects the backdrop fade-out which never previously completely cleanly.

## How Has This Been Tested?

- Tested manually on dev server by opening the slideover and closing.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the slide-over backdrop fade-out animation to last longer.
  - Applied an extended transition duration on larger screens for a smoother visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->