### PR TITLE
refactor(ui): use the Radio component instead of RadioGroup.Option

### DIFF
--- a/src/components/IssueModal/CreateIssueModal/index.tsx
+++ b/src/components/IssueModal/CreateIssueModal/index.tsx
@@ -6,7 +6,7 @@ import useToasts from '@app/hooks/useToasts';
 import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { Label, RadioGroup } from '@headlessui/react';
+import { Label, Radio, RadioGroup } from '@headlessui/react';
 import { ArrowRightCircleIcon } from '@heroicons/react/24/solid';
 import { MediaStatus } from '@server/constants/media';
 import type Issue from '@server/entity/Issue';
@@ -244,8 +244,9 @@ const CreateIssueModal = ({
               <Label className="sr-only">Select an Issue</Label>
               <div className="-space-y-px overflow-hidden rounded-md bg-gray-800/30">
                 {issueOptions.map((setting, index) => (
-                  <RadioGroup.Option
+                  <Radio
                     key={`issue-type-${setting.issueType}`}
+                    as="div"
                     value={setting}
                     className={({ checked }) =>
                       classNames(
@@ -260,7 +261,7 @@ const CreateIssueModal = ({
                       )
                     }
                   >
-                    {({ active, checked }) => (
+                    {({ focus, checked }) => (
                       <>
                         <span
                           className={`${
@@ -268,7 +269,7 @@ const CreateIssueModal = ({
                               ? 'border-transparent bg-indigo-600'
                               : 'border-gray-300 bg-white'
                           } ${
-                            active ? 'ring-2 ring-indigo-300 ring-offset-2' : ''
+                            focus ? 'ring-2 ring-indigo-300 ring-offset-2' : ''
                           } mt-0.5 flex h-4 w-4 cursor-pointer items-center justify-center rounded-full border`}
                           aria-hidden="true"
                         >
@@ -286,7 +287,7 @@ const CreateIssueModal = ({
                         </div>
                       </>
                     )}
-                  </RadioGroup.Option>
+                  </Radio>
                 ))}
               </div>
             </RadioGroup>


### PR DESCRIPTION
## Description

v2 deprecates RadioGroup.Option in favour of Radio. The two are not drop-in as Radio defaults to rendering a span where RadioGroup.Option rendered a div, so passed `as="div"` to keep the option a block-level flex row. Radio's render prop also drops `active` entirely rather than deprecating it, so used `focus`, which is the same state under its current name.

## How Has This Been Tested?

- Manually tested the radio buttons on a dev server

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue-type selection behavior and focus-state handling in the create-issue modal.
  * Preserved the existing selection experience while enhancing accessibility and component consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->