### PR TITLE
fix(server): respond instead of hanging on proxy route errors

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -267,8 +267,11 @@ app
         res: Response,
         // We must provide a next function for the function signature here even though its not used
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        _next: NextFunction
+        next: NextFunction
       ) => {
+        if (res.headersSent) {
+          return next(err);
+        }
         // format error
         res.status(err.status || 500).json({
           message: err.message,

--- a/server/index.ts
+++ b/server/index.ts
@@ -265,8 +265,6 @@ app
         err: { status: number; message: string; errors: string[] },
         _req: Request,
         res: Response,
-        // We must provide a next function for the function signature here even though its not used
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         next: NextFunction
       ) => {
         if (res.headersSent) {

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -115,19 +115,17 @@ export async function checkAvatarChanged(
   }
 }
 
-router.get('/:jellyfinUserId', async (req, res) => {
+router.get('/:jellyfinUserId', async (req, res, next) => {
+  if (!req.params.jellyfinUserId.match(/^[a-f0-9]{32}$/)) {
+    const mediaServerType = getSettings().main.mediaServerType;
+    return next({
+      status: 400,
+      message: `Provided URL is not ${
+        mediaServerType === MediaServerType.JELLYFIN ? 'a Jellyfin' : 'an Emby'
+      } avatar.`,
+    });
+  }
   try {
-    if (!req.params.jellyfinUserId.match(/^[a-f0-9]{32}$/)) {
-      const mediaServerType = getSettings().main.mediaServerType;
-      throw new Error(
-        `Provided URL is not ${
-          mediaServerType === MediaServerType.JELLYFIN
-            ? 'a Jellyfin'
-            : 'an Emby'
-        } avatar.`
-      );
-    }
-
     const avatarImageCache = await initAvatarImageProxy();
 
     const userEtag = req.headers['if-none-match'];
@@ -173,9 +171,14 @@ router.get('/:jellyfinUserId', async (req, res) => {
 
     res.end(imageData.imageBuffer);
   } catch (e) {
-    logger.error('Failed to proxy avatar image', {
-      errorMessage: e.message,
-    });
+    logger.error('Failed to proxy avatar image', { errorMessage: e.message });
+    if (!res.headersSent) {
+      return next({
+        status: 500,
+        message: 'Failed to proxy avatar image.',
+      });
+    }
+    next(e);
   }
 });
 

--- a/server/routes/imageproxy.ts
+++ b/server/routes/imageproxy.ts
@@ -33,12 +33,12 @@ function initTvdbImageProxy() {
 router.get<{
   type: string;
   path: string[];
-}>('/:type/*path', async (req, res) => {
+}>('/:type/*path', async (req, res, next) => {
   const imagePath = '/' + req.params.path.join('/');
 
   if (imagePath.startsWith('//') || imagePath.includes('://')) {
     logger.error('Invalid URL for image proxy', { imagePath });
-    return res.status(403).send('Invalid URL for image proxy');
+    return next({ status: 403, message: 'Invalid URL for image proxy.' });
   }
 
   try {
@@ -52,8 +52,7 @@ router.get<{
         imagePath,
         type: req.params.type,
       });
-      res.status(400).send('Unsupported image type');
-      return;
+      return next({ status: 400, message: 'Unsupported image type.' });
     }
 
     res.writeHead(200, {
@@ -70,7 +69,10 @@ router.get<{
       imagePath,
       errorMessage: e.message,
     });
-    res.status(500).send();
+    if (!res.headersSent) {
+      return next({ status: 500, message: 'Failed to proxy image.' });
+    }
+    next(e);
   }
 });
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail -->Prevents an infinite hang when the :jellyfinUserid fails the 32-hex validation check by providing an error response via next().  Also aligns `imageproxy.ts` to using the global error handler instead of its unique error handling.

**AI Disclosure**: no AI was used as part of this fix

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes #3486 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- Ran all existing tests
- Replicated the reporting user's example calls and received a response
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

`$ curl -m 15 -o /dev/null -s -w 'HTTP %{http_code} after %{time_total}s\n' http://127.0.0.1:5055/avatarproxy/1
HTTP 400 after 0.008540s`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid avatar URLs now return clear 400 error responses.
  - Invalid or unsupported image proxy requests now return structured error responses.
  - Unexpected avatar and image proxy failures now return appropriate 500 responses when possible.
  - Existing error responses are preserved when a response has already started.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->