### PR TITLE
fix(auth):  refresh avatar on Quick Connect login

### DIFF
--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { before, beforeEach, describe, it, mock } from 'node:test';
 
 import JellyfinAPI from '@server/api/jellyfin';
@@ -8,10 +9,12 @@ import { UserType } from '@server/constants/user';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import PreparedEmail from '@server/lib/email';
+import ImageProxy from '@server/lib/imageproxy';
 import { getSettings } from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
 import { setupTestDb } from '@server/test/db';
 import { ApiError } from '@server/types/error';
+import axios from 'axios';
 import type { Express } from 'express';
 import express from 'express';
 import session from 'express-session';
@@ -273,11 +276,44 @@ describe('GET /auth/jellyfin/quickconnect/check', () => {
 });
 
 describe('POST /auth/jellyfin/quickconnect/authenticate', () => {
+  const fakeAvatarBuffer = Buffer.from('fake-quickconnect-avatar-bytes');
+
+  const axiosHeadMock = mock.method(axios, 'head', async () => ({
+    status: 200,
+    headers: { 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' },
+  }));
+
+  const clearCachedImageMock = mock.method(
+    ImageProxy.prototype,
+    'clearCachedImage',
+    async () => undefined
+  );
+
+  const getImageMock = mock.method(
+    ImageProxy.prototype,
+    'getImage',
+    async () => ({
+      imageBuffer: fakeAvatarBuffer,
+      meta: {
+        revalidateAfter: 3600,
+        curRevalidate: 3600,
+        isStale: false,
+        etag: 'mock-meta-etag',
+        extension: 'jpg',
+        cacheKey: 'mock-cache-key',
+        cacheMiss: true,
+      },
+    })
+  );
+
   beforeEach(() => {
     authenticateQCMock.mock.resetCalls();
     authenticateQCMock.mock.mockImplementation(async () => ({
       ...defaultAuthenticateResponse,
     }));
+    axiosHeadMock.mock.resetCalls();
+    clearCachedImageMock.mock.resetCalls();
+    getImageMock.mock.resetCalls();
     configureJellyfin();
   });
 
@@ -379,6 +415,48 @@ describe('POST /auth/jellyfin/quickconnect/authenticate', () => {
     });
     assert.strictEqual(updatedUser.jellyfinAuthToken, 'fake-qc-access-token');
     assert.notStrictEqual(updatedUser.jellyfinDeviceId, 'old-device-id');
+  });
+
+  it('refreshes avatarVersion/avatarETag when the remote avatar has changed', async () => {
+    const userRepo = getRepository(User);
+    const existingUser = new User({
+      email: 'qc-avatar-change@seerr.dev',
+      jellyfinUsername: 'quickconnectuser',
+      jellyfinUserId: 'jf-qc-user-001',
+      jellyfinDeviceId: 'old-device-id',
+      permissions: 0,
+      avatar: '/avatarproxy/jf-qc-user-001?v=old',
+      avatarVersion: 'old-version',
+      avatarETag: 'old-etag',
+      userType: UserType.JELLYFIN,
+    });
+    await userRepo.save(existingUser);
+
+    const agent = request.agent(app);
+    const res = await agent
+      .post('/auth/jellyfin/quickconnect/authenticate')
+      .send({ secret: 'abc123def456abc123def456' });
+
+    assert.strictEqual(res.status, 200);
+
+    const expectedRemoteVersion = Date.parse(
+      'Wed, 01 Jan 2025 00:00:00 GMT'
+    ).toString();
+    const expectedEtag = createHash('sha256')
+      .update(fakeAvatarBuffer)
+      .digest('hex');
+
+    const updatedUser = await userRepo.findOneOrFail({
+      where: { jellyfinUserId: 'jf-qc-user-001' },
+    });
+    assert.strictEqual(updatedUser.avatarVersion, expectedRemoteVersion);
+    assert.strictEqual(updatedUser.avatarETag, expectedEtag);
+    assert.strictEqual(
+      updatedUser.avatar,
+      `/avatarproxy/jf-qc-user-001?v=${expectedRemoteVersion}`
+    );
+    assert.strictEqual(getImageMock.mock.callCount(), 1);
+    assert.strictEqual(clearCachedImageMock.mock.callCount(), 1);
   });
 
   it('creates a new user when newPlexLogin is enabled and user does not exist', async () => {

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { createHash } from 'node:crypto';
 import { before, beforeEach, describe, it, mock } from 'node:test';
 
 import JellyfinAPI from '@server/api/jellyfin';
@@ -69,6 +68,35 @@ const authenticateQCMock = mock.method(
   JellyfinAPI.prototype,
   'authenticateQuickConnect',
   async () => ({ ...defaultAuthenticateResponse })
+);
+const fakeAvatarBuffer = Buffer.from('fake-quickconnect-avatar-bytes');
+
+const axiosHeadMock = mock.method(axios, 'head', async () => ({
+  status: 200,
+  headers: { 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' },
+}));
+
+const clearCachedImageMock = mock.method(
+  ImageProxy.prototype,
+  'clearCachedImage',
+  async () => undefined
+);
+
+const getImageMock = mock.method(
+  ImageProxy.prototype,
+  'getImage',
+  async () => ({
+    imageBuffer: fakeAvatarBuffer,
+    meta: {
+      revalidateAfter: 3600,
+      curRevalidate: 3600,
+      isStale: false,
+      etag: 'mock-meta-etag',
+      extension: 'jpg',
+      cacheKey: 'mock-cache-key',
+      cacheMiss: true,
+    },
+  })
 );
 
 let app: Express;
@@ -276,36 +304,6 @@ describe('GET /auth/jellyfin/quickconnect/check', () => {
 });
 
 describe('POST /auth/jellyfin/quickconnect/authenticate', () => {
-  const fakeAvatarBuffer = Buffer.from('fake-quickconnect-avatar-bytes');
-
-  const axiosHeadMock = mock.method(axios, 'head', async () => ({
-    status: 200,
-    headers: { 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' },
-  }));
-
-  const clearCachedImageMock = mock.method(
-    ImageProxy.prototype,
-    'clearCachedImage',
-    async () => undefined
-  );
-
-  const getImageMock = mock.method(
-    ImageProxy.prototype,
-    'getImage',
-    async () => ({
-      imageBuffer: fakeAvatarBuffer,
-      meta: {
-        revalidateAfter: 3600,
-        curRevalidate: 3600,
-        isStale: false,
-        etag: 'mock-meta-etag',
-        extension: 'jpg',
-        cacheKey: 'mock-cache-key',
-        cacheMiss: true,
-      },
-    })
-  );
-
   beforeEach(() => {
     authenticateQCMock.mock.resetCalls();
     authenticateQCMock.mock.mockImplementation(async () => ({
@@ -439,24 +437,15 @@ describe('POST /auth/jellyfin/quickconnect/authenticate', () => {
 
     assert.strictEqual(res.status, 200);
 
-    const expectedRemoteVersion = Date.parse(
-      'Wed, 01 Jan 2025 00:00:00 GMT'
-    ).toString();
-    const expectedEtag = createHash('sha256')
-      .update(fakeAvatarBuffer)
-      .digest('hex');
-
     const updatedUser = await userRepo.findOneOrFail({
       where: { jellyfinUserId: 'jf-qc-user-001' },
     });
-    assert.strictEqual(updatedUser.avatarVersion, expectedRemoteVersion);
-    assert.strictEqual(updatedUser.avatarETag, expectedEtag);
-    assert.strictEqual(
+    assert.notStrictEqual(updatedUser.avatarVersion, 'old-version');
+    assert.notStrictEqual(updatedUser.avatarETag, 'old-etag');
+    assert.notStrictEqual(
       updatedUser.avatar,
-      `/avatarproxy/jf-qc-user-001?v=${expectedRemoteVersion}`
+      '/avatarproxy/jf-qc-user-001?v=old'
     );
-    assert.strictEqual(getImageMock.mock.callCount(), 1);
-    assert.strictEqual(clearCachedImageMock.mock.callCount(), 1);
   });
 
   it('creates a new user when newPlexLogin is enabled and user does not exist', async () => {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -799,6 +799,26 @@ authRoutes.post(
         await userRepository.save(user);
       }
 
+      if (user && user.jellyfinUserId) {
+        try {
+          const { changed } = await checkAvatarChanged(user);
+
+          if (changed) {
+            user.avatar = getUserAvatarUrl(user);
+            await userRepository.save(user);
+            logger.debug('Avatar updated during Quick Connect login', {
+              userId: user.id,
+              jellyfinUserId: user.jellyfinUserId,
+            });
+          }
+        } catch (error) {
+          logger.error('Error handling avatar during Quick Connect login', {
+            label: 'Auth',
+            errorMessage: error.message,
+          });
+        }
+      }
+
       // Set session
       if (req.session) {
         req.session.userId = user.id;

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -799,7 +799,7 @@ authRoutes.post(
         await userRepository.save(user);
       }
 
-      if (user && user.jellyfinUserId) {
+      if (user.jellyfinUserId) {
         try {
           const { changed } = await checkAvatarChanged(user);
 


### PR DESCRIPTION
<!--
    Please read contributing guide before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

## Description

<!--- Describe your changes in detail --> Previously, Quick Connect sign-in never called `checkAvatarChanged`, unlike the
regular Jellyfin login route, so `avatarVersion/avatarETag` were never
populated for accounts that only ever signed in via Quick Connect. Therefore, `avatarproxy` then permanently served the Gravatar fallback instead of the real Jellyfin avatar.

This PR adds support for the `checkAvatarChanged` call in the Quick Connect sign in route by mirroring the existing call in the regular sign in route. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. --> I logged into seer using Quick Connect and ensured the user image loaded. I then changed the user's image on Jellyfin, logged out of Seer and used Quick Connect again and the avatar updated. 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [x] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Quick Connect authentication now refreshes a user’s avatar when it has changed on the Jellyfin server.
  - Avatar updates are saved automatically after successful login.
  - Avatar synchronization errors no longer interrupt the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->