### PR TITLE
fix(search): normalize queries before forwarding to TMDB

### DIFF
--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -173,6 +173,19 @@ const stripUnreadTvCredits = <T>(data: T): T => {
   return data;
 };
 
+// Canonical search form so punctuation, spacing, and diacritics don't hide
+// titles from TMDB's literal matching. Apostrophes are contracted ("don't" ->
+// "dont") rather than turned into spaces so the words stay joined.
+export const normalizeSearchQuery = (query: string): string =>
+  query
+    .replace(/'/g, '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+
 class TheMovieDb extends ExternalAPI implements TvShowProvider {
   private scanCache = cacheManager.getCache('tmdbscan').data;
   private locale: string;
@@ -208,7 +221,12 @@ class TheMovieDb extends ExternalAPI implements TvShowProvider {
   }: SearchOptions): Promise<TmdbSearchMultiResponse> => {
     try {
       const data = await this.get<TmdbSearchMultiResponse>('/search/multi', {
-        params: { query, page, include_adult: includeAdult, language },
+        params: {
+          query: normalizeSearchQuery(query),
+          page,
+          include_adult: includeAdult,
+          language,
+        },
       });
 
       return data;

--- a/server/api/themoviedb/index.ts
+++ b/server/api/themoviedb/index.ts
@@ -174,11 +174,12 @@ const stripUnreadTvCredits = <T>(data: T): T => {
 };
 
 // Canonical search form so punctuation, spacing, and diacritics don't hide
-// titles from TMDB's literal matching. Apostrophes are contracted ("don't" ->
-// "dont") rather than turned into spaces so the words stay joined.
+// titles from TMDB's literal matching. Apostrophes (straight and typographic)
+// are contracted ("don't"/"don’t" -> "dont") rather than turned into spaces so
+// the words stay joined.
 export const normalizeSearchQuery = (query: string): string =>
   query
-    .replace(/'/g, '')
+    .replace(/['\u2019]/g, '')
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^\p{L}\p{N}\s]+/gu, ' ')

--- a/server/api/themoviedb/search.test.ts
+++ b/server/api/themoviedb/search.test.ts
@@ -10,6 +10,7 @@ describe('normalizeSearchQuery', () => {
     );
     assert.equal(normalizeSearchQuery('Dune: Part Two'), 'dune part two');
     assert.equal(normalizeSearchQuery("don't"), 'dont');
+    assert.equal(normalizeSearchQuery('don\u2019t'), 'dont');
     assert.equal(normalizeSearchQuery('café'), 'cafe');
     assert.equal(normalizeSearchQuery('A   B\tC'), 'a b c');
   });

--- a/server/api/themoviedb/search.test.ts
+++ b/server/api/themoviedb/search.test.ts
@@ -1,0 +1,16 @@
+import { normalizeSearchQuery } from '@server/api/themoviedb';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('normalizeSearchQuery', () => {
+  it('normalizes punctuation, spacing, diacritics, apostrophes, and case', () => {
+    assert.equal(
+      normalizeSearchQuery('  The Godfather, Part II!  '),
+      'the godfather part ii'
+    );
+    assert.equal(normalizeSearchQuery('Dune: Part Two'), 'dune part two');
+    assert.equal(normalizeSearchQuery("don't"), 'dont');
+    assert.equal(normalizeSearchQuery('café'), 'cafe');
+    assert.equal(normalizeSearchQuery('A   B\tC'), 'a b c');
+  });
+});


### PR DESCRIPTION
## Description

TMDB's search endpoint matches literally, so any difference in punctuation, spacing, diacritics, or case between what you type and the stored title returns nothing. This PR normalizes the query before the search call so minor formatting differences stop hiding titles.

The query is normalized before being sent to `/search/multi`: apostrophes and diacritics are stripped, punctuation and whitespace are collapsed, and everything is lowercased. "The Godfather, Part II!" and "the godfather part ii" now produce the same tokens, and a unit test covers the normalizer against punctuation, spacing, diacritics, apostrophes, and case.

- Fixes #3499

## How Has This Been Tested?

Ran `pnpm build`, `pnpm typecheck:server`, and ESLint and Prettier on the changed files. Added and ran a unit test for `normalizeSearchQuery` through the repo's test harness (`node server/test/index.mts server/api/themoviedb/search.test.ts`); it passes. The full test suite has unrelated failures in this environment that reproduce identically on unmodified `develop`, so they are not introduced by this change.

## Screenshots / Logs (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI: **initial codebase analysis**
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movie and media search matching by standardizing search text before processing.
  * Searches now handle capitalization, punctuation, apostrophes, accented characters, and extra spaces more consistently.

* **Tests**
  * Added coverage for search-query normalization, including punctuation, whitespace, apostrophes, and diacritics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->