### PR TITLE
fix(request): guard against null requestedBy to stop Discover crash and per-request 404s

### DIFF
--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -429,13 +429,17 @@ requestRoutes.get('/:requestId', async (req, res, next) => {
   const requestRepository = getRepository(MediaRequest);
 
   try {
-    const request = await requestRepository.findOneOrFail({
+    const request = await requestRepository.findOne({
       where: { id: Number(req.params.requestId) },
       relations: { requestedBy: true, modifiedBy: true },
     });
 
+    if (!request) {
+      return next({ status: 404, message: 'Request not found.' });
+    }
+
     if (
-      request.requestedBy.id !== req.user?.id &&
+      request.requestedBy?.id !== req.user?.id &&
       !req.user?.hasPermission(
         [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
         { type: 'or' }
@@ -474,7 +478,7 @@ requestRoutes.put<{ requestId: string }>(
       }
 
       if (
-        (request.requestedBy.id !== req.user?.id ||
+        (request.requestedBy?.id !== req.user?.id ||
           (req.body.mediaType !== 'tv' &&
             !req.user?.hasPermission(Permission.REQUEST_ADVANCED))) &&
         !req.user?.hasPermission(Permission.MANAGE_REQUESTS)
@@ -496,7 +500,7 @@ requestRoutes.put<{ requestId: string }>(
 
       if (
         req.body.userId &&
-        req.body.userId !== request.requestedBy.id &&
+        req.body.userId !== request.requestedBy?.id &&
         !req.user?.hasPermission([
           Permission.MANAGE_USERS,
           Permission.MANAGE_REQUESTS,
@@ -609,14 +613,18 @@ requestRoutes.delete('/:requestId', async (req, res, next) => {
   const requestRepository = getRepository(MediaRequest);
 
   try {
-    const request = await requestRepository.findOneOrFail({
+    const request = await requestRepository.findOne({
       where: { id: Number(req.params.requestId) },
       relations: { requestedBy: true, modifiedBy: true },
     });
 
+    if (!request) {
+      return next({ status: 404, message: 'Request not found.' });
+    }
+
     if (
       !req.user?.hasPermission(Permission.MANAGE_REQUESTS) &&
-      (request.requestedBy.id !== req.user?.id ||
+      (request.requestedBy?.id !== req.user?.id ||
         request.status !== MediaRequestStatus.PENDING)
     ) {
       return next({
@@ -646,10 +654,14 @@ requestRoutes.post<{
     const requestRepository = getRepository(MediaRequest);
 
     try {
-      const request = await requestRepository.findOneOrFail({
+      const request = await requestRepository.findOne({
         where: { id: Number(req.params.requestId) },
         relations: { requestedBy: true, modifiedBy: true },
       });
+
+      if (!request) {
+        return next({ status: 404, message: 'Request not found.' });
+      }
 
       if (request.status !== MediaRequestStatus.FAILED) {
         return next({
@@ -684,10 +696,14 @@ requestRoutes.post<{
     const requestRepository = getRepository(MediaRequest);
 
     try {
-      const request = await requestRepository.findOneOrFail({
+      const request = await requestRepository.findOne({
         where: { id: Number(req.params.requestId) },
         relations: { requestedBy: true, modifiedBy: true },
       });
+
+      if (!request) {
+        return next({ status: 404, message: 'Request not found.' });
+      }
 
       let newStatus: MediaRequestStatus;
 

--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -106,10 +106,11 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
             </div>
             {requestData && (
               <>
-                {hasPermission(
-                  [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
-                  { type: 'or' }
-                ) && (
+                {requestData.requestedBy &&
+                  hasPermission(
+                    [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
+                    { type: 'or' }
+                  ) && (
                   <div className="card-field !hidden sm:!block">
                     <Link
                       href={`/users/${requestData.requestedBy.id}`}
@@ -383,11 +384,12 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
           >
             {isMovie(title) ? title.title : title.name}
           </Link>
-          {hasPermission(
-            [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
-            { type: 'or' }
-          ) && (
-            <div className="card-field">
+          {requestData.requestedBy &&
+            hasPermission(
+              [Permission.MANAGE_REQUESTS, Permission.REQUEST_VIEW],
+              { type: 'or' }
+            ) && (
+              <div className="card-field">
               <Link
                 href={`/users/${requestData.requestedBy.id}`}
                 className="group flex items-center"
@@ -565,7 +567,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
               )}
             {requestData.status === MediaRequestStatus.PENDING &&
               !hasPermission(Permission.MANAGE_REQUESTS) &&
-              requestData.requestedBy.id === user?.id &&
+              requestData.requestedBy?.id === user?.id &&
               (requestData.type === 'tv' ||
                 hasPermission(Permission.REQUEST_ADVANCED)) && (
                 <div>
@@ -596,7 +598,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
               )}
             {requestData.status === MediaRequestStatus.PENDING &&
               !hasPermission(Permission.MANAGE_REQUESTS) &&
-              requestData.requestedBy.id === user?.id && (
+              requestData.requestedBy?.id === user?.id && (
                 <div>
                   <Button
                     buttonType="danger"


### PR DESCRIPTION
## Description

Replacing `requestRepository.findOneOrFail` with `findOne` plus an explicit 404 in the request routes, and guarding `RequestCard` against a null `requestedBy`, stops the Discover/request-list "Oops" crash and per-request errors that occur when a request's `requestedById` FK is NULL (e.g. after a user is removed from the app, leaving an orphaned FK).

The entity declares `requestedBy` as non-nullable, but orphaned rows still occur, so the code (which assumes non-null) must be hardened against it.

- Fixes the Discover / request-list page crash (null dereference on `requestData.requestedBy`).
- Fixes `GET /api/v1/request/:id`, retry, and status routes erroring/404ing for such requests.

## How Has This Been Tested?

Confirmed against a live instance where requests 95/121/124 had `requestedById = NULL`:

- `GET /api/v1/request/{id}` returns 200 after the fix (was 404 before).
- Discover and request-list pages render without crashing.
- Ran the repo's prettier check against both changed files - clean.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)