### PR TITLE
fix(requests): scope request availability badge to requested seasons

### DIFF
--- a/src/components/RequestCard/index.tsx
+++ b/src/components/RequestCard/index.tsx
@@ -14,6 +14,7 @@ import {
   getRequestDownloadStatus,
   refreshIntervalHelper,
 } from '@app/utils/refreshIntervalHelper';
+import getRequestedSeasonsStatus from '@app/utils/requestStatus';
 import { withProperties } from '@app/utils/typeHelpers';
 import {
   ArrowPathIcon,
@@ -156,11 +157,7 @@ const RequestCardError = ({ requestData }: RequestCardErrorProps) => {
                     </Badge>
                   ) : (
                     <StatusBadge
-                      status={
-                        requestData.media[
-                          requestData.is4k ? 'status4k' : 'status'
-                        ]
-                      }
+                      status={getRequestedSeasonsStatus(requestData)}
                       downloadItem={requestDownloadStatus}
                       title={intl.formatMessage(messages.unknowntitle)}
                       inProgress={requestDownloadStatus.length > 0}
@@ -459,9 +456,7 @@ const RequestCard = ({ request, onTitleData }: RequestCardProps) => {
               </Badge>
             ) : (
               <StatusBadge
-                status={
-                  requestData.media[requestData.is4k ? 'status4k' : 'status']
-                }
+                status={getRequestedSeasonsStatus(requestData)}
                 downloadItem={requestDownloadStatus}
                 title={isMovie(title) ? title.title : title.name}
                 inProgress={requestDownloadStatus.length > 0}

--- a/src/components/RequestList/RequestItem/index.tsx
+++ b/src/components/RequestList/RequestItem/index.tsx
@@ -14,6 +14,7 @@ import {
   getRequestDownloadStatus,
   refreshIntervalHelper,
 } from '@app/utils/refreshIntervalHelper';
+import getRequestedSeasonsStatus from '@app/utils/requestStatus';
 import {
   ArrowPathIcon,
   CheckIcon,
@@ -146,11 +147,7 @@ const RequestItemError = ({
                   </Badge>
                 ) : (
                   <StatusBadge
-                    status={
-                      requestData.media[
-                        requestData.is4k ? 'status4k' : 'status'
-                      ]
-                    }
+                    status={getRequestedSeasonsStatus(requestData)}
                     downloadItem={requestDownloadStatus}
                     title={intl.formatMessage(messages.unknowntitle)}
                     inProgress={requestDownloadStatus.length > 0}
@@ -544,9 +541,7 @@ const RequestItem = ({ request, revalidateList }: RequestItemProps) => {
                 </Badge>
               ) : (
                 <StatusBadge
-                  status={
-                    requestData.media[requestData.is4k ? 'status4k' : 'status']
-                  }
+                  status={getRequestedSeasonsStatus(requestData)}
                   downloadItem={requestDownloadStatus}
                   title={isMovie(title) ? title.title : title.name}
                   inProgress={requestDownloadStatus.length > 0}

--- a/src/utils/requestStatus.ts
+++ b/src/utils/requestStatus.ts
@@ -1,0 +1,51 @@
+import { MediaStatus } from '@server/constants/media';
+import type { MediaRequest } from '@server/entity/MediaRequest';
+import type { NonFunctionProperties } from '@server/interfaces/api/common';
+
+// Resolves the availability status to show for a request. Movie requests use the
+// media status directly. TV requests are scoped to the specific seasons that were
+// requested, so their status is derived from just those seasons rather than the
+// whole show: fully available only when every requested season is available, and
+// partially available when at least one requested season is available.
+export const getRequestedSeasonsStatus = (
+  requestData: NonFunctionProperties<MediaRequest>
+): MediaStatus | undefined => {
+  const statusKey = requestData.is4k ? 'status4k' : 'status';
+
+  if (requestData.type !== 'tv' || !requestData.seasons.length) {
+    return requestData.media[statusKey];
+  }
+
+  const requestedSeasonNumbers = new Set(
+    requestData.seasons.map((season) => season.seasonNumber)
+  );
+  const requestedSeasonStatuses = (requestData.media.seasons ?? [])
+    .filter((season) => requestedSeasonNumbers.has(season.seasonNumber))
+    .map((season) => season[statusKey]);
+
+  // Fall back to the media status when the requested seasons aren't loaded yet
+  // (e.g. the request-list payload before the per-request fetch resolves).
+  if (!requestedSeasonStatuses.length) {
+    return requestData.media[statusKey];
+  }
+
+  if (
+    requestedSeasonStatuses.every((status) => status === MediaStatus.AVAILABLE)
+  ) {
+    return MediaStatus.AVAILABLE;
+  }
+
+  if (
+    requestedSeasonStatuses.some(
+      (status) =>
+        status === MediaStatus.AVAILABLE ||
+        status === MediaStatus.PARTIALLY_AVAILABLE
+    )
+  ) {
+    return MediaStatus.PARTIALLY_AVAILABLE;
+  }
+
+  return Math.min(...requestedSeasonStatuses) as MediaStatus;
+};
+
+export default getRequestedSeasonsStatus;


### PR DESCRIPTION
## What this changes

A request for only some seasons of a multi-season show currently shows **Partially Available** and never flips to **Available**, even after every season you actually requested is available. The badge reads the show's overall status, not the seasons the request was for.

This scopes the request's availability badge to the **specific seasons that were requested**:

- Request S8 only, S8 available → **Available**
- Request S1–S3, some available → **Partially Available**
- Request S1–S3, none available yet → falls back to the current behavior

Movie requests and the show-level media badge are untouched.

## Where

- `src/utils/requestStatus.ts` — new `getRequestedSeasonsStatus` helper: rolls up the requested seasons' own statuses (`media.seasons[].status` / `status4k`).
- `src/components/RequestList/RequestItem/index.tsx` and `src/components/RequestCard/index.tsx` — the two request views now pass that helper's result to `StatusBadge` instead of `media.status`.

## Why it needs no backend change

`MediaRequest.media` and `Media.seasons` are both `eager`, so `/api/v1/request/:id` (which every request row fetches) already returns `media.seasons[].status`. The helper falls back to the media status when seasons aren't present (e.g. the request-list payload before the per-row fetch resolves), so there's no regression during that window.

## Scope

Only the badge shown on a request is changed. The show-level "Available/Partially Available" badge and the request-list server-side status filter are intentionally left alone.

## Related

- seerr #800, #710
- Original report: sct/overseerr #3796