### PR TITLE
fix: fix empty discordId in comment webhooks

### DIFF
--- a/server/subscriber/IssueCommentSubscriber.ts
+++ b/server/subscriber/IssueCommentSubscriber.ts
@@ -27,7 +27,7 @@ export class IssueCommentSubscriber implements EntitySubscriberInterface<IssueCo
       const issue = (
         await getRepository(IssueComment).findOneOrFail({
           where: { id: entity.id },
-          relations: { issue: true },
+          relations: { issue: { createdBy: true } },
         })
       ).issue;
 


### PR DESCRIPTION
## Description

`relations: { issue: true }` only cascades one level of eager relations on typeorm 0.3x, so `Issue.createdBy` is joined but `User.settings` (eager on `User`) is not, leaving `issue.createdBy.settings` undefined. This left `reportedBy_settings_discordIds`/`telegramChatId` empty in `ISSUE_COMMENT`
webhook payloads, while `ISSUE_CREATED`/`ISSUE_RESOLVED` were unaffected since those use the entity straight off the TypeORM `insert`/`update` event instead of a reload.

This PR nests the relations option one level deeper so `createdBy`'s own eager relations (settings) are cascaded too.

- Fixes #3465

## How Has This Been Tested?

- Manually

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue comment notifications now reliably include the related issue creator’s information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->