### PR TITLE
docs(discord): document the Thread ID notification setting.

### DIFF
--- a/docs/using-seerr/notifications/discord.md
+++ b/docs/using-seerr/notifications/discord.md
@@ -22,6 +22,10 @@ You can find the webhook URL in the Discord application, at **Server Settings &r
 
 If a role ID is specified, it will be included in the webhook message. See [Discord role ID](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID).
 
+### Thread ID (optional)
+
+If a thread ID is specified, the notification will be sent to a specific thread, instead of the webhook channel. Leave it blank to send it directly to the channel.
+
 ### Bot Username (optional)
 
 If you would like to override the name you configured for your bot in Discord, you may set this value to whatever you like!


### PR DESCRIPTION
Adding to the document the Thread ID feature

<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail --> Adding the Thread ID feature in the Discord document.
<!--- Why is this change required? What problem does it solve? --> This change adds more organization to the project without any downsides whatsoever. Keeps the docs updated and helps new collaborators to deep into this new feature.
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Documentation-only change. No application code was modified.

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
No AI used.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
(This is a documentation-only change to docs/using-seerr/notifications/discord.md.
No application code was modified, so none of the items above apply).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for optionally configuring a Discord Thread ID to route notifications to a specific thread.
  - Clarified that blank values use the webhook channel, while threads from other channels can cause delivery failure.
  - Reformatted the Notification Language description without changing its content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->