### PR TITLE
refactor(ui): use headlessui flat named exports

### DIFF
--- a/src/components/Common/ButtonWithDropdown/index.tsx
+++ b/src/components/Common/ButtonWithDropdown/index.tsx
@@ -1,6 +1,6 @@
 import Dropdown from '@app/components/Common/Dropdown';
 import { withProperties } from '@app/utils/typeHelpers';
-import { Menu } from '@headlessui/react';
+import { Menu, MenuButton } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import type { AnchorHTMLAttributes, ButtonHTMLAttributes } from 'react';
 
@@ -54,13 +54,13 @@ const ButtonWithDropdown = ({
       </TriggerElement>
       {children && (
         <span className="relative -ml-px block">
-          <Menu.Button
+          <MenuButton
             type="button"
             className={`relative z-10 inline-flex h-full items-center rounded-r-md px-2 py-2 text-sm font-medium leading-5 text-white transition duration-150 ease-in-out hover:z-20 focus:z-20 ${styleClasses.dropdownSideButtonClasses}`}
             aria-label="Expand"
           >
             {dropdownIcon ? dropdownIcon : <ChevronDownIcon />}
-          </Menu.Button>
+          </MenuButton>
           <Dropdown.Items dropdownType={buttonType}>{children}</Dropdown.Items>
         </span>
       )}

--- a/src/components/Common/Dropdown/index.tsx
+++ b/src/components/Common/Dropdown/index.tsx
@@ -1,5 +1,11 @@
 import { withProperties } from '@app/utils/typeHelpers';
-import { Menu, Transition } from '@headlessui/react';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Transition,
+} from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import {
   Fragment,
@@ -19,7 +25,7 @@ const DropdownItem = ({
   ...props
 }: DropdownItemProps) => {
   return (
-    <Menu.Item>
+    <MenuItem>
       <a
         className={[
           'button-md flex cursor-pointer items-center rounded px-4 py-2 text-sm leading-5 text-white focus:text-white focus:outline-none',
@@ -31,7 +37,7 @@ const DropdownItem = ({
       >
         {children}
       </a>
-    </Menu.Item>
+    </MenuItem>
   );
 };
 
@@ -55,7 +61,7 @@ const DropdownItems = ({
       leaveFrom="opacity-100 scale-100"
       leaveTo="opacity-0 scale-95"
     >
-      <Menu.Items
+      <MenuItems
         className={[
           'absolute right-0 z-40 -mr-1 mt-2 w-56 origin-top-right rounded-md p-1 shadow-lg',
           dropdownType === 'ghost'
@@ -66,7 +72,7 @@ const DropdownItems = ({
         {...props}
       >
         <div className="py-1">{children}</div>
-      </Menu.Items>
+      </MenuItems>
     </Transition>
   );
 };
@@ -89,7 +95,7 @@ const Dropdown = ({
 
   return (
     <Menu as="div" className="relative z-10">
-      <Menu.Button
+      <MenuButton
         type="button"
         className={[
           'button-md inline-flex h-full items-center space-x-2 rounded-md border px-4 py-2 text-sm font-medium leading-5 text-white transition duration-150 ease-in-out hover:z-20 focus:z-20 focus:outline-none',
@@ -104,7 +110,7 @@ const Dropdown = ({
       >
         <span>{text}</span>
         {children && (dropdownIcon ? dropdownIcon : <ChevronDownIcon />)}
-      </Menu.Button>
+      </MenuButton>
       {children && (
         <DropdownItems dropdownType={buttonType}>{children}</DropdownItems>
       )}

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from '@app/components/Common/LoadingSpinner';
 import useClickOutside from '@app/hooks/useClickOutside';
 import { useLockBodyScroll } from '@app/hooks/useLockBodyScroll';
 import globalMessages from '@app/i18n/globalMessages';
-import { Transition } from '@headlessui/react';
+import { Transition, TransitionChild } from '@headlessui/react';
 import type { MouseEvent } from 'react';
 import React, { Fragment, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
@@ -88,7 +88,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     useLockBodyScroll(true, disableScrollLock);
 
     return ReactDOM.createPortal(
-      <Transition.Child
+      <TransitionChild
         as="div"
         className="fixed bottom-0 left-0 right-0 top-0 z-50 flex h-full w-full items-center justify-center bg-gray-800/70"
         enter="transition-opacity duration-300"
@@ -242,7 +242,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
             </div>
           )}
         </Transition>
-      </Transition.Child>,
+      </TransitionChild>,
       document.body
     );
   }

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -40,7 +40,7 @@ const SlideOver = ({
       enter="transition-opacity ease-in-out duration-300"
       enterFrom="opacity-0"
       enterTo="opacity-100"
-      leave="transition-opacity ease-in-out duration-300"
+      leave="transition-opacity ease-in-out duration-500 sm:duration-700"
       leaveFrom="opacity-100"
       leaveTo="opacity-0"
     >

--- a/src/components/Common/SlideOver/index.tsx
+++ b/src/components/Common/SlideOver/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 import { useLockBodyScroll } from '@app/hooks/useLockBodyScroll';
-import { Transition } from '@headlessui/react';
+import { Transition, TransitionChild } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
@@ -56,7 +56,7 @@ const SlideOver = ({
       >
         <div className="absolute inset-0 overflow-hidden">
           <section className="absolute inset-y-0 right-0 flex max-w-full">
-            <Transition.Child
+            <TransitionChild
               as="div"
               enter="transition-transform ease-in-out duration-500 sm:duration-700"
               enterFrom="translate-x-full"
@@ -102,7 +102,7 @@ const SlideOver = ({
                   </div>
                 </div>
               </div>
-            </Transition.Child>
+            </TransitionChild>
           </section>
         </div>
       </div>

--- a/src/components/IssueDetails/IssueComment/index.tsx
+++ b/src/components/IssueDetails/IssueComment/index.tsx
@@ -4,7 +4,13 @@ import Modal from '@app/components/Common/Modal';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { Menu, Transition } from '@headlessui/react';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Transition,
+} from '@headlessui/react';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/solid';
 import type { default as IssueCommentType } from '@server/entity/IssueComment';
 import axios from 'axios';
@@ -106,13 +112,13 @@ const IssueComment = ({
               {({ open }) => (
                 <>
                   <div>
-                    <Menu.Button className="flex items-center rounded-full text-gray-400 hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100">
+                    <MenuButton className="flex items-center rounded-full text-gray-400 hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100">
                       <span className="sr-only">Open options</span>
                       <EllipsisVerticalIcon
                         className="h-5 w-5"
                         aria-hidden="true"
                       />
-                    </Menu.Button>
+                    </MenuButton>
                   </div>
 
                   <Transition
@@ -125,13 +131,13 @@ const IssueComment = ({
                     leaveFrom="opacity-100 scale-100"
                     leaveTo="opacity-0 scale-95"
                   >
-                    <Menu.Items
+                    <MenuItems
                       static
                       className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                     >
                       <div className="py-1">
                         {isActiveUser && (
-                          <Menu.Item>
+                          <MenuItem>
                             {({ active }) => (
                               <button
                                 onClick={() => setIsEditing(true)}
@@ -144,9 +150,9 @@ const IssueComment = ({
                                 {intl.formatMessage(messages.edit)}
                               </button>
                             )}
-                          </Menu.Item>
+                          </MenuItem>
                         )}
-                        <Menu.Item>
+                        <MenuItem>
                           {({ active }) => (
                             <button
                               onClick={() => setShowDeleteModal(true)}
@@ -159,9 +165,9 @@ const IssueComment = ({
                               {intl.formatMessage(messages.delete)}
                             </button>
                           )}
-                        </Menu.Item>
+                        </MenuItem>
                       </div>
-                    </Menu.Items>
+                    </MenuItems>
                   </Transition>
                 </>
               )}

--- a/src/components/IssueDetails/IssueDescription/index.tsx
+++ b/src/components/IssueDetails/IssueDescription/index.tsx
@@ -2,7 +2,13 @@ import Button from '@app/components/Common/Button';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { Menu, Transition } from '@headlessui/react';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Transition,
+} from '@headlessui/react';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/solid';
 import { Field, Form, Formik } from 'formik';
 import { useState } from 'react';
@@ -45,13 +51,13 @@ const IssueDescription = ({
             {({ open }) => (
               <>
                 <div>
-                  <Menu.Button className="flex items-center rounded-full text-gray-400 hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100">
+                  <MenuButton className="flex items-center rounded-full text-gray-400 hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-100">
                     <span className="sr-only">Open options</span>
                     <EllipsisVerticalIcon
                       className="h-5 w-5"
                       aria-hidden="true"
                     />
-                  </Menu.Button>
+                  </MenuButton>
                 </div>
 
                 <Transition
@@ -64,13 +70,13 @@ const IssueDescription = ({
                   leaveFrom="opacity-100 scale-100"
                   leaveTo="opacity-0 scale-95"
                 >
-                  <Menu.Items
+                  <MenuItems
                     static
                     className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                   >
                     <div className="py-1">
                       {belongsToUser && (
-                        <Menu.Item>
+                        <MenuItem>
                           {({ active }) => (
                             <button
                               onClick={() => setIsEditing(true)}
@@ -83,11 +89,11 @@ const IssueDescription = ({
                               {intl.formatMessage(messages.edit)}
                             </button>
                           )}
-                        </Menu.Item>
+                        </MenuItem>
                       )}
                       {(hasPermission(Permission.MANAGE_ISSUES) ||
                         !commentCount) && (
-                        <Menu.Item>
+                        <MenuItem>
                           {({ active }) => (
                             <button
                               onClick={() => onDelete()}
@@ -100,10 +106,10 @@ const IssueDescription = ({
                               {intl.formatMessage(messages.deleteissue)}
                             </button>
                           )}
-                        </Menu.Item>
+                        </MenuItem>
                       )}
                     </div>
-                  </Menu.Items>
+                  </MenuItems>
                 </Transition>
               </>
             )}

--- a/src/components/IssueModal/CreateIssueModal/index.tsx
+++ b/src/components/IssueModal/CreateIssueModal/index.tsx
@@ -6,7 +6,7 @@ import useToasts from '@app/hooks/useToasts';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { RadioGroup } from '@headlessui/react';
+import { Label, RadioGroup } from '@headlessui/react';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/solid';
 import { MediaStatus } from '@server/constants/media';
 import type Issue from '@server/entity/Issue';
@@ -241,9 +241,7 @@ const CreateIssueModal = ({
               onChange={(issue) => setFieldValue('selectedIssue', issue)}
               className="mt-4"
             >
-              <RadioGroup.Label className="sr-only">
-                Select an Issue
-              </RadioGroup.Label>
+              <Label className="sr-only">Select an Issue</Label>
               <div className="-space-y-px overflow-hidden rounded-md bg-gray-800/30">
                 {issueOptions.map((setting, index) => (
                   <RadioGroup.Option
@@ -277,14 +275,14 @@ const CreateIssueModal = ({
                           <span className="h-1.5 w-1.5 rounded-full bg-white" />
                         </span>
                         <div className="ml-3 flex flex-col">
-                          <RadioGroup.Label
+                          <Label
                             as="span"
                             className={`block text-sm font-medium ${
                               checked ? 'text-indigo-100' : 'text-gray-100'
                             }`}
                           >
                             {intl.formatMessage(setting.name)}
-                          </RadioGroup.Label>
+                          </Label>
                         </div>
                       </>
                     )}

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -3,7 +3,7 @@ import VersionStatus from '@app/components/Layout/VersionStatus';
 import useClickOutside from '@app/hooks/useClickOutside';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
-import { Transition } from '@headlessui/react';
+import { Transition, TransitionChild } from '@headlessui/react';
 import {
   ClockIcon,
   CogIcon,
@@ -152,7 +152,7 @@ const Sidebar = ({
       <div className="lg:hidden">
         <Transition as={Fragment} show={open}>
           <div className="fixed inset-0 z-40 flex">
-            <Transition.Child
+            <TransitionChild
               as="div"
               enter="transition-opacity ease-linear duration-300"
               enterFrom="opacity-0"
@@ -164,8 +164,8 @@ const Sidebar = ({
               <div className="fixed inset-0">
                 <div className="absolute inset-0 bg-gray-900 opacity-90" />
               </div>
-            </Transition.Child>
-            <Transition.Child
+            </TransitionChild>
+            <TransitionChild
               as="div"
               enter="transition-transform ease-in-out duration-300"
               enterFrom="-translate-x-full"
@@ -243,7 +243,7 @@ const Sidebar = ({
                   {/* <!-- Force sidebar to shrink to fit close icon --> */}
                 </div>
               </>
-            </Transition.Child>
+            </TransitionChild>
           </div>
         </Transition>
       </div>

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -2,7 +2,13 @@ import CachedImage from '@app/components/Common/CachedImage';
 import MiniQuotaDisplay from '@app/components/Layout/UserDropdown/MiniQuotaDisplay';
 import { Permission, useUser } from '@app/hooks/useUser';
 import defineMessages from '@app/utils/defineMessages';
-import { Menu, Transition } from '@headlessui/react';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Transition,
+} from '@headlessui/react';
 import {
   ArrowRightOnRectangleIcon,
   ClockIcon,
@@ -49,7 +55,7 @@ const UserDropdown = () => {
   return (
     <Menu as="div" className="relative ml-3">
       <div>
-        <Menu.Button
+        <MenuButton
           className="flex max-w-xs items-center rounded-full text-sm ring-1 ring-gray-700 hover:ring-gray-500 focus:outline-none focus:ring-gray-500"
           data-testid="user-menu"
         >
@@ -61,7 +67,7 @@ const UserDropdown = () => {
             width={40}
             height={40}
           />
-        </Menu.Button>
+        </MenuButton>
       </div>
       <Transition
         as={Fragment}
@@ -73,7 +79,7 @@ const UserDropdown = () => {
         leaveTo="opacity-0 scale-95"
         appear
       >
-        <Menu.Items className="absolute right-0 mt-2 w-72 origin-top-right rounded-md shadow-lg">
+        <MenuItems className="absolute right-0 mt-2 w-72 origin-top-right rounded-md shadow-lg">
           <div className="divide-y divide-gray-700 rounded-md bg-gray-800/80 ring-1 ring-gray-700 backdrop-blur">
             <div className="flex flex-col space-y-4 px-4 py-4">
               <div className="flex items-center space-x-2">
@@ -99,7 +105,7 @@ const UserDropdown = () => {
               {user && <MiniQuotaDisplay userId={user?.id} />}
             </div>
             <div className="p-1">
-              <Menu.Item>
+              <MenuItem>
                 {({ active }) => (
                   <ForwardedLink
                     href={`/profile`}
@@ -114,8 +120,8 @@ const UserDropdown = () => {
                     <span>{intl.formatMessage(messages.myprofile)}</span>
                   </ForwardedLink>
                 )}
-              </Menu.Item>
-              <Menu.Item>
+              </MenuItem>
+              <MenuItem>
                 {({ active }) => (
                   <ForwardedLink
                     href={
@@ -137,8 +143,8 @@ const UserDropdown = () => {
                     <span>{intl.formatMessage(messages.requests)}</span>
                   </ForwardedLink>
                 )}
-              </Menu.Item>
-              <Menu.Item>
+              </MenuItem>
+              <MenuItem>
                 {({ active }) => (
                   <ForwardedLink
                     href={`/profile/settings`}
@@ -153,8 +159,8 @@ const UserDropdown = () => {
                     <span>{intl.formatMessage(messages.settings)}</span>
                   </ForwardedLink>
                 )}
-              </Menu.Item>
-              <Menu.Item>
+              </MenuItem>
+              <MenuItem>
                 {({ active }) => (
                   <a
                     href="#"
@@ -169,10 +175,10 @@ const UserDropdown = () => {
                     <span>{intl.formatMessage(messages.signout)}</span>
                   </a>
                 )}
-              </Menu.Item>
+              </MenuItem>
             </div>
           </div>
-        </Menu.Items>
+        </MenuItems>
       </Transition>
     </Menu>
   );

--- a/src/components/RegionSelector/index.tsx
+++ b/src/components/RegionSelector/index.tsx
@@ -1,6 +1,12 @@
 import useSettings from '@app/hooks/useSettings';
 import defineMessages from '@app/utils/defineMessages';
-import { Listbox, Transition } from '@headlessui/react';
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+  Transition,
+} from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
 import type { Region } from '@server/lib/settings';
 import { countries } from 'country-flag-icons';
@@ -94,7 +100,7 @@ const RegionSelector = ({
         {({ open }) => (
           <div className="relative">
             <span className="inline-block w-full rounded-md shadow-sm">
-              <Listbox.Button className="focus:shadow-outline-blue relative flex w-full cursor-default items-center rounded-md border border-gray-500 bg-gray-700 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+              <ListboxButton className="focus:shadow-outline-blue relative flex w-full cursor-default items-center rounded-md border border-gray-500 bg-gray-700 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
                 {((selectedRegion &&
                   countries.includes(selectedRegion?.iso_3166_1)) ||
                   (isUserSetting &&
@@ -123,7 +129,7 @@ const RegionSelector = ({
                 <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2 text-gray-500">
                   <ChevronDownIcon className="h-5 w-5" />
                 </span>
-              </Listbox.Button>
+              </ListboxButton>
             </span>
 
             <Transition
@@ -134,12 +140,12 @@ const RegionSelector = ({
               leaveTo="opacity-0"
               className="absolute z-50 mt-1 w-full rounded-md bg-gray-800 shadow-lg"
             >
-              <Listbox.Options
+              <ListboxOptions
                 static
                 className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
               >
                 {isUserSetting && (
-                  <Listbox.Option value={null}>
+                  <ListboxOption value={null}>
                     {({ selected, active }) => (
                       <div
                         className={`${
@@ -177,10 +183,10 @@ const RegionSelector = ({
                         )}
                       </div>
                     )}
-                  </Listbox.Option>
+                  </ListboxOption>
                 )}
                 {!disableAll && (
-                  <Listbox.Option value={isUserSetting ? allRegion : null}>
+                  <ListboxOption value={isUserSetting ? allRegion : null}>
                     {({ selected, active }) => (
                       <div
                         className={`${
@@ -205,10 +211,10 @@ const RegionSelector = ({
                         )}
                       </div>
                     )}
-                  </Listbox.Option>
+                  </ListboxOption>
                 )}
                 {sortedRegions?.map((region) => (
-                  <Listbox.Option key={region.iso_3166_1} value={region}>
+                  <ListboxOption key={region.iso_3166_1} value={region}>
                     {({ selected, active }) => (
                       <div
                         className={`${
@@ -242,9 +248,9 @@ const RegionSelector = ({
                         )}
                       </div>
                     )}
-                  </Listbox.Option>
+                  </ListboxOption>
                 ))}
-              </Listbox.Options>
+              </ListboxOptions>
             </Transition>
           </div>
         )}

--- a/src/components/RequestModal/AdvancedRequester/index.tsx
+++ b/src/components/RequestModal/AdvancedRequester/index.tsx
@@ -7,7 +7,14 @@ import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import { formatBytes } from '@app/utils/numberHelpers';
-import { Listbox, Transition } from '@headlessui/react';
+import {
+  Label,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+  Transition,
+} from '@headlessui/react';
 import { CheckIcon, ChevronDownIcon } from '@heroicons/react/24/solid';
 import type {
   ServiceCommonServer,
@@ -619,12 +626,10 @@ const AdvancedRequester = ({
             >
               {({ open }) => (
                 <>
-                  <Listbox.Label>
-                    {intl.formatMessage(messages.requestas)}
-                  </Listbox.Label>
+                  <Label>{intl.formatMessage(messages.requestas)}</Label>
                   <div className="relative">
                     <span className="inline-block w-full rounded-md shadow-sm">
-                      <Listbox.Button className="focus:shadow-outline-blue relative w-full cursor-default rounded-md border border-gray-700 bg-gray-800 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
+                      <ListboxButton className="focus:shadow-outline-blue relative w-full cursor-default rounded-md border border-gray-700 bg-gray-800 py-2 pl-3 pr-10 text-left text-white transition duration-150 ease-in-out focus:border-blue-300 focus:outline-none sm:text-sm sm:leading-5">
                         <span className="flex items-center">
                           <CachedImage
                             type="avatar"
@@ -647,7 +652,7 @@ const AdvancedRequester = ({
                         <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2 text-gray-500">
                           <ChevronDownIcon className="h-5 w-5" />
                         </span>
-                      </Listbox.Button>
+                      </ListboxButton>
                     </span>
 
                     <Transition
@@ -661,12 +666,12 @@ const AdvancedRequester = ({
                       leaveTo="opacity-0"
                       className="mt-1 w-full rounded-md border border-gray-700 bg-gray-800 shadow-lg"
                     >
-                      <Listbox.Options
+                      <ListboxOptions
                         static
                         className="shadow-xs max-h-60 overflow-auto rounded-md py-1 text-base leading-6 focus:outline-none sm:text-sm sm:leading-5"
                       >
                         {filteredUserData?.map((user) => (
-                          <Listbox.Option key={user.id} value={user}>
+                          <ListboxOption key={user.id} value={user}>
                             {({ selected, active }) => (
                               <div
                                 className={`${
@@ -709,9 +714,9 @@ const AdvancedRequester = ({
                                 )}
                               </div>
                             )}
-                          </Listbox.Option>
+                          </ListboxOption>
                         ))}
-                      </Listbox.Options>
+                      </ListboxOptions>
                     </Transition>
                   </div>
                 </>

--- a/src/components/TvDetails/index.tsx
+++ b/src/components/TvDetails/index.tsx
@@ -35,7 +35,12 @@ import ErrorPage from '@app/pages/_error';
 import { sortCrewPriority } from '@app/utils/creditHelpers';
 import defineMessages from '@app/utils/defineMessages';
 import { refreshIntervalHelper } from '@app/utils/refreshIntervalHelper';
-import { Disclosure, Transition } from '@headlessui/react';
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+  Transition,
+} from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 import {
   ArrowRightCircleIcon,
@@ -854,7 +859,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                   <Disclosure key={`season-discoslure-${season.seasonNumber}`}>
                     {({ open }) => (
                       <>
-                        <Disclosure.Button
+                        <DisclosureButton
                           className={`mt-2 flex w-full items-center justify-between space-x-2 border-gray-700 bg-gray-800 px-4 py-2 text-gray-200 ${
                             open
                               ? 'rounded-t-md border-l border-r border-t'
@@ -1068,7 +1073,7 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                               open ? 'rotate-180' : ''
                             } h-6 w-6 text-gray-500`}
                           />
-                        </Disclosure.Button>
+                        </DisclosureButton>
                         <Transition
                           as="div"
                           show={open}
@@ -1081,12 +1086,12 @@ const TvDetails = ({ tv }: TvDetailsProps) => {
                           // Not sure why this transition is adding a margin without this here
                           style={{ margin: '0px' }}
                         >
-                          <Disclosure.Panel className="w-full rounded-b-md border-b border-l border-r border-gray-700 px-4 pb-2">
+                          <DisclosurePanel className="w-full rounded-b-md border-b border-l border-r border-gray-700 px-4 pb-2">
                             <Season
                               tvId={data.id}
                               seasonNumber={season.seasonNumber}
                             />
-                          </Disclosure.Panel>
+                          </DisclosurePanel>
                         </Transition>
                       </>
                     )}


### PR DESCRIPTION
## Description
 
v2 deprecates dot notation in favour of flat named exports. Renamed all 70 dotted tags across 12 files and update the imports to match. The dotted names are aliases of the same implementations, so this is behaviour-neutral.

## How Has This Been Tested?

- Manually tested opening all the affected places in a dev server.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dropdowns, menus, list selectors, modals, slide-overs, sidebars, and disclosure panels to use the latest component APIs.
  * Preserved existing interactions, styling, labels, and selection behavior.
  * Improved compatibility with the current UI component library without changing the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->