### PR TITLE
fix(requests): let managers recover failed request for stale *arr server

### DIFF
--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { before, beforeEach, describe, it, mock } from 'node:test';
+import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 
 import TheMovieDb from '@server/api/themoviedb';
 import type {
@@ -18,6 +18,7 @@ import OverrideRule from '@server/entity/OverrideRule';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
 import { User } from '@server/entity/User';
+import { Notification } from '@server/lib/notifications';
 import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
@@ -187,7 +188,10 @@ async function loginAs(email: string, password: string) {
   }
 }
 
-async function seedRequest(status = MediaRequestStatus.PENDING) {
+async function seedRequest(
+  status = MediaRequestStatus.PENDING,
+  overrides: Partial<MediaRequest> = {}
+) {
   const userRepo = getRepository(User);
   const mediaRepo = getRepository(Media);
   const requestRepo = getRepository(MediaRequest);
@@ -213,12 +217,58 @@ async function seedRequest(status = MediaRequestStatus.PENDING) {
       requestedBy,
       is4k: false,
       updatedAt: new Date('2025-03-01T00:00:00.000Z'),
+      ...overrides,
     })
   );
 
   return requestRepo.findOneOrFail({
     where: { id: created.id },
-    relations: { requestedBy: true, modifiedBy: true },
+    relations: { requestedBy: true, modifiedBy: true, media: true },
+  });
+}
+
+async function seedTvRequest(
+  status = MediaRequestStatus.PENDING,
+  overrides: Partial<MediaRequest> = {}
+) {
+  const userRepo = getRepository(User);
+  const mediaRepo = getRepository(Media);
+  const requestRepo = getRepository(MediaRequest);
+
+  const requestedBy = await userRepo.findOneOrFail({
+    where: { email: 'friend@seerr.dev' },
+  });
+
+  const media = await mediaRepo.save(
+    new Media({
+      mediaType: MediaType.TV,
+      tmdbId: 67890,
+      status: MediaStatus.UNKNOWN,
+      status4k: MediaStatus.UNKNOWN,
+    })
+  );
+
+  const created = await requestRepo.save(
+    new MediaRequest({
+      type: MediaType.TV,
+      status,
+      media,
+      requestedBy,
+      is4k: false,
+      seasons: [new SeasonRequest({ seasonNumber: 1, status })],
+      updatedAt: new Date('2025-03-01T00:00:00.000Z'),
+      ...overrides,
+    })
+  );
+
+  return requestRepo.findOneOrFail({
+    where: { id: created.id },
+    relations: {
+      requestedBy: true,
+      modifiedBy: true,
+      media: true,
+      seasons: true,
+    },
   });
 }
 
@@ -518,6 +568,101 @@ describe('POST /request/:requestId/retry', () => {
 
     const persisted = await repo.findOneOrFail({ where: { id: pending.id } });
     assert.strictEqual(persisted.status, MediaRequestStatus.PENDING);
+  });
+});
+
+describe('POST /request/:requestId/:status, unresolved *arr server', () => {
+  afterEach(() => {
+    // configureRadarr/configureSonarr mutate the shared settings singleton and
+    // nothing else resets it; clear it so later suites start clean.
+    const settings = getSettings();
+    settings.radarr = [];
+    settings.sonarr = [];
+  });
+
+  function failedNotificationSent(): boolean {
+    return sendNotificationMock.calls.some(
+      (call) => call.arguments[2] === Notification.MEDIA_FAILED
+    );
+  }
+
+  it('fails a movie request whose serverId no longer exists instead of silently abandoning it', async () => {
+    configureRadarr([{ id: 0, isDefault: true, is4k: false }]);
+    getSettings().sonarr = [];
+
+    const pending = await seedRequest(MediaRequestStatus.PENDING, {
+      serverId: 999,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/approve`);
+    assert.strictEqual(res.status, 200);
+
+    const persisted = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: pending.id },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.FAILED);
+
+    const media = await getRepository(Media).findOneOrFail({
+      where: { id: pending.media.id },
+    });
+    assert.strictEqual(media.status, MediaStatus.UNKNOWN);
+
+    assert.ok(failedNotificationSent());
+  });
+
+  it('does not fail a movie request when no default Radarr server is configured (silent skip preserved)', async () => {
+    configureRadarr([{ isDefault: false, is4k: false }]);
+    getSettings().sonarr = [];
+
+    const pending = await seedRequest();
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/approve`);
+    assert.strictEqual(res.status, 200);
+
+    const persisted = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: pending.id },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
+    assert.strictEqual(failedNotificationSent(), false);
+  });
+
+  it('fails a series request whose serverId no longer exists', async () => {
+    configureSonarr([{ id: 0, isDefault: true, is4k: false }]);
+    getSettings().radarr = [];
+
+    const pending = await seedTvRequest(MediaRequestStatus.PENDING, {
+      serverId: 999,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/approve`);
+    assert.strictEqual(res.status, 200);
+
+    const persisted = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: pending.id },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.FAILED);
+
+    assert.ok(failedNotificationSent());
+  });
+
+  it('does not fail a series request when no default Sonarr server is configured (silent skip preserved)', async () => {
+    configureSonarr([{ isDefault: false, is4k: false }]);
+    getSettings().radarr = [];
+
+    const pending = await seedTvRequest();
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${pending.id}/approve`);
+    assert.strictEqual(res.status, 200);
+
+    const persisted = await getRepository(MediaRequest).findOneOrFail({
+      where: { id: pending.id },
+    });
+    assert.strictEqual(persisted.status, MediaRequestStatus.APPROVED);
+    assert.strictEqual(failedNotificationSent(), false);
   });
 });
 

--- a/server/routes/request.test.ts
+++ b/server/routes/request.test.ts
@@ -367,7 +367,7 @@ describe('PUT /request/:requestId (movie)', () => {
     assert.strictEqual(saved.rootFolder, '/updated/movies');
   });
 
-  it('refuses to modify a request that is no longer pending', async () => {
+  it('refuses to modify a request that is neither pending nor failed', async () => {
     const requestRepo = getRepository(MediaRequest);
     const mediaRequest = await seedRequest(MediaRequestStatus.APPROVED);
 
@@ -379,13 +379,82 @@ describe('PUT /request/:requestId (movie)', () => {
     });
 
     assert.strictEqual(res.status, 409);
-    assert.match(res.body.message, /pending/i);
+    assert.match(res.body.message, /pending or failed/i);
 
     const saved = await requestRepo.findOneOrFail({
       where: { id: mediaRequest.id },
     });
     assert.strictEqual(saved.serverId, null);
     assert.strictEqual(saved.rootFolder, null);
+  });
+});
+
+describe('PUT /request/:requestId, failed request', () => {
+  afterEach(() => {
+    const settings = getSettings();
+    settings.radarr = [];
+    settings.sonarr = [];
+  });
+
+  it('lets a manager repoint a failed request and resubmits it', async () => {
+    configureRadarr([{ id: 2, isDefault: true, is4k: false }]);
+    const failed = await seedRequest(MediaRequestStatus.FAILED, {
+      serverId: 999,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.put(`/request/${failed.id}`).send({
+      mediaType: MediaType.MOVIE,
+      serverId: 2,
+      profileId: 7,
+      rootFolder: '/movies',
+      tags: [],
+    });
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.serverId, 2);
+    assert.strictEqual(res.body.modifiedBy.email, 'admin@seerr.dev');
+  });
+
+  it('rejects a failed-request edit that still points at a missing server', async () => {
+    configureRadarr([{ id: 2, isDefault: true, is4k: false }]);
+    const requestRepo = getRepository(MediaRequest);
+    const failed = await seedRequest(MediaRequestStatus.FAILED, {
+      serverId: 999,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.put(`/request/${failed.id}`).send({
+      mediaType: MediaType.MOVIE,
+      serverId: 998,
+    });
+
+    assert.strictEqual(res.status, 400);
+    assert.match(res.body.message, /not configured/i);
+
+    const saved = await requestRepo.findOneOrFail({ where: { id: failed.id } });
+    assert.strictEqual(saved.status, MediaRequestStatus.FAILED);
+    assert.strictEqual(saved.serverId, 999);
+  });
+
+  it('forbids a non-manager from modifying a failed request', async () => {
+    const requestRepo = getRepository(MediaRequest);
+    const failed = await seedTvRequest(MediaRequestStatus.FAILED, {
+      serverId: 999,
+    });
+    const friend = await loginAs('friend@seerr.dev', 'test1234');
+
+    const res = await friend.put(`/request/${failed.id}`).send({
+      mediaType: MediaType.TV,
+      serverId: 2,
+      seasons: [1],
+    });
+
+    assert.strictEqual(res.status, 403);
+    assert.match(res.body.message, /manager/i);
+
+    const saved = await requestRepo.findOneOrFail({ where: { id: failed.id } });
+    assert.strictEqual(saved.status, MediaRequestStatus.FAILED);
   });
 });
 
@@ -568,6 +637,44 @@ describe('POST /request/:requestId/retry', () => {
 
     const persisted = await repo.findOneOrFail({ where: { id: pending.id } });
     assert.strictEqual(persisted.status, MediaRequestStatus.PENDING);
+  });
+});
+
+describe('POST /request/:requestId/retry, stale server', () => {
+  afterEach(() => {
+    const settings = getSettings();
+    settings.radarr = [];
+    settings.sonarr = [];
+  });
+
+  it('refuses to retry when the request server no longer exists', async () => {
+    configureRadarr([{ id: 0, isDefault: true, is4k: false }]);
+    const repo = getRepository(MediaRequest);
+    const failed = await seedRequest(MediaRequestStatus.FAILED, {
+      serverId: 999,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${failed.id}/retry`);
+
+    assert.strictEqual(res.status, 409);
+    assert.match(res.body.message, /no longer exists/i);
+
+    const persisted = await repo.findOneOrFail({ where: { id: failed.id } });
+    assert.strictEqual(persisted.status, MediaRequestStatus.FAILED);
+  });
+
+  it('retries when the request server still exists', async () => {
+    configureRadarr([{ id: 5, isDefault: true, is4k: false }]);
+    const failed = await seedRequest(MediaRequestStatus.FAILED, {
+      serverId: 5,
+    });
+    const admin = await loginAs('admin@seerr.dev', 'test1234');
+
+    const res = await admin.post(`/request/${failed.id}/retry`);
+
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.modifiedBy.email, 'admin@seerr.dev');
   });
 });
 

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -29,6 +29,17 @@ import { Router } from 'express';
 
 const requestRoutes = Router();
 
+const arrServerConfigured = (
+  serverId: number | null | undefined,
+  type: MediaType,
+  settings = getSettings()
+): boolean =>
+  serverId == null ||
+  serverId < 0 ||
+  (type === MediaType.MOVIE ? settings.radarr : settings.sonarr).some(
+    (server) => server.id === serverId
+  );
+
 requestRoutes.get<Record<string, unknown>, RequestResultsResponse>(
   '/',
   async (req, res, next) => {
@@ -485,10 +496,23 @@ requestRoutes.put<{ requestId: string }>(
         });
       }
 
-      if (request.status !== MediaRequestStatus.PENDING) {
+      if (
+        request.status !== MediaRequestStatus.PENDING &&
+        request.status !== MediaRequestStatus.FAILED
+      ) {
         return next({
           status: 409,
-          message: 'Only pending requests can be modified.',
+          message: 'Only pending or failed requests can be modified.',
+        });
+      }
+
+      if (
+        request.status === MediaRequestStatus.FAILED &&
+        !req.user?.hasPermission(Permission.MANAGE_REQUESTS)
+      ) {
+        return next({
+          status: 403,
+          message: 'Only request managers can modify a failed request.',
         });
       }
 
@@ -510,6 +534,19 @@ requestRoutes.put<{ requestId: string }>(
         requestUser = await userRepository.findOneOrFail({
           where: { id: req.body.userId },
         });
+      }
+
+      const resubmitAfterEdit = request.status === MediaRequestStatus.FAILED;
+      if (resubmitAfterEdit) {
+        if (!arrServerConfigured(req.body.serverId, req.body.mediaType)) {
+          return next({
+            status: 400,
+            message:
+              'The selected server is not configured. Choose a valid server before resubmitting.',
+          });
+        }
+        request.status = MediaRequestStatus.APPROVED;
+        request.modifiedBy = req.user as User;
       }
 
       if (req.body.mediaType === MediaType.MOVIE) {
@@ -655,6 +692,17 @@ requestRoutes.post<{
         return next({
           status: 409,
           message: 'Only failed requests can be retried.',
+        });
+      }
+
+      if (!arrServerConfigured(request.serverId, request.type)) {
+        return next({
+          status: 409,
+          message:
+            `This request's ${
+              request.type === MediaType.MOVIE ? 'Radarr' : 'Sonarr'
+            } server (id ${request.serverId}) no longer exists. ` +
+            `Edit the request to select a valid server, then retry.`,
         });
       }
 

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -180,6 +180,56 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
       });
     }
   }
+  /**
+   * When a request's target *arr server cannot be resolved: if the request
+   * carried an explicit `serverId` that no longer exists, mark it FAILED and
+   * notify the requester; otherwise (no override and no default configured)
+   * log and return, preserving the previous silent-skip behaviour.
+   */
+  private async handleUnresolvedServer(
+    entity: MediaRequest,
+    manager: EntityManager,
+    service: 'Radarr' | 'Sonarr'
+  ): Promise<void> {
+    const tier = entity.is4k ? '4K ' : '';
+    const hasExplicitServer = entity.serverId !== null && entity.serverId >= 0;
+
+    if (!hasExplicitServer) {
+      logger.warn(
+        `There is no default ${tier}${service} server configured. Did you set one of your ${tier}${service} servers as default?`,
+        {
+          label: 'Media Request',
+          requestId: entity.id,
+          mediaId: entity.media.id,
+        }
+      );
+      return;
+    }
+
+    const media = await manager.getRepository(Media).findOne({
+      where: { id: entity.media.id },
+    });
+    if (!media) {
+      return;
+    }
+
+    logger.warn(
+      `Unable to resolve a ${tier}${service} server for this request; marking it as FAILED. The ${tier}${service} server this request was configured for (id ${entity.serverId}) no longer exists; recreate the request to route it to a configured server.`,
+      {
+        label: 'Media Request',
+        requestId: entity.id,
+        mediaId: entity.media.id,
+        serverId: entity.serverId,
+        is4k: entity.is4k,
+      }
+    );
+
+    if (entity.status !== MediaRequestStatus.FAILED) {
+      entity.status = MediaRequestStatus.FAILED;
+      await manager.getRepository(MediaRequest).save(entity);
+      MediaRequest.sendNotification(entity, media, Notification.MEDIA_FAILED);
+    }
+  }
 
   public async sendToRadarr(
     entity: MediaRequest,
@@ -227,18 +277,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         }
 
         if (!radarrSettings) {
-          logger.warn(
-            `There is no default ${
-              entity.is4k ? '4K ' : ''
-            }Radarr server configured. Did you set any of your ${
-              entity.is4k ? '4K ' : ''
-            }Radarr servers as default?`,
-            {
-              label: 'Media Request',
-              requestId: entity.id,
-              mediaId: entity.media.id,
-            }
-          );
+          await this.handleUnresolvedServer(entity, manager, 'Radarr');
           return;
         }
 
@@ -526,18 +565,7 @@ export class MediaRequestSubscriber implements EntitySubscriberInterface<MediaRe
         }
 
         if (!sonarrSettings) {
-          logger.warn(
-            `There is no default ${
-              entity.is4k ? '4K ' : ''
-            }Sonarr server configured. Did you set any of your ${
-              entity.is4k ? '4K ' : ''
-            }Sonarr servers as default?`,
-            {
-              label: 'Media Request',
-              requestId: entity.id,
-              mediaId: entity.media.id,
-            }
-          );
+          await this.handleUnresolvedServer(entity, manager, 'Sonarr');
           return;
         }
 

--- a/src/components/RequestBlock/index.tsx
+++ b/src/components/RequestBlock/index.tsx
@@ -4,7 +4,7 @@ import CachedImage from '@app/components/Common/CachedImage';
 import Tooltip from '@app/components/Common/Tooltip';
 import RequestModal from '@app/components/RequestModal';
 import useRequestOverride from '@app/hooks/useRequestOverride';
-import { useUser } from '@app/hooks/useUser';
+import { Permission, useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
 import {
@@ -46,7 +46,7 @@ interface RequestBlockProps {
 }
 
 const RequestBlock = ({ request, onUpdate }: RequestBlockProps) => {
-  const { user } = useUser();
+  const { user, hasPermission } = useUser();
   const intl = useIntl();
   const [isUpdating, setIsUpdating] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -177,16 +177,21 @@ const RequestBlock = ({ request, onUpdate }: RequestBlockProps) => {
                     <XMarkIcon />
                   </Button>
                 </Tooltip>
-                <Tooltip content={intl.formatMessage(messages.edit)}>
-                  <Button
-                    buttonType="warning"
-                    onClick={() => setShowEditModal(true)}
-                    disabled={isUpdating}
-                  >
-                    <PencilIcon className="icon-sm" />
-                  </Button>
-                </Tooltip>
               </>
+            )}
+            {(request.status === MediaRequestStatus.PENDING ||
+              (request.status === MediaRequestStatus.FAILED &&
+                hasPermission(Permission.MANAGE_REQUESTS))) && (
+              <Tooltip content={intl.formatMessage(messages.edit)}>
+                <Button
+                  buttonType="warning"
+                  className="mr-1"
+                  onClick={() => setShowEditModal(true)}
+                  disabled={isUpdating}
+                >
+                  <PencilIcon className="icon-sm" />
+                </Button>
+              </Tooltip>
             )}
             {request.status !== MediaRequestStatus.PENDING && (
               <Tooltip content={intl.formatMessage(messages.delete)}>

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -339,7 +339,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
         tmdbId={request.media.tmdbId}
         type={request.type}
         is4k={request.is4k}
-        editRequest={request}
+        editRequest={requestData}
         onCancel={() => setShowEditModal(false)}
         onComplete={() => {
           revalidate();
@@ -480,20 +480,37 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
           <div className="flex flex-1 items-end space-x-2">
             {requestData.status === MediaRequestStatus.FAILED &&
               hasPermission(Permission.MANAGE_REQUESTS) && (
-                <Button
-                  buttonType="primary"
-                  buttonSize="sm"
-                  disabled={isRetrying}
-                  onClick={() => retryRequest()}
-                >
-                  <ArrowPathIcon
-                    className={isRetrying ? 'animate-spin' : ''}
-                    style={{ marginRight: '0', animationDirection: 'reverse' }}
-                  />
-                  <span className="ml-1.5 hidden sm:block">
-                    {intl.formatMessage(globalMessages.retry)}
-                  </span>
-                </Button>
+                <>
+                  <Button
+                    buttonType="primary"
+                    buttonSize="sm"
+                    aria-label={intl.formatMessage(messages.editrequest)}
+                    disabled={isRetrying}
+                    onClick={() => setShowEditModal(true)}
+                  >
+                    <PencilIcon />
+                    <span className="ml-1.5 hidden sm:block">
+                      {intl.formatMessage(messages.editrequest)}
+                    </span>
+                  </Button>
+                  <Button
+                    buttonType="primary"
+                    buttonSize="sm"
+                    disabled={isRetrying}
+                    onClick={() => retryRequest()}
+                  >
+                    <ArrowPathIcon
+                      className={isRetrying ? 'animate-spin' : ''}
+                      style={{
+                        marginRight: '0',
+                        animationDirection: 'reverse',
+                      }}
+                    />
+                    <span className="ml-1.5 hidden sm:block">
+                      {intl.formatMessage(globalMessages.retry)}
+                    </span>
+                  </Button>
+                </>
               )}
             {requestData.status === MediaRequestStatus.PENDING &&
               hasPermission(Permission.MANAGE_REQUESTS) && (

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -428,7 +428,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
         tmdbId={request.media.tmdbId}
         type={request.type}
         is4k={request.is4k}
-        editRequest={request}
+        editRequest={requestData}
         onCancel={() => setShowEditModal(false)}
         onComplete={() => {
           revalidateList();
@@ -754,23 +754,25 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                 </span>
               </div>
             )}
-          {requestData.status === MediaRequestStatus.PENDING &&
+          {((requestData.status === MediaRequestStatus.PENDING &&
             (hasPermission(Permission.MANAGE_REQUESTS) ||
               (requestData.requestedBy.id === user?.id &&
                 (requestData.type === 'tv' ||
-                  hasPermission(Permission.REQUEST_ADVANCED)))) && (
-              <span className="w-full">
-                <Button
-                  className="w-full"
-                  buttonType="primary"
-                  onClick={() => setShowEditModal(true)}
-                  disabled={updatingType !== null}
-                >
-                  <PencilIcon />
-                  <span>{intl.formatMessage(messages.editrequest)}</span>
-                </Button>
-              </span>
-            )}
+                  hasPermission(Permission.REQUEST_ADVANCED))))) ||
+            (requestData.status === MediaRequestStatus.FAILED &&
+              hasPermission(Permission.MANAGE_REQUESTS))) && (
+            <span className="w-full">
+              <Button
+                className="w-full"
+                buttonType="primary"
+                onClick={() => setShowEditModal(true)}
+                disabled={updatingType !== null || isRetrying}
+              >
+                <PencilIcon />
+                <span>{intl.formatMessage(messages.editrequest)}</span>
+              </Button>
+            </span>
+          )}
           {requestData.status === MediaRequestStatus.PENDING &&
             !hasPermission(Permission.MANAGE_REQUESTS) &&
             requestData.requestedBy.id === user?.id && (

--- a/src/components/RequestModal/MovieRequestModal.tsx
+++ b/src/components/RequestModal/MovieRequestModal.tsx
@@ -7,7 +7,7 @@ import useToasts from '@app/hooks/useToasts';
 import { useUser } from '@app/hooks/useUser';
 import globalMessages from '@app/i18n/globalMessages';
 import defineMessages from '@app/utils/defineMessages';
-import { MediaStatus } from '@server/constants/media';
+import { MediaRequestStatus, MediaStatus } from '@server/constants/media';
 import type { MediaRequest } from '@server/entity/MediaRequest';
 import type { NonFunctionProperties } from '@server/interfaces/api/common';
 import type { QuotaResponse } from '@server/interfaces/api/userInterfaces';
@@ -33,6 +33,8 @@ const messages = defineMessages('components.RequestModal', {
   errorediting: 'Something went wrong while editing the request.',
   requestedited: 'Request for <strong>{title}</strong> edited successfully!',
   requestApproved: 'Request for <strong>{title}</strong> approved!',
+  requestRetried:
+    'Request for <strong>{title}</strong> updated and resubmitted.',
   requesterror: 'Something went wrong while submitting the request.',
   pendingapproval: 'Your request is pending approval.',
 });
@@ -176,6 +178,9 @@ const MovieRequestModal = ({
   const updateRequest = async (alsoApproveRequest = false) => {
     setIsUpdating(true);
 
+    // The PUT resubmits a failed request itself; /approve would 409 on it.
+    const isFailedResubmit = editRequest?.status === MediaRequestStatus.FAILED;
+
     try {
       await axios.put(`/api/v1/request/${editRequest?.id}`, {
         mediaType: 'movie',
@@ -186,7 +191,7 @@ const MovieRequestModal = ({
         tags: requestOverrides?.tags,
       });
 
-      if (alsoApproveRequest) {
+      if (alsoApproveRequest && !isFailedResubmit) {
         await axios.post(`/api/v1/request/${editRequest?.id}/approve`);
       }
       mutate('/api/v1/request?filter=all&take=10&sort=modified&skip=0');
@@ -195,9 +200,11 @@ const MovieRequestModal = ({
       addToast(
         <span>
           {intl.formatMessage(
-            alsoApproveRequest
-              ? messages.requestApproved
-              : messages.requestedited,
+            isFailedResubmit
+              ? messages.requestRetried
+              : alsoApproveRequest
+                ? messages.requestApproved
+                : messages.requestedited,
             {
               title: data?.title,
               strong: (msg: React.ReactNode) => <strong>{msg}</strong>,

--- a/src/components/RequestModal/TvRequestModal.tsx
+++ b/src/components/RequestModal/TvRequestModal.tsx
@@ -46,6 +46,8 @@ const messages = defineMessages('components.RequestModal', {
   errorediting: 'Something went wrong while editing the request.',
   requestedited: 'Request for <strong>{title}</strong> edited successfully!',
   requestApproved: 'Request for <strong>{title}</strong> approved!',
+  requestRetried:
+    'Request for <strong>{title}</strong> updated and resubmitted.',
   requestcancelled: 'Request for <strong>{title}</strong> canceled.',
   autoapproval: 'Automatic Approval',
   requesterror: 'Something went wrong while submitting the request.',
@@ -110,6 +112,9 @@ const TvRequestModal = ({
       mutate('/api/v1/request/count');
     }
 
+    // The PUT resubmits a failed request itself; /approve would 409 on it.
+    const isFailedResubmit = editRequest.status === MediaRequestStatus.FAILED;
+
     try {
       if (selectedSeasons.length > 0) {
         await axios.put(`/api/v1/request/${editRequest.id}`, {
@@ -123,7 +128,7 @@ const TvRequestModal = ({
           seasons: selectedSeasons.sort((a, b) => a - b),
         });
 
-        if (alsoApproveRequest) {
+        if (alsoApproveRequest && !isFailedResubmit) {
           await axios.post(`/api/v1/request/${editRequest.id}/approve`);
         }
       } else {
@@ -136,9 +141,11 @@ const TvRequestModal = ({
         <span>
           {selectedSeasons.length > 0
             ? intl.formatMessage(
-                alsoApproveRequest
-                  ? messages.requestApproved
-                  : messages.requestedited,
+                isFailedResubmit
+                  ? messages.requestRetried
+                  : alsoApproveRequest
+                    ? messages.requestApproved
+                    : messages.requestedited,
                 {
                   title: data?.name,
                   strong: (msg: React.ReactNode) => <strong>{msg}</strong>,

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -583,6 +583,7 @@
   "components.RequestModal.pendingrequest": "Pending Request",
   "components.RequestModal.requestApproved": "Request for <strong>{title}</strong> approved!",
   "components.RequestModal.requestCancel": "Request for <strong>{title}</strong> canceled.",
+  "components.RequestModal.requestRetried": "Request for <strong>{title}</strong> updated and resubmitted.",
   "components.RequestModal.requestSuccess": "<strong>{title}</strong> requested successfully!",
   "components.RequestModal.requestadmin": "This request will be approved automatically.",
   "components.RequestModal.requestcancelled": "Request for <strong>{title}</strong> canceled.",


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->This change allows users with `MANAGE_REQUESTS` permissions to edit `FAILED` requests. This change builds on the work in #3461 by giving those requests that would otherwise be stuck a repair route.

This change auto-resubmits a `FAILED` request upon edit of the `serverId` field and guards against selecting another stale server. If a user edits another field that isn't `serverId`, it does not auto resubmit for Retry.

This expanded ability to edit was done by expanding the `PENDING`-only guard to include `FAILED` for `MANAGE_REQUESTS `permission holders only.

**AI Disclosure**: Claude Code helped write the tests, I verified them and ensured that they were testing the targeted paths.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #3460 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. --> Ran the new and old unit tests
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added the ability to edit and resubmit failed movie and TV requests.
* Users with request management permissions can edit failed requests.
* Added clearer confirmation when failed requests are resubmitted.

## Bug Fixes
* Requests using unavailable media servers now fail with an appropriate notification.
* Retries are rejected when the selected media server is no longer available.
* Prevented invalid edits to requests that are neither pending nor failed.
* Orphaned TV seasons are reset when their covering request is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->