### PR TITLE
fix(db): remap leftover Overseerr DELETED status after migration

### DIFF
--- a/server/migration/postgres/1789254652580-RemapOverseerrDeletedStatus.ts
+++ b/server/migration/postgres/1789254652580-RemapOverseerrDeletedStatus.ts
@@ -1,0 +1,28 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Hand written as its data only because Overseerr's MediaStatus.DELETED = 6
+// collides with our BLOCKLISTED, so rows from an imported database read as blocklisted.
+// see https://github.com/seerr-team/seerr/issues/3508
+export class RemapOverseerrDeletedStatus1789257612345 implements MigrationInterface {
+  name = 'RemapOverseerrDeletedStatus1789257612345';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "season" SET "status" = 7 WHERE "status" = 6`
+    );
+    await queryRunner.query(
+      `UPDATE "season" SET "status4k" = 7 WHERE "status4k" = 6`
+    );
+    await queryRunner.query(
+      `UPDATE "media" SET "status" = 7 WHERE "status" = 6 AND NOT EXISTS (SELECT 1 FROM "blocklist" WHERE "blocklist"."tmdbId" = "media"."tmdbId" AND "blocklist"."mediaType" = "media"."mediaType")`
+    );
+    await queryRunner.query(
+      `UPDATE "media" SET "status4k" = 7 WHERE "status4k" = 6 AND NOT EXISTS (SELECT 1 FROM "blocklist" WHERE "blocklist"."tmdbId" = "media"."tmdbId" AND "blocklist"."mediaType" = "media"."mediaType")`
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Intentionally left empty as remapped rows are indistinguishable from rows
+    // that were already DELETED.
+  }
+}

--- a/server/migration/sqlite/1789254652493-RemapOverseerrDeletedStatus.ts
+++ b/server/migration/sqlite/1789254652493-RemapOverseerrDeletedStatus.ts
@@ -1,0 +1,28 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+// Hand written as its data only because Overseerr's MediaStatus.DELETED = 6
+// collides with our BLOCKLISTED, so rows from an imported database read as blocklisted.
+// see https://github.com/seerr-team/seerr/issues/3508
+export class RemapOverseerrDeletedStatus1789257612345 implements MigrationInterface {
+  name = 'RemapOverseerrDeletedStatus1789257612345';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE "season" SET "status" = 7 WHERE "status" = 6`
+    );
+    await queryRunner.query(
+      `UPDATE "season" SET "status4k" = 7 WHERE "status4k" = 6`
+    );
+    await queryRunner.query(
+      `UPDATE "media" SET "status" = 7 WHERE "status" = 6 AND NOT EXISTS (SELECT 1 FROM "blocklist" WHERE "blocklist"."tmdbId" = "media"."tmdbId" AND "blocklist"."mediaType" = "media"."mediaType")`
+    );
+    await queryRunner.query(
+      `UPDATE "media" SET "status4k" = 7 WHERE "status4k" = 6 AND NOT EXISTS (SELECT 1 FROM "blocklist" WHERE "blocklist"."tmdbId" = "media"."tmdbId" AND "blocklist"."mediaType" = "media"."mediaType")`
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Intentionally left empty as remapped rows are indistinguishable from rows
+    // that were already DELETED.
+  }
+}


### PR DESCRIPTION
## Description

Overseerr's MediaStatus ends at `DELETED = 6`, which collides with our BLOCKLISTED. Rows that Overseerr marked as deleted therefore read as blocklisted after the database is picked up by seerr and affected seasons show as already requested and get filtered out of new requests, and affected media rows reject requests as blocklisted while Clear Data refuses to remove them.

This adds a data-only migration, sqlite and postgres, remapping 6 to 7. Seasons are remapped unconditionally because no version has ever written BLOCKLISTED to a season row, and media rows only where no blocklist entry backs them, which leaves genuinely blocklisted items alone. It wont do anything on databases that never came from Overseerr, and it still runs for anyone migrating after this ships, since an imported database brings Overseerr's migration list with it.

- Fixes #3508

## How Has This Been Tested?

(should work)

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected media and season status mappings so deleted items display with the appropriate status.
  * Preserved genuinely blocklisted items during the status correction.
  * Applied the correction across supported database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->