### PR TITLE
fix: improve Servarr download queue syncing

### DIFF
--- a/server/api/servarr/base.test.ts
+++ b/server/api/servarr/base.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+import SonarrAPI from '@server/api/servarr/sonarr';
+
+function buildSonarr(): SonarrAPI {
+  return new SonarrAPI({ url: 'http://localhost:8989/api/v3', apiKey: 'test' });
+}
+
+function getAxios(sonarr: SonarrAPI): AxiosInstance {
+  return (sonarr as unknown as { axios: AxiosInstance }).axios;
+}
+
+function queueResponse(
+  page: number,
+  totalRecords: number,
+  records: Record<string, unknown>[]
+) {
+  return {
+    data: {
+      page,
+      pageSize: 100,
+      sortKey: 'timeleft',
+      sortDirection: 'ascending',
+      totalRecords,
+      records,
+    },
+  };
+}
+
+describe('ServarrBase queue pagination', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('retrieves every queue page and preserves episode data', async () => {
+    const sonarr = buildSonarr();
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      episode: { seasonNumber: 1, episodeNumber: index + 1 },
+    }));
+    const secondPage = Array.from({ length: 14 }, (_, index) => ({
+      id: index + 101,
+      episode: { seasonNumber: 2, episodeNumber: index + 1 },
+    }));
+    const get = mock.method(
+      getAxios(sonarr),
+      'get',
+      async (_path: string, config?: AxiosRequestConfig) =>
+        config?.params?.page === 1
+          ? queueResponse(1, 114, firstPage)
+          : queueResponse(2, 114, secondPage)
+    );
+
+    const queue = await sonarr.getQueue();
+
+    assert.strictEqual(queue.length, 114);
+    assert.deepStrictEqual(queue[113].episode, {
+      seasonNumber: 2,
+      episodeNumber: 14,
+    });
+    assert.strictEqual(get.mock.callCount(), 2);
+    assert.deepStrictEqual(get.mock.calls[0].arguments[1]?.params, {
+      includeEpisode: true,
+      page: 1,
+      pageSize: 100,
+    });
+  });
+
+  it('rejects the whole queue fetch when a later page fails', async () => {
+    const sonarr = buildSonarr();
+    let page = 0;
+    mock.method(getAxios(sonarr), 'get', async () => {
+      page += 1;
+      if (page === 1) {
+        return queueResponse(
+          1,
+          101,
+          Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }))
+        );
+      }
+
+      throw new Error('second page unavailable');
+    });
+
+    await assert.rejects(() => sonarr.getQueue(), /Failed to retrieve queue/);
+  });
+});
+
+describe('ServarrBase command completion', () => {
+  afterEach(() => mock.restoreAll());
+
+  it('waits for the submitted command to complete successfully', async () => {
+    const sonarr = buildSonarr();
+    mock.method(getAxios(sonarr), 'post', async () => ({
+      data: { id: 42, status: 'queued', result: 'unknown' },
+    }));
+    let poll = 0;
+    const get = mock.method(getAxios(sonarr), 'get', async () => {
+      poll += 1;
+      return {
+        data:
+          poll === 1
+            ? { id: 42, status: 'started', result: 'unknown' }
+            : { id: 42, status: 'completed', result: 'successful' },
+      };
+    });
+
+    await sonarr.refreshMonitoredDownloads({
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    assert.strictEqual(get.mock.callCount(), 2);
+    assert.strictEqual(get.mock.calls[0].arguments[0], '/command/42');
+  });
+
+  it('rejects a failed command', async () => {
+    const sonarr = buildSonarr();
+    mock.method(getAxios(sonarr), 'post', async () => ({
+      data: { id: 43, status: 'queued', result: 'unknown' },
+    }));
+    mock.method(getAxios(sonarr), 'get', async () => ({
+      data: {
+        id: 43,
+        status: 'failed',
+        result: 'unsuccessful',
+        exception: 'client unavailable',
+      },
+    }));
+
+    await assert.rejects(
+      () =>
+        sonarr.refreshMonitoredDownloads({
+          pollIntervalMs: 1,
+          timeoutMs: 100,
+        }),
+      /client unavailable/
+    );
+  });
+
+  it('rejects when command completion times out', async () => {
+    const sonarr = buildSonarr();
+    mock.method(getAxios(sonarr), 'post', async () => ({
+      data: { id: 44, status: 'queued', result: 'unknown' },
+    }));
+    mock.method(getAxios(sonarr), 'get', async () => ({
+      data: { id: 44, status: 'started', result: 'unknown' },
+    }));
+
+    await assert.rejects(
+      () =>
+        sonarr.refreshMonitoredDownloads({
+          pollIntervalMs: 1,
+          timeoutMs: 5,
+        }),
+      /timed out/
+    );
+  });
+});

--- a/server/api/servarr/base.test.ts
+++ b/server/api/servarr/base.test.ts
@@ -157,4 +157,33 @@ describe('ServarrBase command completion', () => {
       /timed out/
     );
   });
+
+  it('rejects when a command poll completes after the deadline', async () => {
+    const sonarr = buildSonarr();
+    mock.method(getAxios(sonarr), 'post', async () => ({
+      data: { id: 45, status: 'queued', result: 'unknown' },
+    }));
+    const get = mock.method(
+      getAxios(sonarr),
+      'get',
+      async (_path: string, config?: AxiosRequestConfig) => {
+        assert.ok(config?.timeout);
+        assert.ok(config.timeout <= 20);
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        return {
+          data: { id: 45, status: 'completed', result: 'successful' },
+        };
+      }
+    );
+
+    await assert.rejects(
+      () =>
+        sonarr.refreshMonitoredDownloads({
+          pollIntervalMs: 1,
+          timeoutMs: 20,
+        }),
+      /Command 45 timed out after 20ms/
+    );
+    assert.strictEqual(get.mock.callCount(), 1);
+  });
 });

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -78,6 +78,24 @@ interface QueueResponse<QueueItemAppendT> {
   records: (QueueItem & QueueItemAppendT)[];
 }
 
+interface CommandResponse {
+  id: number;
+  status:
+    | 'queued'
+    | 'started'
+    | 'completed'
+    | 'failed'
+    | 'aborted'
+    | 'cancelled'
+    | 'orphaned';
+  result: 'unknown' | 'successful' | 'unsuccessful';
+  exception?: string;
+}
+
+const QUEUE_PAGE_SIZE = 100;
+const COMMAND_POLL_INTERVAL_MS = 1000;
+const COMMAND_TIMEOUT_MS = 30000;
+
 class ServarrBase<QueueItemAppendT> extends ExternalAPI {
   static buildUrl(settings: DVRSettings, path?: string): string {
     return `${settings.useSsl ? 'https' : 'http'}://${settings.hostname}:${
@@ -163,16 +181,37 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
 
   public getQueue = async (): Promise<(QueueItem & QueueItemAppendT)[]> => {
     try {
-      const response = await this.axios.get<QueueResponse<QueueItemAppendT>>(
-        `/queue`,
-        {
-          params: {
-            includeEpisode: true,
-          },
-        }
-      );
+      const records: (QueueItem & QueueItemAppendT)[] = [];
+      let page = 1;
+      let totalRecords: number;
 
-      return response.data.records;
+      do {
+        const response = await this.axios.get<QueueResponse<QueueItemAppendT>>(
+          `/queue`,
+          {
+            params: {
+              includeEpisode: true,
+              page,
+              pageSize: QUEUE_PAGE_SIZE,
+            },
+          }
+        );
+
+        records.push(...response.data.records);
+        totalRecords = response.data.totalRecords;
+        page += 1;
+
+        if (
+          response.data.records.length === 0 &&
+          records.length < totalRecords
+        ) {
+          throw new Error(
+            `Queue pagination ended after ${records.length} of ${totalRecords} records`
+          );
+        }
+      } while (records.length < totalRecords);
+
+      return records;
     } catch (e) {
       throw new Error(
         `[${this.apiName}] Failed to retrieve queue: ${e.message}`,
@@ -229,24 +268,84 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     }
   };
 
-  async refreshMonitoredDownloads(): Promise<void> {
-    await this.runCommand('RefreshMonitoredDownloads', {});
+  async refreshMonitoredDownloads({
+    pollIntervalMs = COMMAND_POLL_INTERVAL_MS,
+    timeoutMs = COMMAND_TIMEOUT_MS,
+  }: {
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+  } = {}): Promise<void> {
+    const command = await this.runCommand('RefreshMonitoredDownloads', {});
+    await this.waitForCommand(command.id, pollIntervalMs, timeoutMs);
   }
 
   protected async runCommand(
     commandName: string,
     options: Record<string, unknown>
-  ): Promise<void> {
+  ): Promise<CommandResponse> {
     try {
-      await this.axios.post(`/command`, {
+      const response = await this.axios.post<CommandResponse>(`/command`, {
         name: commandName,
         ...options,
       });
+
+      return response.data;
     } catch (e) {
       throw new Error(`[${this.apiName}] Failed to run command: ${e.message}`, {
         cause: e,
       });
     }
+  }
+
+  private async waitForCommand(
+    commandId: number,
+    pollIntervalMs: number,
+    timeoutMs: number
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+      let command: CommandResponse;
+      try {
+        const response = await this.axios.get<CommandResponse>(
+          `/command/${commandId}`
+        );
+        command = response.data;
+      } catch (e) {
+        throw new Error(
+          `[${this.apiName}] Failed to retrieve command ${commandId}: ${e.message}`,
+          { cause: e }
+        );
+      }
+
+      if (command.status === 'completed' && command.result === 'successful') {
+        return;
+      }
+
+      if (
+        command.status === 'failed' ||
+        command.status === 'aborted' ||
+        command.status === 'cancelled' ||
+        command.status === 'orphaned' ||
+        command.status === 'completed'
+      ) {
+        throw new Error(
+          `[${this.apiName}] Command ${commandId} ${command.status}: ${
+            command.exception ?? command.result
+          }`
+        );
+      }
+
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(pollIntervalMs, remainingMs))
+      );
+    }
+
+    throw new Error(
+      `[${this.apiName}] Command ${commandId} timed out after ${timeoutMs}ms`
+    );
   }
 }
 

--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -2,6 +2,7 @@ import ExternalAPI from '@server/api/externalapi';
 import type { AvailableCacheIds } from '@server/lib/cache';
 import cacheManager from '@server/lib/cache';
 import { getSettings, type DVRSettings } from '@server/lib/settings';
+import axios from 'axios';
 
 export interface SystemStatus {
   version: string;
@@ -304,19 +305,38 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
   ): Promise<void> {
     const deadline = Date.now() + timeoutMs;
 
-    while (Date.now() <= deadline) {
+    while (true) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+
+      const axiosTimeout = this.axios.defaults.timeout;
+      const requestTimeout =
+        axiosTimeout && axiosTimeout > 0
+          ? Math.min(axiosTimeout, remainingMs)
+          : remainingMs;
       let command: CommandResponse;
       try {
         const response = await this.axios.get<CommandResponse>(
-          `/command/${commandId}`
+          `/command/${commandId}`,
+          { timeout: requestTimeout }
         );
         command = response.data;
       } catch (e) {
+        if (
+          requestTimeout === remainingMs &&
+          axios.isAxiosError(e) &&
+          (e.code === 'ECONNABORTED' || e.code === 'ETIMEDOUT')
+        ) {
+          break;
+        }
+
         throw new Error(
           `[${this.apiName}] Failed to retrieve command ${commandId}: ${e.message}`,
           { cause: e }
         );
       }
+
+      if (Date.now() >= deadline) break;
 
       if (command.status === 'completed' && command.result === 'successful') {
         return;
@@ -336,10 +356,10 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
         );
       }
 
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) break;
+      const delayRemainingMs = deadline - Date.now();
+      if (delayRemainingMs <= 0) break;
       await new Promise((resolve) =>
-        setTimeout(resolve, Math.min(pollIntervalMs, remainingMs))
+        setTimeout(resolve, Math.min(pollIntervalMs, delayRemainingMs))
       );
     }
 

--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -205,7 +205,11 @@ export const startJobs = (): void => {
       logger.debug('Starting scheduled job: Download Sync', {
         label: 'Jobs',
       });
-      downloadTracker.updateDownloads();
+      downloadTracker.updateDownloads().catch((e) => {
+        logger.error(`Failed to update download tracker: ${e.message}`, {
+          label: 'Jobs',
+        });
+      });
     }),
   });
 

--- a/server/lib/downloadtracker.test.ts
+++ b/server/lib/downloadtracker.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+import { DownloadTracker } from '@server/lib/downloadtracker';
+
+describe('DownloadTracker updateDownloads', () => {
+  it('shares one active refresh between concurrent callers', async () => {
+    const tracker = new DownloadTracker();
+    let resolveRefresh: (() => void) | undefined;
+    const refresh = mock.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    (
+      tracker as unknown as {
+        performUpdateDownloads: () => Promise<void>;
+      }
+    ).performUpdateDownloads = refresh;
+
+    const first = tracker.updateDownloads();
+    const second = tracker.updateDownloads();
+
+    assert.strictEqual(first, second);
+    assert.strictEqual(refresh.mock.callCount(), 1);
+
+    resolveRefresh?.();
+    await first;
+
+    const third = tracker.updateDownloads();
+    assert.notStrictEqual(third, first);
+    assert.strictEqual(refresh.mock.callCount(), 2);
+    resolveRefresh?.();
+    await third;
+  });
+});

--- a/server/lib/downloadtracker.ts
+++ b/server/lib/downloadtracker.ts
@@ -24,9 +24,10 @@ export interface DownloadingItem {
   episode?: EpisodeNumberResult;
 }
 
-class DownloadTracker {
+export class DownloadTracker {
   private radarrServers: Record<number, DownloadingItem[]> = {};
   private sonarrServers: Record<number, DownloadingItem[]> = {};
+  private updatePromise?: Promise<void>;
 
   public getMovieProgress(
     serverId: number,
@@ -59,9 +60,21 @@ class DownloadTracker {
     this.sonarrServers = {};
   }
 
-  public updateDownloads() {
-    this.updateRadarrDownloads();
-    this.updateSonarrDownloads();
+  public updateDownloads(): Promise<void> {
+    if (!this.updatePromise) {
+      this.updatePromise = this.performUpdateDownloads().finally(() => {
+        this.updatePromise = undefined;
+      });
+    }
+
+    return this.updatePromise;
+  }
+
+  private async performUpdateDownloads(): Promise<void> {
+    await Promise.all([
+      this.updateRadarrDownloads(),
+      this.updateSonarrDownloads(),
+    ]);
   }
 
   private async updateRadarrDownloads() {
@@ -77,7 +90,7 @@ class DownloadTracker {
     });
 
     // Load downloads from Radarr servers
-    Promise.all(
+    await Promise.all(
       filteredServers.map(async (server) => {
         if (server.syncEnabled) {
           const radarr = new RadarrAPI({
@@ -155,7 +168,7 @@ class DownloadTracker {
     });
 
     // Load downloads from Sonarr servers
-    Promise.all(
+    await Promise.all(
       filteredServers.map(async (server) => {
         if (server.syncEnabled) {
           const sonarr = new SonarrAPI({


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

The /queue endpoint is paginated and defaults to 10 records, but Seerr was only reading the first page. With more than 10 items the rest where lost. This change fetches the full queue and waits for `RefreshMonitoredDownloads` to complete before reading it.

I used ChatGPT to investigate the issue, help with the changes and tests. I reviewd the code changes and tested against a local Seerr instance with live sonarr.

## How Has This Been Tested?

Added automated tests for queue pagination, refresh command handling, failures/timeouts, and overlapping sync calls.

I also tested it against Sonarr with:
- a 27-episode season pack;
- 13 individual episode downloads.

In both cases Seerr received all queue entries and the correct per-episode progress.

## Screenshots / Logs (if applicable)
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Queue retrieval now includes all available pages while preserving episode details.
  * Monitored download refreshes now wait for command completion and clearly report failures or timeouts.
  * Concurrent download updates are consolidated into a single refresh, preventing duplicate work.
* **Bug Fixes**
  * Scheduled download synchronization errors are now caught and logged instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->