### PR TITLE
ci: remove third party action dawidd6/action-download-artifact

### DIFF
--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -52,14 +52,23 @@ jobs:
           CI: true
         run: pnpm install --frozen-lockfile
 
-      - name: Download issue index
-        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
+      - name: Get latest successful run id
+        id: get-latest-run-id
+        run: |
+          RUN_ID=$(gh api \
+            /repos/${{ github.repository }}/actions/workflows/rebuild-issue-index.yml/runs \
+            --jq '[.workflow_runs[] | select(.status=="completed" and .conclusion=="success")][0].id')
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: issue-index
-          workflow: rebuild-issue-index.yml
           path: bin/duplicate-detector
-          search_artifacts: true
-          if_no_artifact_found: warn
+          run-id: ${{ steps.get-latest-run-id.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build index if missing
         working-directory: bin/duplicate-detector

--- a/.github/workflows/detect-duplicate.yml
+++ b/.github/workflows/detect-duplicate.yml
@@ -57,12 +57,14 @@ jobs:
         run: |
           RUN_ID=$(gh api \
             /repos/${{ github.repository }}/actions/workflows/rebuild-issue-index.yml/runs \
-            --jq '[.workflow_runs[] | select(.status=="completed" and .conclusion=="success")][0].id')
+            --jq '[.workflow_runs[] | select(.status=="completed" and .conclusion=="success")][0].id // empty')
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifact
+        if: steps.get-latest-run-id.outputs.run_id != ''
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: issue-index


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Replace third party  action

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Didn't test except the `gh api` call.
```
$ gh api /repos/seerr-team/seerr/actions/workflows/rebuild-issue-index.yml/runs --jq '[.workflow_runs[] | select(.status=="completed" and .conclusion=="success")][0].id'
34008186513
```

## Screenshots / Logs (if applicable)

n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved duplicate-detection workflow handling when no index rebuild run is available.
  - Artifact downloads are now skipped when no run identifier is found.
  - Failed artifact downloads no longer prevent the workflow from attempting to build the index when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->