### PR TITLE
test: block outbound HTTP in unit tests

### DIFF
--- a/server/lib/availabilitySync.test.ts
+++ b/server/lib/availabilitySync.test.ts
@@ -28,6 +28,7 @@ import Media from '@server/entity/Media';
 import MediaRequest from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
+import availabilitySync from '@server/lib/availabilitySync';
 import type { RadarrSettings, SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
@@ -170,6 +171,14 @@ Object.defineProperty(TheMovieDb.prototype, 'getShowByTvdbIdForScan', {
   configurable: true,
 });
 
+// getTvShowForScan is assigned in the constructor, so the prototype stub misses
+// the instance availabilitySync built when it was first imported
+Object.defineProperty(availabilitySync.tmdb, 'getTvShowForScan', {
+  value: async (args: { tvId: number; language?: string }) =>
+    getTvShowImpl(args),
+  configurable: true,
+});
+
 // --- Helpers ---
 
 function fakeTmdbShow(
@@ -220,8 +229,6 @@ function fakeTmdbShow(
     videos: { results: [] },
   };
 }
-
-import availabilitySync from '@server/lib/availabilitySync';
 
 setupTestDb();
 

--- a/server/lib/scanners/jellyfin/jellyfin.test.ts
+++ b/server/lib/scanners/jellyfin/jellyfin.test.ts
@@ -15,6 +15,7 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
+import { jellyfinFullScanner } from '@server/lib/scanners/jellyfin';
 import type { Library } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
@@ -109,7 +110,15 @@ Object.defineProperty(TheMovieDb.prototype, 'getTvShowForScan', {
   configurable: true,
 });
 
-import { jellyfinFullScanner } from '@server/lib/scanners/jellyfin';
+// both are assigned in the constructor, so the prototype stubs miss the
+// instance jellyfinFullScanner built when it was first imported
+for (const method of ['getTvShow', 'getTvShowForScan'] as const) {
+  Object.defineProperty(jellyfinFullScanner.tmdb, method, {
+    value: async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args),
+    configurable: true,
+  });
+}
 
 setupTestDb();
 

--- a/server/lib/scanners/sonarr/sonarr.test.ts
+++ b/server/lib/scanners/sonarr/sonarr.test.ts
@@ -15,6 +15,7 @@ import Media from '@server/entity/Media';
 import MediaRequest from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import { User } from '@server/entity/User';
+import { sonarrScanner } from '@server/lib/scanners/sonarr';
 import type { SonarrSettings } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import { setupTestDb } from '@server/test/db';
@@ -116,7 +117,16 @@ Object.defineProperty(TheMovieDb.prototype, 'getTvShowForScan', {
   configurable: true,
 });
 
-import { sonarrScanner } from '@server/lib/scanners/sonarr';
+// both are assigned in the constructor, so the prototype stubs miss the instance
+// sonarrScanner built when it was first imported
+for (const method of ['getTvShow', 'getTvShowForScan'] as const) {
+  Object.defineProperty(sonarrScanner.tmdb, method, {
+    value: async (args: { tvId: number; language?: string }) =>
+      getTvShowImpl(args),
+    configurable: true,
+  });
+}
+
 mock.method(MediaRequest, 'sendNotification', async () => undefined);
 
 setupTestDb();

--- a/server/lib/watchlistsync.test.ts
+++ b/server/lib/watchlistsync.test.ts
@@ -11,6 +11,7 @@ import { MediaRequest } from '@server/entity/MediaRequest';
 import { User } from '@server/entity/User';
 import { UserSettings } from '@server/entity/UserSettings';
 import { Permission } from '@server/lib/permissions';
+import watchlistSync from '@server/lib/watchlistsync';
 import { setupTestDb } from '@server/test/db';
 import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
@@ -40,8 +41,6 @@ Object.defineProperty(MediaRequest, 'request', {
   writable: true,
   configurable: true,
 });
-
-import watchlistSync from '@server/lib/watchlistsync';
 
 setupTestDb();
 

--- a/server/routes/issue.test.ts
+++ b/server/routes/issue.test.ts
@@ -10,6 +10,7 @@ import { User } from '@server/entity/User';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import { checkUser } from '@server/middleware/auth';
+import { IssueCommentSubscriber } from '@server/subscriber/IssueCommentSubscriber';
 import { IssueSubscriber } from '@server/subscriber/IssueSubscriber';
 import { setupTestDb } from '@server/test/db';
 import type { Express } from 'express';
@@ -26,6 +27,14 @@ const sendIssueNotificationMock = mock.method(
   'sendIssueNotification',
   async () => undefined
 ).mock;
+
+mock.method(
+  IssueCommentSubscriber.prototype as unknown as {
+    sendIssueCommentNotification: (...args: unknown[]) => Promise<void>;
+  },
+  'sendIssueCommentNotification',
+  async () => undefined
+);
 
 let app: Express;
 

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,5 +1,71 @@
 import logger from '@server/logger';
+import http from 'node:http';
+import https from 'node:https';
 import { after, before } from 'node:test';
+
+// supertest serves the app over a real loopback socket, so only external hosts
+// can be refused
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '::1']);
+
+const blocked = new Set<string>();
+
+function stripPort(host: string): string {
+  const bracketed = host.match(/^\[(.+)\]/);
+  if (bracketed) {
+    return bracketed[1];
+  }
+
+  const parts = host.split(':');
+  return parts.length === 2 ? parts[0] : host;
+}
+
+function hostnameOf(args: unknown[]): string {
+  const [first, second] = args;
+  const fromUrl =
+    typeof first === 'string' || first instanceof URL
+      ? new URL(String(first)).hostname
+      : undefined;
+
+  const options = (fromUrl !== undefined ? second : first) as
+    | { hostname?: string; host?: string }
+    | undefined;
+  const fromOptions =
+    typeof options === 'object' && options !== null
+      ? (options.hostname ??
+        (options.host ? stripPort(options.host) : undefined))
+      : undefined;
+
+  return stripPort(fromOptions ?? fromUrl ?? 'localhost');
+}
+
+function blockOutboundRequests(
+  mod: typeof http | typeof https,
+  scheme: string
+) {
+  // get() calls the module's internal request(), not the exported one
+  for (const name of ['request', 'get'] as const) {
+    const original = mod[name] as (...args: unknown[]) => unknown;
+
+    mod[name] = ((...args: unknown[]) => {
+      const hostname = hostnameOf(args);
+
+      if (!LOOPBACK.has(hostname)) {
+        const target = `${scheme}//${hostname}`;
+        blocked.add(target);
+        throw new Error(
+          `Blocked outbound request to ${target}. Stub the API client this test uses, or set ALLOW_NETWORK=true.`
+        );
+      }
+
+      return original(...args);
+    }) as typeof mod.request;
+  }
+}
+
+if (process.env.ALLOW_NETWORK != 'true') {
+  blockOutboundRequests(http, 'http:');
+  blockOutboundRequests(https, 'https:');
+}
 
 before(() => {
   if (process.env.VERBOSE != 'true') logger.silent = true;
@@ -7,4 +73,11 @@ before(() => {
 
 after(() => {
   if (process.env.VERBOSE != 'true') logger.silent = false;
+
+  // callers that swallow the error would otherwise leave the suite green
+  if (blocked.size) {
+    throw new Error(
+      `Test reached the network: ${[...blocked].join(', ')}. Stub the API client this test uses.`
+    );
+  }
 });


### PR DESCRIPTION
## Description

Several unit test suites were silently calling the real TMDB API. TheMovieDb assigns most of its methods as class properties in the constructor rather than defining them on the prototype, so the suites that stub them use a getter/setter pair on `TheMovieDb.prototype`, where an empty setter swallows the constructor’s assignment and reads fall through to the getter. 

That only works for instances built after the stub is installed, and both availabilitySync and the scanner singletons build theirs at import time, so their real methods shadowed the stub permanently. The affected suites worked around this by importing the singleton further down the file, below the stubs, which holds only as long as nothing else pulls the module in first. `server/api/jellyfin.ts` imports availabilitySync, so that suite’s deferred import was already a cache hit by the time it ran and its stubs never bound at all. The ones in the scanner suites survived on the accident of their import graphs. The result was tests that made real network calls, passed anyway, and quietly asserted against live data. One availability test was only green because TMDB really does report more seasons than its own fixture declared, and three specials fixtures had never been applied to anything. 

This PR stubs the singleton’s own instance, which does not depend on import order at all, and removes the deferred imports entirely. To stop the class of problem coming back, the test setup now wraps request and get on `node:http` and `node:https` and refuses anything that is not loopback. Loopback stays open because supertest serves the app over a real socket. Blocking alone would not be enough, since the two leaks this found were both in code that catches and logs its errors, so the guard also records every blocked host and fails the suite from the existing after hook. It can be turned off with `ALLOW_NETWORK=true` if a test ever genuinely needs the network. 

## How Has This Been Tested?

The leaks were found by pointing axios at a dead proxy so that every outbound attempt had to surface, rather than succeeding quietly: 
```
env HTTPS_PROXY=http://127.0.0.1:1 HTTP_PROXY=http://127.0.0.1:1 \
NO_PROXY=localhost,127.0.0.1,::1 VERBOSE=true pnpm test
```

 That run recorded 17 real outbound requests, all external, and one failing test (should mark show as PARTIALLY_AVAILABLE when some seasons are available and some are unknown), which returned AVAILABLE once it could no longer reach TMDB. The same command now reports no outbound attempts, and that test passes on the four-season fixture its own `beforeEach` was already building. 

pnpm test passes. Also to confirm the guard actually engages, I tested with a throwaway test file calling new `TheMovieDb().getMovie({ movieId: 550 })` was run against it and failed on both paths, the request itself threw, and the after hook reported that test reached the network: https://api.themoviedb.org. 

## Screenshots / Logs (if applicable)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read and followed the contribution [guidelines](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md).
- [ ] Disclosed any use of AI (see our [policy](https://github.com/seerr-team/seerr/blob/develop/CONTRIBUTING.md#ai-assistance-notice))
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup and mocking for TV show scanning, Jellyfin, Sonarr, watchlists, and issue notifications.
  * Added safeguards to prevent unintended external network requests during tests, while allowing explicitly enabled network access.
  * Tests now detect and report any unexpected outbound requests.

* **Chores**
  * Organized test imports for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->